### PR TITLE
chore(tests): trim prose in tests/cli root suite

### DIFF
--- a/tests/cli/test_agent_artifact_contract.py
+++ b/tests/cli/test_agent_artifact_contract.py
@@ -23,7 +23,7 @@ def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return db_path
 
 
-# ── test_teardown_no_contract_unchanged ──────────────────────────────────────
+# test_teardown_no_contract_unchanged
 
 
 async def test_teardown_no_contract_unchanged(temp_db_path: Path):
@@ -42,7 +42,7 @@ async def test_teardown_no_contract_unchanged(temp_db_path: Path):
     assert s["artifact_verification_json"] is None
 
 
-# ── test_teardown_contract_passed_stays_completed ────────────────────────────
+# test_teardown_contract_passed_stays_completed
 
 
 async def test_teardown_contract_passed_stays_completed(temp_db_path: Path, tmp_path: Path):
@@ -71,7 +71,7 @@ async def test_teardown_contract_passed_stays_completed(temp_db_path: Path, tmp_
     assert v["status"] == "passed"
 
 
-# ── test_teardown_contract_failed_overrides_completed ────────────────────────
+# test_teardown_contract_failed_overrides_completed
 
 
 async def test_teardown_contract_failed_overrides_completed(temp_db_path: Path, tmp_path: Path):
@@ -108,7 +108,7 @@ async def test_teardown_contract_failed_overrides_completed(temp_db_path: Path, 
     assert v["status"] == "failed"
 
 
-# ── test_teardown_already_failed_keeps_original_reason ───────────────────────
+# test_teardown_already_failed_keeps_original_reason
 
 
 async def test_teardown_already_failed_keeps_original_reason(temp_db_path: Path, tmp_path: Path):

--- a/tests/cli/test_agent_cancelled_exc.py
+++ b/tests/cli/test_agent_cancelled_exc.py
@@ -11,9 +11,7 @@ import importlib
 import anyio
 import pytest
 
-# ---------------------------------------------------------------------------
 # Unit tests for lionagi.ln.concurrency.errors
-# ---------------------------------------------------------------------------
 
 
 class TestCacheAndReaderFunctions:
@@ -131,9 +129,7 @@ class TestCacheAndReaderFunctions:
         assert isinstance(exc, cancelled_exc_classes())
 
 
-# ---------------------------------------------------------------------------
 # Integration test: simulate the run_agent error path post-loop-exit
-# ---------------------------------------------------------------------------
 
 
 class TestRunAgentCancelledExcPath:

--- a/tests/cli/test_agent_cli_endpoint_preflight.py
+++ b/tests/cli/test_agent_cli_endpoint_preflight.py
@@ -18,9 +18,7 @@ import pytest
 
 from lionagi._errors import ConfigurationError
 
-# ---------------------------------------------------------------------------
 # _run_agent: fails before any spawn / run allocation
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_codex_robustness.py
+++ b/tests/cli/test_agent_codex_robustness.py
@@ -17,7 +17,7 @@ from lionagi.cli._providers import (
     build_chat_model,
 )
 
-# ── build_chat_model threads bypass kwarg ────────────────────────────────────
+# build_chat_model threads bypass kwarg
 
 
 def test_build_chat_model_bypass_applies_bypass_kwargs(monkeypatch):
@@ -80,7 +80,7 @@ def test_build_chat_model_bypass_claude_applies_permission_mode(monkeypatch):
     assert kwargs.get("permission_mode") == "bypassPermissions"
 
 
-# ── _run_agent threads bypass and warns for naked codex ──────────────────────
+# _run_agent threads bypass and warns for naked codex
 
 
 def _make_agent_mocks_with_bypass(monkeypatch, tmp_path, captured_kwargs: list):
@@ -277,7 +277,7 @@ async def test_run_agent_codex_with_yolo_no_warning(monkeypatch, tmp_path):
     assert not bypass_req_warns, f"Unexpected warning with yolo=True: {bypass_req_warns}"
 
 
-# ── partial output preserved on timeout ──────────────────────────────────────
+# partial output preserved on timeout
 
 
 @pytest.mark.asyncio
@@ -437,7 +437,7 @@ async def test_run_agent_timeout_empty_partial_returns_empty_string(monkeypatch,
     assert result == "", f"Expected empty string, got: {result!r}"
 
 
-# ── progress heartbeat fires during timeout runs ─────────────────────────────
+# progress heartbeat fires during timeout runs
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_context_from.py
+++ b/tests/cli/test_agent_context_from.py
@@ -37,7 +37,7 @@ from lionagi.cli._context_from import (
 from lionagi.cli._runs import RunDir
 from lionagi.state.db import StateDB
 
-# ── Fixtures ──────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -113,7 +113,7 @@ def _write_branch_file(runs_root: Path, run_id: str, branch_id: str) -> Path:
     return path
 
 
-# ── Ladder: artifact present / final-message fallback / truncation marker ──
+# Ladder: artifact present / final-message fallback / truncation marker
 
 
 def test_ladder_uses_verbatim_artifact_when_it_fits():
@@ -161,7 +161,7 @@ def test_ladder_truncates_loudly_when_both_oversized():
     assert len(text) <= 100
 
 
-# ── Budget: total-not-per-ref, argv order, tail-ref loud truncation ────────
+# Budget: total-not-per-ref, argv order, tail-ref loud truncation
 
 
 def test_build_context_block_allocates_total_budget_in_argv_order(caplog):
@@ -256,7 +256,7 @@ def test_file_ref_over_budget_truncates_loudly_no_verbatim_blowup(tmp_path):
     assert "[...truncated...]" in block
 
 
-# ── Ref resolution order + unique prefix + miss ─────────────────────────────
+# Ref resolution order + unique prefix + miss
 
 
 @pytest.mark.asyncio
@@ -348,7 +348,7 @@ async def test_resolve_empty_source_branch_errors(temp_db_path, runs_root):
             await resolve_context_refs([bid])
 
 
-# ── Ambiguous prefix (2+ matches) → hard error listing candidates ─────────
+# Ambiguous prefix (2+ matches) → hard error listing candidates
 
 
 @pytest.mark.asyncio
@@ -389,7 +389,7 @@ async def test_resolve_ambiguous_run_prefix_raises(temp_db_path, runs_root):
         await resolve_context_refs(["run-dup"])
 
 
-# ── CLI wiring: mutual exclusion, manifest, first-instruction injection ────
+# CLI wiring: mutual exclusion, manifest, first-instruction injection
 
 
 def _wire_agent_stubs(
@@ -597,7 +597,7 @@ async def test_injected_block_present_above_prompt_in_first_instruction(monkeypa
     assert instruction.index(marker) < instruction.index("the user prompt")
 
 
-# ── Explicit `--context-budget 0` must be preserved, not defaulted ─────────
+# Explicit `--context-budget 0` must be preserved, not defaulted
 
 
 @pytest.mark.asyncio
@@ -699,7 +699,7 @@ def test_build_context_block_budget_zero_yields_only_truncation_marker():
     assert "final" not in block
 
 
-# ── CLI surface: exit codes, stderr content, precedence, argv ordering ─────
+# CLI surface: exit codes, stderr content, precedence, argv ordering
 
 
 def _base_cli_args(**overrides) -> SimpleNamespace:

--- a/tests/cli/test_agent_cwd_failfast.py
+++ b/tests/cli/test_agent_cwd_failfast.py
@@ -20,9 +20,7 @@ import pytest
 from lionagi._errors import ConfigurationError
 from lionagi.cli._util import validate_cwd_exists
 
-# ---------------------------------------------------------------------------
 # validate_cwd_exists — the shared validator
-# ---------------------------------------------------------------------------
 
 
 class TestValidateCwdExists:
@@ -74,9 +72,7 @@ class TestValidateCwdExists:
         assert "--cwd" not in str(exc_info.value)
 
 
-# ---------------------------------------------------------------------------
 # _run_agent: fails before any spawn / run allocation
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -196,9 +192,7 @@ async def test_run_agent_forwards_tilde_expanded_cwd_to_spawn(monkeypatch, tmp_p
     assert spawned.get("repo") == str(tmp_path / "ws")
 
 
-# ---------------------------------------------------------------------------
 # run_agent (sync CLI entry point): clean diagnostic before re-raising
-# ---------------------------------------------------------------------------
 
 
 def _agent_args(**overrides) -> SimpleNamespace:

--- a/tests/cli/test_agent_depth.py
+++ b/tests/cli/test_agent_depth.py
@@ -30,9 +30,7 @@ def _clean_depth_env(monkeypatch):
     monkeypatch.delenv(SEAT_PROFILES_ENV, raising=False)
 
 
-# ---------------------------------------------------------------------------
 # _parse_depth
-# ---------------------------------------------------------------------------
 
 
 class TestParseDepth:
@@ -55,9 +53,7 @@ class TestParseDepth:
         assert _parse_depth("0") == 0
 
 
-# ---------------------------------------------------------------------------
 # inherited_depth — import-captured, not a live re-read
-# ---------------------------------------------------------------------------
 
 
 class TestInheritedDepth:
@@ -74,9 +70,7 @@ class TestInheritedDepth:
         assert inherited_depth() == 2
 
 
-# ---------------------------------------------------------------------------
 # stamp_agent_depth — seat vs non-seat vs no-profile
-# ---------------------------------------------------------------------------
 
 
 class TestStampAgentDepth:
@@ -114,9 +108,7 @@ class TestStampAgentDepth:
         assert os.environ[DEPTH_ENV] == str(depth)
 
 
-# ---------------------------------------------------------------------------
 # stamp_worker_depth — always parent+1, never a seat
-# ---------------------------------------------------------------------------
 
 
 class TestStampWorkerDepth:
@@ -137,9 +129,7 @@ class TestStampWorkerDepth:
         assert os.environ[DEPTH_ENV] == str(depth)
 
 
-# ---------------------------------------------------------------------------
 # Auto-resume recursion must not double-increment
-# ---------------------------------------------------------------------------
 
 
 def test_double_stamp_in_one_process_does_not_double_increment(monkeypatch):

--- a/tests/cli/test_agent_image_input.py
+++ b/tests/cli/test_agent_image_input.py
@@ -104,9 +104,7 @@ class TestLoadImageDataUris:
             _load_image_data_uris([str(f)])
 
 
-# ---------------------------------------------------------------------------
 # CLI wiring: --image -> run_agent -> _run_agent(images=[...])
-# ---------------------------------------------------------------------------
 
 _CAPTURED: dict[str, Any] = {}
 

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -19,7 +19,7 @@ from lionagi.cli._runs import setup_agent_persist as _setup_live_persist
 from lionagi.cli._runs import teardown_agent_persist as _teardown_live_persist
 from lionagi.state.db import StateDB
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ def _aiosqlite_thread_count() -> int:
     )
 
 
-# ── _setup_live_persist: happy path + invariants ──────────────────────────────
+# _setup_live_persist: happy path + invariants
 
 
 async def test_setup_creates_session_branch_progression_rows(
@@ -109,7 +109,7 @@ async def test_setup_persists_system_message_when_branch_has_one(
     await _teardown_live_persist(ctx, status="completed")
 
 
-# ── _setup_live_persist: failure paths must close the DB ──────────────────────
+# _setup_live_persist: failure paths must close the DB
 
 
 async def test_setup_db_open_failure_disables_persist_no_thread_leak(
@@ -174,7 +174,7 @@ async def test_setup_create_session_failure_closes_db(
     monkeypatch.setattr(StateDB, "create_session", original_create)
 
 
-# ── Shared-db reuse + teardown cleanup (lifecycle-hook leak guard) ────────────
+# Shared-db reuse + teardown cleanup (lifecycle-hook leak guard)
 
 
 async def test_lifecycle_hooks_reuse_owned_db_no_shared_leak(temp_db_path: Path):
@@ -326,7 +326,7 @@ async def test_close_shared_db_rejects_stale_waiter(temp_db_path: Path):
     assert _aiosqlite_thread_count() == before, "stale-waiter open leaked an aiosqlite worker"
 
 
-# ── Resume path ───────────────────────────────────────────────────────────────
+# Resume path
 
 
 async def test_setup_resume_loads_existing_session_and_progression(
@@ -359,7 +359,7 @@ async def test_setup_resume_loads_existing_session_and_progression(
     await _teardown_live_persist(ctx2, status="completed")
 
 
-# ── Hook contract: best-effort + system_msg_id update ─────────────────────────
+# Hook contract: best-effort + system_msg_id update
 
 
 async def test_hook_dedupes_existing_messages_on_resume(
@@ -579,7 +579,7 @@ async def test_hook_updates_system_msg_id_when_system_replaced(
     await _teardown_live_persist(ctx, status="completed")
 
 
-# ── _teardown_live_persist: invariants ────────────────────────────────────────
+# _teardown_live_persist: invariants
 
 
 async def test_teardown_updates_session_bookmarks_and_status(
@@ -861,7 +861,7 @@ async def test_teardown_with_none_context_is_noop(temp_db_path: Path):
     await _teardown_live_persist(None, status="completed")  # MUST NOT raise
 
 
-# ── defer_terminal: auto-resume must not stamp a premature terminal status ────
+# defer_terminal: auto-resume must not stamp a premature terminal status
 
 
 async def test_teardown_defer_terminal_leaves_session_running(
@@ -916,7 +916,7 @@ async def test_teardown_non_resume_timeout_stamps_terminal_unchanged(
     assert s["ended_at"] is not None
 
 
-# ── ADR-0035 terminal-race: a second teardown must not crash past callers ─────
+# ADR-0035 terminal-race: a second teardown must not crash past callers
 
 
 async def test_teardown_already_terminal_session_reports_attempted_status(
@@ -1026,7 +1026,7 @@ async def test_teardown_concurrent_race_non_terminal_entry_returns_winner_status
     assert s["status"] == "completed"
 
 
-# ── End-to-end: no aiosqlite thread leak across setup+teardown ────────────────
+# End-to-end: no aiosqlite thread leak across setup+teardown
 
 
 async def test_setup_teardown_does_not_leak_aiosqlite_thread(
@@ -1064,16 +1064,16 @@ async def test_setup_teardown_does_not_leak_aiosqlite_thread(
         )
 
 
-# ── R5-A HIGH-2: NULL progression_id resume repair ────────────────────────────
+# NULL progression_id resume repair
 
 
 async def _legacy_db_with_nullable_progression(
     db_path: Path,
 ) -> StateDB:
     """Open a DB and rebuild branches+sessions tables with NULLABLE
-    progression_id, mimicking the legacy schema pre-PR. The current
-    schema declares those columns NOT NULL, so we can only reach the
-    repair path by relaxing the constraint in test setup.
+    progression_id, mimicking the legacy schema. The current schema
+    declares those columns NOT NULL, so we can only reach the repair
+    path by relaxing the constraint in test setup.
     """
     state = StateDB(db_path)
     await state.open()
@@ -1134,7 +1134,7 @@ async def test_setup_resume_repairs_null_branch_progression_id(
     so future hook calls dedupe correctly.
 
     Without repair, append_to_progression(None, msg_id) is a no-op and
-    branch history is silently lost (R5-A HIGH-2).
+    branch history is silently lost.
     """
     import uuid
 
@@ -1189,14 +1189,12 @@ async def test_setup_resume_repairs_null_branch_progression_id(
 async def test_repair_branch_progression_returns_existing_id_under_race(
     temp_db_path: Path,
 ):
-    """R6 HIGH-2: when two callers race to repair the same NULL
-    progression_id, the conditional UPDATE only lands one id. The
-    LOSER's repair call must return the WINNING id so the loser does
-    not keep using its locally-generated (orphan) progression.
-
-    Without this, the loser writes to an orphan progression while
-    branches.progression_id points elsewhere — same silent data loss
-    as the original HIGH-2.
+    """When two callers race to repair the same NULL progression_id, the
+    conditional UPDATE only lands one id. The loser's repair call must
+    return the winning id so the loser does not keep using its
+    locally-generated (orphan) progression — otherwise it writes to an
+    orphan progression while branches.progression_id points elsewhere,
+    the same silent data loss the repair exists to fix.
     """
     import uuid
 
@@ -1327,7 +1325,7 @@ async def test_setup_resume_repairs_null_session_progression_id(
     await _teardown_live_persist(ctx, status="completed")
 
 
-# ── ADR-0064: artifact contract snapshot and verification ─────────────────────
+# ADR-0064: artifact contract snapshot and verification
 
 
 async def test_setup_persists_artifact_contract(temp_db_path: Path):
@@ -1449,7 +1447,7 @@ async def test_teardown_verification_preserves_non_completed_reason(
     assert v["status"] == "failed"
 
 
-# ── Phantom 'failed' suppression: linked engine session is alive/completed ───
+# Phantom 'failed' suppression: linked engine session is alive/completed
 
 
 async def test_teardown_suppresses_failed_when_linked_engine_session_running(

--- a/tests/cli/test_agent_notify_without_persistence.py
+++ b/tests/cli/test_agent_notify_without_persistence.py
@@ -5,24 +5,22 @@
 could register the callback that would normally deliver one, still gets it
 delivered.
 
-`--notify` is ordinarily delivered by a callback registered against this
-run's session entity and fired by that entity's terminal transition. When
-persistence setup fails there is no session entity, so no transition can ever
-happen and the registered path can never fire, however well it resolves. This
-run instead delivers the notice itself, directly, once its own terminal
-status is known — see `deliver_flow_notify_now` in
-`lionagi/cli/orchestrate/_notify.py` and docs/internals/cli.md.
+`--notify` is ordinarily delivered by a callback registered against the run's
+session entity, fired by that entity's terminal transition. When persistence
+setup fails there is no session entity and no transition ever fires, so this
+run instead delivers the notice itself once its own terminal status is known
+— see `deliver_flow_notify_now` in `lionagi/cli/orchestrate/_notify.py` and
+docs/internals/cli.md.
 
-That matters because the consumers are automated. The lion MCP server wires
-`--notify` on every job it spawns and takes the resulting notice as the run's
-end; without one it eventually observes the process is gone with nothing
-recorded and publishes `outcome=indeterminate`, which is the opposite of what
-happened to a run that did all of its work.
+This matters because consumers are automated: the lion MCP server wires
+`--notify` on every job it spawns and takes the notice as the run's end;
+without one it eventually observes the process gone with nothing recorded and
+publishes `outcome=indeterminate` for a run that actually completed its work.
 
 Recording a refusal is not the same as delivering a notice: the refusal
-record (`notify_outcome.json` with a `reason`) is now written only when
-delivery is actually attempted and genuinely cannot be completed — nothing
-usable is configured — never merely because persistence broke.
+record (`notify_outcome.json` with a `reason`) is written only when delivery
+is actually attempted and genuinely cannot complete, never merely because
+persistence broke.
 """
 
 from __future__ import annotations

--- a/tests/cli/test_agent_preset_form.py
+++ b/tests/cli/test_agent_preset_form.py
@@ -20,9 +20,7 @@ from lionagi.cli.agent import (
     run_agent,
 )
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_parser():
@@ -70,9 +68,7 @@ def _agent_args(**overrides):
     return SimpleNamespace(**defaults)
 
 
-# ---------------------------------------------------------------------------
 # 3a — --preset parser tests
-# ---------------------------------------------------------------------------
 
 
 class TestPresetParserFlag:
@@ -104,9 +100,7 @@ class TestPresetParserFlag:
         assert ns.form == str(spec_path)
 
 
-# ---------------------------------------------------------------------------
 # 3b — --form parser tests
-# ---------------------------------------------------------------------------
 
 
 class TestFormParserFlag:
@@ -121,9 +115,7 @@ class TestFormParserFlag:
         assert ns.form is None
 
 
-# ---------------------------------------------------------------------------
 # _load_form_spec unit tests
-# ---------------------------------------------------------------------------
 
 
 class TestLoadFormSpec:
@@ -152,9 +144,7 @@ class TestLoadFormSpec:
             _load_form_spec(str(p))
 
 
-# ---------------------------------------------------------------------------
 # _build_work_form unit tests
-# ---------------------------------------------------------------------------
 
 
 class TestBuildWorkForm:
@@ -203,9 +193,7 @@ class TestBuildWorkForm:
             _build_work_form(spec, "<test>")
 
 
-# ---------------------------------------------------------------------------
 # _form_to_context_block unit tests
-# ---------------------------------------------------------------------------
 
 
 class TestFormToContextBlock:
@@ -223,9 +211,7 @@ class TestFormToContextBlock:
         assert "/tmp/x" in block
 
 
-# ---------------------------------------------------------------------------
 # run_agent — --form validation gate fires BEFORE LLM call
-# ---------------------------------------------------------------------------
 
 
 class TestFormValidationGate:
@@ -375,9 +361,7 @@ class TestFormValidationGate:
         assert captured_prompts[0] == "bare prompt"
 
 
-# ---------------------------------------------------------------------------
 # run_agent — --preset forwarded correctly in the _run_agent() call
-# ---------------------------------------------------------------------------
 
 
 class TestPresetCodingBehaviour:
@@ -445,9 +429,7 @@ class TestPresetCodingBehaviour:
         assert captured_kwargs[0].get("cwd") == str(tmp_path)
 
 
-# ---------------------------------------------------------------------------
 # _run_agent — preset param wires _make_coding_preset() and create_agent
-# ---------------------------------------------------------------------------
 
 #: Core CodingToolkit tool names expected when preset=coding is used.
 _CODING_TOOL_NAMES = {"reader", "editor", "bash", "search"}
@@ -659,9 +641,7 @@ async def test_run_agent_continue_last_with_preset_raises(monkeypatch, tmp_path)
         )
 
 
-# ---------------------------------------------------------------------------
 # profile + preset system prompt composition
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -789,9 +769,7 @@ async def test_run_agent_profile_without_preset_system_prompt_unchanged(monkeypa
     assert PROFILE_PROMPT in sys_msg.rendered
 
 
-# ---------------------------------------------------------------------------
 # form spec closed schema enforcement
-# ---------------------------------------------------------------------------
 
 
 class TestFormSpecClosedSchema:
@@ -894,9 +872,7 @@ class TestFormSpecClosedSchema:
         )
 
 
-# ---------------------------------------------------------------------------
 # directory --form path → rc=1, clear error, no traceback
-# ---------------------------------------------------------------------------
 
 
 class TestFormDirectoryPath:
@@ -928,9 +904,7 @@ class TestFormDirectoryPath:
         )
 
 
-# ---------------------------------------------------------------------------
 # non-mapping fields / values probe shapes
-# ---------------------------------------------------------------------------
 
 
 class TestFormNonMappingTypes:
@@ -998,9 +972,7 @@ class TestFormNonMappingTypes:
         assert errors
 
 
-# ---------------------------------------------------------------------------
 # LION_SYSTEM_MESSAGE dedup with real profile files
-# ---------------------------------------------------------------------------
 
 
 def _make_agents_dir(tmp_path, monkeypatch):

--- a/tests/cli/test_agent_profile_role.py
+++ b/tests/cli/test_agent_profile_role.py
@@ -25,9 +25,7 @@ import pytest
 
 from lionagi.cli._providers import _parse_profile
 
-# ---------------------------------------------------------------------------
 # Shared stub wiring (mirrors tests/cli/test_agent_profile_timeout.py)
-# ---------------------------------------------------------------------------
 
 
 def _wire_agent_stubs(monkeypatch, tmp_path: Path):
@@ -100,9 +98,7 @@ def _stub_profile(monkeypatch, name: str, text: str):
     return profile
 
 
-# ---------------------------------------------------------------------------
 # Item 1: role: reviewer -> create_agent path, reviewer policy block
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -150,11 +146,9 @@ async def test_profile_role_key_without_preset_flag(monkeypatch, tmp_path):
     assert "bash" in branch.acts.registry  # create_agent path, not bare Branch
 
 
-# ---------------------------------------------------------------------------
 # Falsy explicit `role:` values must fail closed, not silently default to
 # "implementer" (a role profile with role: "" / false / 0 must not silently
 # be granted implementer coding authority).
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -221,9 +215,7 @@ async def test_profile_falsy_role_value_raises_on_resume_too(
         await _run_agent(None, "go", agent_name="falsy-role-profile", resume="deadbeef")
 
 
-# ---------------------------------------------------------------------------
 # Item 2: unknown role -> ValueError surfaces, not swallowed
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -241,9 +233,7 @@ async def test_profile_role_unknown_raises_value_error(monkeypatch, tmp_path):
         await _run_agent(None, "go", agent_name="ghost-role-profile")
 
 
-# ---------------------------------------------------------------------------
 # Item 4: profile without role: key -> byte-for-byte unchanged (bare Branch)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -281,14 +271,10 @@ async def test_profile_with_unrelated_frontmatter_keys_no_role_key(monkeypatch, 
     assert not {"bash", "reader", "editor", "search"}.intersection(branch.acts.registry.keys())
 
 
-# ---------------------------------------------------------------------------
 # Item 7: --preset coding with no -a is unaffected (default role implementer)
-# ---------------------------------------------------------------------------
 
 
-# ---------------------------------------------------------------------------
 # lion_system: false must propagate to the create_agent path (role: key)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_profile_timeout.py
+++ b/tests/cli/test_agent_profile_timeout.py
@@ -21,9 +21,7 @@ import pytest
 
 from lionagi.cli._providers import AgentProfile, _parse_profile
 
-# ---------------------------------------------------------------------------
 # Unit tests: profile field parsing/validation
-# ---------------------------------------------------------------------------
 
 
 def test_parse_profile_timeout_valid():
@@ -61,9 +59,7 @@ def test_parse_profile_timeout_rejects_bool_and_float(raw_yaml, caplog):
     assert profile.timeout is None
 
 
-# ---------------------------------------------------------------------------
 # Integration: _run_agent precedence (explicit flag > profile > built-in default)
-# ---------------------------------------------------------------------------
 
 
 def _wire_agent_stubs(

--- a/tests/cli/test_agent_resume_empty_stream.py
+++ b/tests/cli/test_agent_resume_empty_stream.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for li agent -r (resume) empty-stream detection (closes #1427)."""
+"""Tests for li agent -r (resume) empty-stream detection."""
 
 from __future__ import annotations
 
@@ -12,9 +12,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
 # Shared stub helpers
-# ---------------------------------------------------------------------------
 
 
 def _wire_agent_stubs(monkeypatch, tmp_path: Path, operate_return=None):
@@ -81,9 +79,7 @@ def _make_branch_json(tmp_path: Path) -> tuple[str, Path]:
     return branch_id, p
 
 
-# ---------------------------------------------------------------------------
 # Test: resume with empty stream → non-zero exit + actionable message
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -200,9 +196,7 @@ async def test_resume_empty_stream_exit_code_nonzero(monkeypatch, tmp_path):
     assert rc != 0, f"Expected non-zero exit code on empty-stream resume, got {rc}"
 
 
-# ---------------------------------------------------------------------------
 # Test: resume with non-empty stream → exit 0 (no regression)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_resume_gemini_effort.py
+++ b/tests/cli/test_agent_resume_gemini_effort.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for `li agent -r --effort` re-applying effort to gemini-code /
-gemini-cli (agy) branches — issue #1595.
+gemini-cli (agy) branches.
 
 agy has no effort flag/kwarg; effort is folded into the `--model` display
-name (e.g. "Gemini 3.5 Flash (High)"). On resume, `cfg["model"]` already
-holds that resolved display name from the first turn. `resolve_agy_model`'s
-exact-match short-circuit (correct for a caller-typed pin) was firing on
-this *persisted* value too, silently dropping a new `--effort` passed on
-resume with no new `--model`. These tests pin:
+name (e.g. "Gemini 3.5 Flash (High)"), and `cfg["model"]` already holds that
+resolved display name on resume. `resolve_agy_model`'s exact-match
+short-circuit (correct for a caller-typed pin) was firing on this
+*persisted* value too, silently dropping a new `--effort` passed on resume
+with no new `--model`. These tests pin:
 
   * resume + explicit --effort (no new model) re-applies effort onto the
     persisted agy model name,

--- a/tests/cli/test_agent_resume_model_override.py
+++ b/tests/cli/test_agent_resume_model_override.py
@@ -119,9 +119,7 @@ def _reset_channel(name: str) -> logging.Logger:
     return logger
 
 
-# ---------------------------------------------------------------------------
 # Implausible bare token as resume MODEL override → rejected
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -197,9 +195,7 @@ async def test_garbage_model_token_on_resume_exits_nonzero(monkeypatch, tmp_path
     assert any("c95-32617270327a" in rec.message for rec in caplog.records)
 
 
-# ---------------------------------------------------------------------------
 # Legitimate provider/model override on resume → proceeds + warns
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -263,9 +259,7 @@ async def test_matching_model_override_on_resume_does_not_warn(monkeypatch, tmp_
     assert not override_warns, f"Unexpected override warning for a no-op override: {override_warns}"
 
 
-# ---------------------------------------------------------------------------
 # Prefix-matched resume id → hint emitted
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_resume_on_timeout.py
+++ b/tests/cli/test_agent_resume_on_timeout.py
@@ -25,9 +25,7 @@ import pytest
 
 from lionagi.cli._providers import AgentProfile, _parse_profile
 
-# ---------------------------------------------------------------------------
 # Unit tests: profile field parsing/validation
-# ---------------------------------------------------------------------------
 
 
 def test_parse_profile_resume_on_timeout_once():
@@ -58,9 +56,7 @@ def test_parse_profile_resume_on_timeout_rejects_non_once_values(raw_yaml, caplo
     assert profile.resume_on_timeout is False
 
 
-# ---------------------------------------------------------------------------
 # Integration: _run_agent auto-resume wiring
-# ---------------------------------------------------------------------------
 
 
 def _make_branch_json(tmp_path: Path) -> tuple[str, Path]:
@@ -445,14 +441,12 @@ async def test_profile_resume_on_timeout_opts_in(monkeypatch, tmp_path):
     assert status == "completed"
 
 
-# ---------------------------------------------------------------------------
 # Real-persistence regression: the ADR-0035 terminal-guard race between an
 # auto-resume leg's premature terminal stamp and the resumed leg's own
 # teardown. Unlike _wire_agent_stubs (which stubs teardown_agent_persist
 # entirely), these tests leave setup_agent_persist/teardown_agent_persist
 # wired to the real StateDB-backed implementation, so a wiring regression in
 # the defer_terminal plumbing shows up as a real TransitionRejectedError.
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture

--- a/tests/cli/test_agent_resume_plain_profile_system_prompt.py
+++ b/tests/cli/test_agent_resume_plain_profile_system_prompt.py
@@ -8,13 +8,12 @@ A prior fix addressed a role/preset branch's create_agent-composed system
 message (role header + policy block) getting clobbered by a bare
 `add_message(system=profile.system_prompt)` on resume. That fix's guard —
 skip reapplication whenever the leg is a resume/continue-last — was
-unconditional though: it also disabled reapplication for *plain* profiles
-(no `role:` key), which never go through create_agent and never had a
-composed message to protect. `load_agent_profile(agent_name)` re-reads the
-profile file from disk on every `_run_agent` call, so editing a plain
-profile's body and then `-r`/`-c`-ing back into an existing branch is
-expected to pick up the edit on the next turn — for plain profiles there is
-no role/preset composition to protect in the first place.
+unconditional, so it also disabled reapplication for *plain* profiles (no
+`role:` key), which never go through create_agent and never had a composed
+message to protect. `load_agent_profile(agent_name)` re-reads the profile
+file from disk on every `_run_agent` call, so editing a plain profile and
+`-r`/`-c`-ing back into an existing branch should pick up the edit on the
+next turn.
 """
 
 from __future__ import annotations

--- a/tests/cli/test_agent_resume_role_branch_origin_marker.py
+++ b/tests/cli/test_agent_resume_role_branch_origin_marker.py
@@ -3,35 +3,29 @@
 
 """Regression: resuming a role-composed branch must not clobber its persisted
 system message even when the CURRENT invocation's profile no longer signals
-`role:` — either because a different, plain `-a` profile is supplied, or
-because the same profile file has since had its `role:` key removed.
+`role:` — either a different, plain `-a` profile is supplied, or the same
+profile file has since had its `role:` key removed.
 
 A prior guard derived "was this branch composed via create_agent?" from the
-profile reloaded for the *resuming* invocation (`has_role_key`). That is the
-wrong signal on a resumed leg: `has_role_key` describes only what was passed
-to this particular `-a`, not how the persisted branch was originally built.
-Resuming a role-composed branch under a mismatched profile made the guard
-treat it as a plain branch and call `branch.msgs.add_message(system=...)`,
-which replaces the branch's composed role header + policy block with the
-current profile's bare body.
+*resuming* invocation's profile (`has_role_key`) — the wrong signal, since
+that describes only what was passed to this `-a`, not how the persisted
+branch was built. Resuming a role-composed branch under a mismatched profile
+made the guard treat it as plain and call `branch.msgs.add_message(system=...)`,
+replacing the composed role header + policy block with the current profile's
+bare body. The fix stamps every create_agent-built branch with an immutable
+origin marker in `branch.metadata` (`CREATE_AGENT_BRANCH_ORIGIN_KEY`) that
+round-trips through save/resume, and consults that marker instead.
 
-The fix stamps every create_agent-built branch with an immutable origin
-marker in `branch.metadata` (`CREATE_AGENT_BRANCH_ORIGIN_KEY`) that
-round-trips through save/resume, and consults that marker — not the current
-profile — on any resumed/continued leg.
-
-A later guard additionally treated the *content* of a persisted system
-message as a provenance signal: if it contained one of the three headings
-`_render_policy_block` emits (`## Authority`, `## Operational Boundaries`,
-`## Escalation Conditions`), it was inferred to be create_agent-composed and
-the marker was backfilled. Those headings are ordinary user-authored prompt
-text and are not exclusive to create_agent, so a hand-written plain profile
-using e.g. `## Authority` was misclassified and a newly requested role's
-system prompt was silently dropped on resume. That content heuristic (and
-the backfill it drove) has been removed entirely: only the immutable
-`CREATE_AGENT_BRANCH_ORIGIN_KEY` marker counts as create_agent provenance. A
-markerless branch always gets the newly requested role's system prompt
-applied, regardless of what its persisted system message happens to contain.
+A later guard also inferred provenance from *content*: a persisted system
+message containing one of `_render_policy_block`'s three headings
+(`## Authority`, `## Operational Boundaries`, `## Escalation Conditions`) was
+treated as create_agent-composed and backfilled the marker. Those headings
+are ordinary prompt text, not exclusive to create_agent, so a hand-written
+profile using e.g. `## Authority` was misclassified and a newly requested
+role's system prompt was silently dropped on resume. That content heuristic
+and its backfill are gone: only the immutable marker counts as provenance,
+and a markerless branch always gets the newly requested role's system
+prompt applied regardless of its persisted content.
 """
 
 from __future__ import annotations

--- a/tests/cli/test_agent_resume_role_system_message.py
+++ b/tests/cli/test_agent_resume_role_system_message.py
@@ -5,15 +5,14 @@
 persisted system message.
 
 A brand-new role-profile branch composes its system message via
-create_agent (role header + policy block + profile body). Once that branch
-is persisted and later reopened (-r / --continue-last / the automatic
-timeout-resume leg), `took_create_agent_path` is False for the reopened leg
-(neither --preset nor a fresh profile-role branch is being created — an
-existing branch is just being loaded back). Before the fix, the
+create_agent (role header + policy block + profile body). Once persisted and
+later reopened (-r / --continue-last / the automatic timeout-resume leg),
+`took_create_agent_path` is False for the reopened leg — an existing branch
+is just being loaded back, not freshly composed. Before the fix, the
 profile-system-prompt block ran unconditionally whenever
-`not took_create_agent_path`, so it called `branch.msgs.add_message(system=...)`
--> `set_system` -> replaced the persisted composed system message with the
-bare profile body, silently dropping the role header and policy block.
+`not took_create_agent_path`, calling `branch.msgs.add_message(system=...)`
+-> `set_system` -> replacing the persisted composed message with the bare
+profile body, silently dropping the role header and policy block.
 """
 
 from __future__ import annotations

--- a/tests/cli/test_agent_sigterm_and_failed_logging.py
+++ b/tests/cli/test_agent_sigterm_and_failed_logging.py
@@ -103,9 +103,7 @@ def _agent_args(**overrides) -> SimpleNamespace:
     return SimpleNamespace(**base)
 
 
-# ---------------------------------------------------------------------------
 # Site 1: _run_agent's inner except — "failed" bucket must log before raising
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -161,9 +159,7 @@ async def test_run_agent_inner_does_not_log_on_success(monkeypatch, tmp_path):
     assert not errors_emitted, f"log_error should not fire on success; got: {errors_emitted}"
 
 
-# ---------------------------------------------------------------------------
 # Site 2: run_agent's outer except — "failed" bucket must log before raising
-# ---------------------------------------------------------------------------
 
 
 def test_run_agent_outer_logs_failed_exception_before_reraising(monkeypatch):
@@ -190,9 +186,7 @@ def test_run_agent_outer_logs_failed_exception_before_reraising(monkeypatch):
     assert "outer boundary failure" in combined
 
 
-# ---------------------------------------------------------------------------
 # Site 2: run_agent's new SigtermInterrupt branch
-# ---------------------------------------------------------------------------
 
 
 def test_run_agent_outer_handles_sigterm_interrupt(monkeypatch):
@@ -247,9 +241,7 @@ def test_run_agent_outer_sigterm_not_caught_as_generic_failure(monkeypatch):
     )
 
 
-# ---------------------------------------------------------------------------
 # _util.classify_exception: SigtermInterrupt maps to the "cancelled" bucket
-# ---------------------------------------------------------------------------
 
 
 def test_classify_exception_sigterm_interrupt_maps_to_cancelled():
@@ -268,9 +260,7 @@ def test_classify_exception_sigterm_interrupt_distinct_from_aborted():
     assert classify_exception(SigtermInterrupt("received SIGTERM")) != "aborted"
 
 
-# ---------------------------------------------------------------------------
 # Both handlers write the typed cause the MCP job record reads
-# ---------------------------------------------------------------------------
 
 
 class TestTheTerminalPathReachesTheCauseWriter:

--- a/tests/cli/test_agent_status_hint.py
+++ b/tests/cli/test_agent_status_hint.py
@@ -113,9 +113,7 @@ def _agent_args(**overrides) -> SimpleNamespace:
     return SimpleNamespace(**defaults)
 
 
-# ---------------------------------------------------------------------------
 # _run_agent: session_id is the 5th return value
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -142,9 +140,7 @@ async def test_run_agent_session_id_none_when_persist_disabled(monkeypatch, tmp_
     assert session_id is None
 
 
-# ---------------------------------------------------------------------------
 # run_agent(): post-run hint includes the status line
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -106,7 +106,7 @@ class _RecordingBranch:
         return f"turn-{len(self.calls)}"
 
 
-# ── enqueue gate ─────────────────────────────────────────────────────────────
+# enqueue gate
 
 
 @pytest.mark.anyio
@@ -216,7 +216,7 @@ async def test_msg_refused_for_terminal_agent_session(temp_db_path, capsys):
         assert await db.list_pending_session_controls(sid) == []
 
 
-# ── run-id addressing (the operator's actual handle for an agent leg) ──────
+# run-id addressing (the operator's actual handle for an agent leg)
 
 
 @pytest.mark.anyio
@@ -303,7 +303,7 @@ async def test_msg_by_full_session_id_unaffected_by_run_id_fallback(temp_db_path
         assert len(await db.list_pending_session_controls(sid)) == 1
 
 
-# ── turn-end drain ───────────────────────────────────────────────────────────
+# turn-end drain
 
 
 @pytest.mark.anyio
@@ -399,7 +399,7 @@ async def test_drain_without_live_session_is_noop(temp_db_path):
     assert branch.calls == []
 
 
-# ── terminal tombstone ───────────────────────────────────────────────────────
+# terminal tombstone
 
 
 @pytest.mark.anyio
@@ -495,7 +495,7 @@ async def test_drain_returns_quietly_when_there_is_no_persistence_at_all(caplog)
     assert "no database handle" not in caplog.text
 
 
-# ── at-most-once and the deadline boundary ───────────────────────────────────
+# at-most-once and the deadline boundary
 
 
 @pytest.mark.anyio
@@ -679,7 +679,7 @@ async def test_drain_does_not_start_a_continuation_after_the_deadline(temp_db_pa
         assert [r["result"] for r in pending] == [None]
 
 
-# ── claim ownership: a claimed row belongs to its claimant ───────────────────
+# claim ownership: a claimed row belongs to its claimant
 
 
 @pytest.mark.anyio
@@ -837,7 +837,7 @@ async def test_a_claim_whose_leg_died_stays_visible_rather_than_being_resolved(t
         assert ctl["claimed_at"] is not None
 
 
-# ── enqueue against a run that is terminalizing ──────────────────────────────
+# enqueue against a run that is terminalizing
 
 
 @pytest.mark.anyio
@@ -964,7 +964,7 @@ async def test_the_runner_sweeps_after_it_terminalizes_not_before(
         await db.__aexit__(None, None, None)
 
 
-# ── operator resolution of a wedged claim ────────────────────────────────────
+# operator resolution of a wedged claim
 
 
 @pytest.mark.anyio

--- a/tests/cli/test_agent_timeout_deadline.py
+++ b/tests/cli/test_agent_timeout_deadline.py
@@ -12,7 +12,7 @@ import pytest
 
 from lionagi.cli._providers import build_deadline_preamble
 
-# ── build_deadline_preamble unit tests ────────────────────────────────────────
+# build_deadline_preamble unit tests
 
 
 def test_preamble_contains_deadline_tags():
@@ -84,7 +84,7 @@ def test_preamble_sub_minute_timeout_clamps_to_1():
     assert "1 minute " in preamble
 
 
-# ── Integration: preamble prepended to prompt in _run_agent ──────────────────
+# Integration: preamble prepended to prompt in _run_agent
 #
 # Strategy: mock branch.operate at the *class* level using monkeypatch so we
 # avoid Pydantic's __setattr__ guard.  The spy records what instruction was

--- a/tests/cli/test_argv_injection.py
+++ b/tests/cli/test_argv_injection.py
@@ -10,9 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _schedule(**kwargs) -> dict:
@@ -32,9 +30,7 @@ def _schedule(**kwargs) -> dict:
     return base
 
 
-# ---------------------------------------------------------------------------
 # subprocess.build_argv — action_model validation
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvActionModelInjection:
@@ -192,9 +188,7 @@ class TestBuildArgvActionModelInjection:
                 os.unlink(tmp)
 
 
-# ---------------------------------------------------------------------------
 # subprocess.build_argv — action_extra_args validation
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvExtraArgsInjection:
@@ -252,9 +246,7 @@ class TestBuildArgvExtraArgsInjection:
         assert tmp is None
 
 
-# ---------------------------------------------------------------------------
 # subprocess.build_argv — identifier fields (action_agent/project/playbook)
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvIdentifierInjection:
@@ -295,9 +287,7 @@ class TestBuildArgvIdentifierInjection:
         assert tmp is None
 
 
-# ---------------------------------------------------------------------------
 # build_argv structural: -- sentinel and positional ordering
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvSentinelStructure:
@@ -503,9 +493,7 @@ class TestBuildArgvSentinelStructure:
         )
 
 
-# ---------------------------------------------------------------------------
 # service layer — create_schedule validation
-# ---------------------------------------------------------------------------
 
 
 class TestCreateScheduleInjectionRejection:
@@ -604,9 +592,7 @@ class TestCreateScheduleInjectionRejection:
         assert "id" in result
 
 
-# ---------------------------------------------------------------------------
 # service layer — update_schedule (PATCH) validation
-# ---------------------------------------------------------------------------
 
 
 class TestUpdateScheduleInjectionRejection:
@@ -721,9 +707,7 @@ class TestUpdateScheduleInjectionRejection:
         assert not write_called["value"], "DB write must not be called when validation rejects"
 
 
-# ---------------------------------------------------------------------------
 # action_prompt == '--' sentinel rejection
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvPromptSentinelRejection:
@@ -834,9 +818,7 @@ class TestBuildArgvPromptSentinelRejection:
             asyncio.run(_go())
 
 
-# ---------------------------------------------------------------------------
 # cli/main.py — pre-parse verbose scan must be sentinel-aware
-# ---------------------------------------------------------------------------
 
 
 class TestMainVerboseScanSentinelAware:
@@ -947,10 +929,8 @@ class TestMainVerboseScanSentinelAware:
         )
 
 
-# ---------------------------------------------------------------------------
 # build_argv — template injection: rendered prompt must be validated post-render
 # (order-of-operations bypass)
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvTemplateInjection:
@@ -1027,9 +1007,7 @@ class TestBuildArgvTemplateInjection:
             build_argv(_schedule(action_prompt="--"), {})
 
 
-# ---------------------------------------------------------------------------
 # CWE-918 github_repo path manipulation — validator unit tests
-# ---------------------------------------------------------------------------
 
 
 class TestGithubRepoValidatorUnit:
@@ -1159,9 +1137,7 @@ class TestGithubRepoValidatorUnit:
         _validate_github_repo(f"owner/{name}")  # must not raise
 
 
-# ---------------------------------------------------------------------------
 # CWE-918 github_repo — service boundary (create and update)
-# ---------------------------------------------------------------------------
 
 
 class TestGithubRepoServiceValidation:
@@ -1170,7 +1146,7 @@ class TestGithubRepoServiceValidation:
     def _run(self, coro):
         return asyncio.run(coro)
 
-    # -- create_schedule --
+    # create_schedule
 
     def test_create_path_traversal_raises(self):
         """create_schedule raises ValueError for '../../other-endpoint'."""
@@ -1299,7 +1275,7 @@ class TestGithubRepoServiceValidation:
             )
         assert "id" in result
 
-    # -- update_schedule --
+    # update_schedule
 
     def _mock_db(self, existing: dict):
         class _MockDB:

--- a/tests/cli/test_argv_parser_regression.py
+++ b/tests/cli/test_argv_parser_regression.py
@@ -12,9 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
 # Shared capture store — reset before each parametrized test invocation
-# ---------------------------------------------------------------------------
 
 _CAPTURED: dict[str, Any] = {}
 
@@ -23,11 +21,9 @@ def _reset() -> None:
     _CAPTURED.clear()
 
 
-# ---------------------------------------------------------------------------
 # Fake run functions
 # Each captures the positional and keyword arguments it receives so tests can
 # assert on flag values without executing any network/agent logic.
-# ---------------------------------------------------------------------------
 
 
 async def _fake_run_agent(
@@ -93,9 +89,7 @@ async def _fake_run_fanout(
     return "output", "completed"
 
 
-# ---------------------------------------------------------------------------
 # Helper: run main() with argv (strips 'uv run li' wrapper from build_argv output)
-# ---------------------------------------------------------------------------
 
 
 def _run_main_with_argv(argv: list[str]) -> int:
@@ -121,9 +115,7 @@ def _argv_without_wrapper(argv: list[str]) -> list[str]:
     return argv[3:]
 
 
-# ---------------------------------------------------------------------------
 # agent kind
-# ---------------------------------------------------------------------------
 
 HOSTILE_PROMPTS = ["--bypass", "--yolo", "--fast", "--verbose"]
 
@@ -209,9 +201,7 @@ class TestFanoutTerminalStatusExitCode:
         assert rc == 0
 
 
-# ---------------------------------------------------------------------------
 # flow kind
-# ---------------------------------------------------------------------------
 
 
 class TestFlowParserPromptInjection:
@@ -249,9 +239,7 @@ class TestFlowParserPromptInjection:
         assert c["verbose"] is False, f"verbose=True after hostile prompt {hostile!r}"
 
 
-# ---------------------------------------------------------------------------
 # fanout kind
-# ---------------------------------------------------------------------------
 
 
 class TestFanoutParserPromptInjection:
@@ -289,9 +277,7 @@ class TestFanoutParserPromptInjection:
         assert c["verbose"] is False, f"verbose=True after hostile prompt {hostile!r}"
 
 
-# ---------------------------------------------------------------------------
 # flow_yaml kind — prompt EXCLUDED from argv
-# ---------------------------------------------------------------------------
 
 
 class TestFlowYamlParserPromptExclusion:
@@ -374,9 +360,7 @@ class TestFlowYamlParserPromptExclusion:
                 os.unlink(tmp_yaml)
 
 
-# ---------------------------------------------------------------------------
 # Sentinel placement sanity: verify '--' is before positionals in argv shape
-# ---------------------------------------------------------------------------
 
 
 class TestSentinelPlacement:
@@ -488,9 +472,7 @@ class TestSentinelPlacement:
                 os.unlink(tmp_path)
 
 
-# ---------------------------------------------------------------------------
 # Regression pin: '-- --' and '-- trailing' pass through
-# ---------------------------------------------------------------------------
 
 
 class TestDoubleDashSentinelEdgeCases:
@@ -568,9 +550,7 @@ class TestDoubleDashSentinelEdgeCases:
             )
 
 
-# ---------------------------------------------------------------------------
 # Parser-level: template-rendered sentinel rejection
-# ---------------------------------------------------------------------------
 
 
 class TestTemplateRenderedSentinelRejection:

--- a/tests/cli/test_cli_contracts.py
+++ b/tests/cli/test_cli_contracts.py
@@ -3,32 +3,22 @@
 
 """CLI contract goldens for `li agent`, `li schedule`, and `li monitor`.
 
-These three commands are the CLI surfaces that spawn or observe other
-processes (subagents, scheduled fires, running entities). The regression
-class this module guards against: a spawn-forwarding surface silently
-accepting invalid input (bad flag, missing required argument, unreachable
-backend) instead of failing loudly with a clear diagnostic and a nonzero
-exit code, and CLI flag/exit-code drift going unnoticed because nothing
-pins the actual `--help` surface or the current, empirically observed
-error shape.
+These are the CLI surfaces that spawn or observe other processes (subagents,
+scheduled fires, running entities). Guards against: a spawn-forwarding
+surface silently accepting invalid input instead of failing loudly with a
+nonzero exit code, and CLI flag/exit-code drift going unnoticed.
 
-Everything here is invoked out-of-process via `sys.executable -m
-lionagi.cli.main ...` (the real `li` entrypoint per `[project.scripts]` in
-pyproject.toml is `lionagi.cli.main:main`), so these tests see exactly what
-an external caller of the installed `li` binary sees: real exit codes, real
-stdout/stderr, no patched internals.
+Invoked out-of-process via `sys.executable -m lionagi.cli.main ...` (the
+real `li` entrypoint is `lionagi.cli.main:main`), so these tests see exactly
+what an external caller of the installed `li` binary sees.
 
-Flag-set goldens compare *sorted flag lists* extracted from `--help` output,
-not full help text — full text (wrapped descriptions, epilogs, examples)
-churns on every wording tweak; the flag set is the actual contract external
-callers and scheduled actions depend on.
+Flag-set goldens compare *sorted flag lists* from `--help`, not full help
+text — full text churns on wording tweaks; the flag set is the actual
+contract callers depend on.
 
-Anything that requires a live Studio daemon (`li studio`) with real
-scheduled/session data is skipped with a reason rather than mocked — mocking
-the daemon would just be testing the mock. Where an error path can be
-triggered deterministically without a daemon (unreachable Studio URL,
-absent state.db) by pointing the command at an empty/unreachable target via
-env vars, that is exercised directly: it's cheap, hermetic, and real.
+Anything needing a live Studio daemon is skipped with a reason rather than
+mocked. Error paths triggerable without a daemon (unreachable Studio URL,
+absent state.db) are exercised directly instead.
 """
 
 from __future__ import annotations
@@ -108,7 +98,7 @@ def test_scheduled_cli_inherits_invocation_from_environment(
     )
 
 
-# --- goldens: sorted flag sets, pinned from the actual parser definitions ---
+# goldens: sorted flag sets, pinned from the actual parser definitions
 
 AGENT_HELP_FLAGS = [
     "--agent",

--- a/tests/cli/test_cli_surface_goldens.py
+++ b/tests/cli/test_cli_surface_goldens.py
@@ -3,53 +3,31 @@
 
 """CLI contract goldens, part 2: full-registry surface + in-process error paths.
 
-Complements ``tests/cli/test_cli_contracts.py`` (which pins ``li agent`` /
-``li schedule`` / ``li schedule create`` / ``li monitor`` flag sets and exit
-codes via out-of-process ``subprocess`` calls to the real entrypoint). This
-module extends that coverage in three ways rather than duplicating it:
+Complements ``tests/cli/test_cli_contracts.py`` (out-of-process ``subprocess``
+goldens for ``li agent`` / ``li schedule`` / ``li monitor``). This module
+walks the whole top-level command registry plus the ``li o flow`` /
+``li o fanout`` / remaining ``li schedule`` subcommands the other file
+doesn't pin, calls ``lionagi.cli.main.main`` in-process instead of
+subprocessing (faster, and immune to any state a subprocess could leak
+across ``pytest-xdist`` workers), and pins the regression this file exists
+for: a spawn-forwarding surface (``li agent``, ``li o flow``, ``li o fanout``)
+must reject a nonexistent ``--cwd`` before allocating a run record or
+spawning a provider, not silently create the directory and report success as
+a prior version did. Each case monkeypatches the run-allocation function to
+raise if reached, then asserts the *validation* error propagates — proving
+allocation was never reached, not just that the process exits non-zero.
 
-1. It walks the *whole* top-level command registry and the ``li o flow`` /
-   ``li o fanout`` and remaining ``li schedule`` subcommand surfaces (list,
-   get, limits, enable, disable, trigger, delete, runs) that the existing
-   file does not pin — a command silently added to (or removed from) the
-   registry, or a flag silently added to/removed from a spawn-forwarding
-   subcommand, now fails a golden until the change is deliberate.
-2. Every case here is invoked **in-process** — calling ``lionagi.cli.main.main``
-   directly and either catching the ``SystemExit`` argparse raises or reading
-   its plain integer return value — instead of spawning a subprocess. This
-   is materially faster and avoids any shared-state assumptions across
-   ``pytest-xdist`` workers that an out-of-process test could accidentally
-   pick up (it can't: nothing here touches the filesystem outside ``tmp_path``
-   or the network).
-3. It pins, end-to-end through the real CLI entrypoint, the specific
-   regression class this whole test area exists to guard: a spawn-forwarding
-   surface (``li agent``, ``li o flow``, ``li o fanout``) silently accepting
-   a bad input — concretely, a ``--cwd`` that does not exist — instead of
-   failing loudly before anything is spawned or persisted. A prior version of
-   ``li agent --cwd <typo'd path>`` let the underlying provider silently
-   create the directory and report a clean, completed-ok run; the fix makes
-   every one of these three surfaces validate ``--cwd`` before allocating a
-   run record or spawning a provider process. The tests below monkeypatch
-   the run-allocation function each surface calls to raise if reached, then
-   assert the *validation* error is what actually propagates — proving
-   allocation was never reached, not merely that the process exits non-zero.
+``--effort`` has no argparse ``choices=`` deliberately — it's passed through
+unvalidated so a new provider effort tier is never rejected by a stale
+allowlist (see ``lionagi/service/providers.py::normalize_effort``), so there
+is no hermetic "invalid --effort" case to pin here. ``--trigger-type`` and
+``--action-kind`` on ``li schedule create`` are the CLI's actual
+choices=-validated flags and stand in for that contract instead.
 
-A note on one substitution: the source generic guidance for this test area
-mentions pinning an "invalid --effort value" exit code. ``--effort`` is
-deliberately free text with no argparse ``choices=`` — it is lower-cased and
-passed through unvalidated so a newly supported provider effort tier is never
-silently rejected by a stale allowlist (see
-``lionagi/service/providers.py::normalize_effort``). There is therefore no
-cheap, hermetic "invalid --effort" error to pin without mocking a live
-provider spawn. ``--trigger-type`` and ``--action-kind`` on
-``li schedule create`` are the CLI's actual argparse-``choices=``-validated
-flags and serve the same "invalid enum value" contract this module pins
-instead.
-
-Flake rule: every assertion here is deterministic — pure argparse
-introspection, or an in-process call whose only external dependency is a
-nonexistent path the test itself constructs under ``tmp_path``. A flaking
-case is a bug in the test, not grounds to skip it in place.
+Every assertion here is deterministic: pure argparse introspection, or an
+in-process call whose only external dependency is a nonexistent path the
+test itself builds under ``tmp_path``. A flake here is a test bug, not
+grounds to skip.
 """
 
 from __future__ import annotations
@@ -65,9 +43,7 @@ import pytest
 import lionagi.cli.main as cli_main
 from lionagi._errors import ConfigurationError
 
-# ---------------------------------------------------------------------------
 # Shared introspection + invocation helpers
-# ---------------------------------------------------------------------------
 
 
 def _command_parser(command: str, *subs: str) -> argparse.ArgumentParser:
@@ -132,9 +108,7 @@ def _run_main(argv: list[str]) -> int:
         return code if isinstance(code, int) else 1
 
 
-# ---------------------------------------------------------------------------
 # Goldens — sorted flag/positional sets, pinned from the actual parser tree
-# ---------------------------------------------------------------------------
 
 TOP_LEVEL_COMMANDS = [
     "agent",
@@ -311,9 +285,7 @@ class TestScheduleSubcommandShapeGoldens:
         assert _positional_dests("schedule", name) == positionals
 
 
-# ---------------------------------------------------------------------------
 # In-process exit-code / error-shape contracts (no subprocess)
-# ---------------------------------------------------------------------------
 
 
 class TestInProcessContractErrors:
@@ -364,9 +336,7 @@ class TestInProcessContractErrors:
         assert "--action-kind" in captured.err
 
 
-# ---------------------------------------------------------------------------
 # The regression class itself: nonexistent --cwd must fail fast, end-to-end
-# ---------------------------------------------------------------------------
 
 
 class TestNonexistentCwdFailFastEndToEnd:
@@ -469,9 +439,7 @@ class TestNonexistentCwdFailFastEndToEnd:
         assert captured.out == ""
 
 
-# ---------------------------------------------------------------------------
 # Console-script entrypoint smoke test (the one deliberate subprocess case)
-# ---------------------------------------------------------------------------
 
 
 def _find_li_console_script() -> str | None:

--- a/tests/cli/test_code_identity.py
+++ b/tests/cli/test_code_identity.py
@@ -185,7 +185,7 @@ def test_no_comparison_ref_is_unknown_not_ok(tmp_path: Path) -> None:
     assert drift["unknown"]
 
 
-# ── the drift verdict ────────────────────────────────────────────────────────
+# the drift verdict
 
 
 def test_version_mismatch_against_installed_distribution_is_drift() -> None:
@@ -207,7 +207,7 @@ def test_behind_outranks_unknown_in_the_verdict() -> None:
     assert any("24 commit(s) behind" in reason for reason in drift["reasons"])
 
 
-# ── the snapshot, and the tree moving underneath it ──────────────────────────
+# the snapshot, and the tree moving underneath it
 
 
 @pytest.fixture
@@ -300,7 +300,7 @@ def test_the_snapshot_answers_when_the_checkout_has_moved() -> None:
     assert any("24 commit(s) behind" in reason for reason in drift["reasons"])
 
 
-# ── the tree moving without the commit moving ────────────────────────────────
+# the tree moving without the commit moving
 
 
 def test_a_dirty_tree_is_fingerprinted_and_a_clean_one_is_too(checkout_behind: Path) -> None:
@@ -683,7 +683,7 @@ def test_code_identity_reports_this_process() -> None:
     assert identity["git_live"]["status"] in ("ok", "not_a_git_checkout", "unknown")
 
 
-# ── the doctor check ─────────────────────────────────────────────────────────
+# the doctor check
 
 
 def _identity(drift_status: str, **overrides: object) -> dict[str, object]:
@@ -758,7 +758,7 @@ def test_run_doctor_exits_nonzero_on_unknown(monkeypatch: pytest.MonkeyPatch) ->
     assert doctor.run_doctor(_Args()) == 1
 
 
-# ── the surfaces a client reads ──────────────────────────────────────────────
+# the surfaces a client reads
 
 
 def test_handshake_carries_code_identity() -> None:

--- a/tests/cli/test_command_action_kind.py
+++ b/tests/cli/test_command_action_kind.py
@@ -27,9 +27,7 @@ def _schedule(**kwargs) -> dict:
     return base
 
 
-# ---------------------------------------------------------------------------
 # subprocess.build_argv — basic argv shape
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvCommandShape:
@@ -83,9 +81,7 @@ class TestBuildArgvCommandShape:
         assert "/abs/path/to/li" not in argv
 
 
-# ---------------------------------------------------------------------------
 # subprocess.build_argv — templated-argv rendering
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvCommandTemplateRendering:
@@ -117,9 +113,7 @@ class TestBuildArgvCommandTemplateRendering:
         assert argv == ["kdev", "pr-7"]
 
 
-# ---------------------------------------------------------------------------
 # subprocess.build_argv — leading-'-' injection rejection on a rendered arg
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvCommandArgInjection:
@@ -163,9 +157,7 @@ class TestBuildArgvCommandArgInjection:
             build_argv(sched, {})
 
 
-# ---------------------------------------------------------------------------
 # subprocess — action_command allow-list gate
-# ---------------------------------------------------------------------------
 
 
 class TestCommandAllowlist:
@@ -267,9 +259,7 @@ class TestCommandAllowlist:
             build_argv(_schedule(action_command="--kdev"), {})
 
 
-# ---------------------------------------------------------------------------
 # services.schedules — build/validation-time refusal
-# ---------------------------------------------------------------------------
 
 
 class TestCreateScheduleCommandValidation:
@@ -410,9 +400,7 @@ class TestUpdateScheduleCommandValidation:
             self._run_update(existing, {"action_kind": "command"})
 
 
-# ---------------------------------------------------------------------------
 # CLI — --action-kind accepts 'command'
-# ---------------------------------------------------------------------------
 
 
 class TestCliActionKindChoices:
@@ -446,9 +434,7 @@ class TestCliActionKindChoices:
         assert args.action_command_args == ["review-pr"]
 
 
-# ---------------------------------------------------------------------------
 # worker.default_execute — the worker/task-application execution path
-# ---------------------------------------------------------------------------
 
 
 class TestWorkerDefaultExecuteCommandKind:
@@ -508,11 +494,9 @@ class TestWorkerDefaultExecuteCommandKind:
         assert "cannot resolve li executable" in stderr
 
 
-# ---------------------------------------------------------------------------
 # CLI — _cmd_create's --action-command-args JSON handling. TestCliActionKindChoices
 # above only pins argparse's raw string capture; the JSON-parse/shape error
 # paths inside _cmd_create itself (cli.py lines ~839-848) were untested.
-# ---------------------------------------------------------------------------
 
 
 class TestCmdCreateActionCommandArgsJSON:

--- a/tests/cli/test_dispatch_machine_writes.py
+++ b/tests/cli/test_dispatch_machine_writes.py
@@ -73,7 +73,7 @@ def _run(argv: list[str], capfd) -> tuple[int, dict]:
     return rc, _envelope(capfd)
 
 
-# ── ack ──────────────────────────────────────────────────────────────────────
+# ack
 
 
 def test_ack_applies_and_reports_the_row_acked(monkeypatch, tmp_path, capfd):
@@ -222,7 +222,7 @@ def test_a_lost_race_on_a_row_that_is_then_deleted_is_not_found_not_a_null_confl
     ), "an absent row was given a status field"
 
 
-# ── retry ────────────────────────────────────────────────────────────────────
+# retry
 
 
 def test_retry_requeues_a_dead_letter_row(monkeypatch, tmp_path, capfd):
@@ -261,7 +261,7 @@ def test_retry_of_an_unknown_id_is_not_found(monkeypatch, tmp_path, capfd):
     assert envelope["error"]["kind"] == "not_found"
 
 
-# ── purge ────────────────────────────────────────────────────────────────────
+# purge
 
 
 def test_purge_deletes_the_row_and_reports_the_status_it_had(monkeypatch, tmp_path, capfd):
@@ -342,7 +342,7 @@ def test_purge_with_no_id_and_no_criteria_is_invalid_input(monkeypatch, tmp_path
     assert envelope["error"]["kind"] == "invalid_input"
 
 
-# ── the store itself ─────────────────────────────────────────────────────────
+# the store itself
 
 
 def test_a_write_against_a_store_that_does_not_exist_is_not_found(monkeypatch, tmp_path, capfd):

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -35,7 +35,7 @@ def _closed_port_url() -> str:
     return f"http://127.0.0.1:{port}/api/admin/readiness"
 
 
-# ── _looks_editable ──────────────────────────────────────────────────────────
+# _looks_editable
 
 
 def test_looks_editable_true_under_pyproject(tmp_path: Path) -> None:
@@ -58,7 +58,7 @@ def test_looks_editable_false_for_none() -> None:
     assert _looks_editable(None) is False
 
 
-# ── _check_version ───────────────────────────────────────────────────────────
+# _check_version
 
 
 def test_check_version_ok_when_import_succeeds() -> None:
@@ -99,7 +99,7 @@ def test_check_version_fail_on_broken_import(monkeypatch: pytest.MonkeyPatch) ->
     assert "simulated broken install" in result["detail"]
 
 
-# ── _check_python ────────────────────────────────────────────────────────────
+# _check_python
 
 
 def test_check_python_warns_outside_venv(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -117,7 +117,7 @@ def test_check_python_ok_inside_venv(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result["status"] == "ok"
 
 
-# ── _check_imports ───────────────────────────────────────────────────────────
+# _check_imports
 
 
 def test_check_imports_all_ok_on_healthy_install() -> None:
@@ -142,7 +142,7 @@ def test_check_imports_reports_broken_module(monkeypatch: pytest.MonkeyPatch) ->
     assert results["lionagi"]["status"] == "ok"
 
 
-# ── _check_core_deps ─────────────────────────────────────────────────────────
+# _check_core_deps
 
 
 def test_check_core_deps_all_ok() -> None:
@@ -167,7 +167,7 @@ def test_check_core_deps_reports_missing(monkeypatch: pytest.MonkeyPatch) -> Non
     assert results["aiohttp"]["status"] == "ok"
 
 
-# ── _check_studio_daemon ─────────────────────────────────────────────────────
+# _check_studio_daemon
 
 
 def test_check_studio_daemon_unreachable_is_warn_not_fail() -> None:
@@ -185,7 +185,7 @@ def test_studio_default_target_is_readiness_not_the_composite_report() -> None:
     assert _STUDIO_READINESS_URL_DEFAULT.endswith("/api/admin/readiness")
 
 
-# ── _readiness_verdict ───────────────────────────────────────────────────────
+# _readiness_verdict
 # Readiness answers 200 for all three of its states, so these assert the verdict
 # is taken from the body. A code-only check would pass every one of them.
 
@@ -223,7 +223,7 @@ def test_readiness_verdict_unrecognised_status_is_unknown() -> None:
     assert result["status"] == "unknown"
 
 
-# ── _check_lionagi_home ──────────────────────────────────────────────────────
+# _check_lionagi_home
 
 
 def test_check_lionagi_home_ok_when_writable(tmp_path: Path) -> None:
@@ -244,7 +244,7 @@ def test_check_lionagi_home_fail_when_not_writable(tmp_path: Path) -> None:
         home.chmod(0o700)
 
 
-# ── collect_checks / run_doctor ──────────────────────────────────────────────
+# collect_checks / run_doctor
 
 
 def test_collect_checks_shape() -> None:

--- a/tests/cli/test_engine_agent_failure_diagnostics.py
+++ b/tests/cli/test_engine_agent_failure_diagnostics.py
@@ -13,9 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
 # Helpers (mirrors tests/cli/test_engine_emission_diagnostics.py)
-# ---------------------------------------------------------------------------
 
 
 def _build_args(**kwargs) -> argparse.Namespace:
@@ -58,9 +56,7 @@ class MockStateDB:
         self.update_calls.append({"run_id": run_id, "status": status, "error": error})
 
 
-# ---------------------------------------------------------------------------
 # Engine CLI: _total_agent_failure → status='failed', errors in error column
-# ---------------------------------------------------------------------------
 
 
 async def test_total_agent_failure_written_to_db_as_failed(monkeypatch):
@@ -206,12 +202,10 @@ async def test_engine_without_total_agent_failure_attr_stays_completed(monkeypat
     assert completed[0]["error"] is None
 
 
-# ---------------------------------------------------------------------------
 # INTEGRATION: real Engine subclass whose _run() drives every agent to error
 # — verifies the full Engine.run() → CLI read-site handoff for the total
 # agent-failure signal (the same integration shape as the emission-failure
 # test in test_engine_emission_diagnostics.py).
-# ---------------------------------------------------------------------------
 
 
 async def _build_all_agents_failed_engine():

--- a/tests/cli/test_engine_cli.py
+++ b/tests/cli/test_engine_cli.py
@@ -16,9 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
 # Fixtures
-# ---------------------------------------------------------------------------
 
 
 def _build_args(**kwargs) -> argparse.Namespace:
@@ -40,9 +38,7 @@ def _build_args(**kwargs) -> argparse.Namespace:
     return argparse.Namespace(**defaults)
 
 
-# ---------------------------------------------------------------------------
 # Subparser registration
-# ---------------------------------------------------------------------------
 
 
 def test_add_engine_subparser_registers_engine_command():
@@ -122,9 +118,7 @@ def test_engine_run_accepts_model_and_depth_flags():
     assert args.max_depth == 5
 
 
-# ---------------------------------------------------------------------------
 # Coding kind: missing --test-cmd → exit 1
-# ---------------------------------------------------------------------------
 
 
 async def test_coding_without_test_cmd_returns_1(monkeypatch):
@@ -140,9 +134,7 @@ async def test_coding_without_test_cmd_returns_1(monkeypatch):
     assert result == 1
 
 
-# ---------------------------------------------------------------------------
 # Successful engine run (mocked engine)
-# ---------------------------------------------------------------------------
 
 
 async def test_successful_engine_run_returns_0(monkeypatch, capsys):
@@ -197,9 +189,7 @@ async def test_engine_failure_returns_1(monkeypatch):
     assert result == 1
 
 
-# ---------------------------------------------------------------------------
 # Pydantic model result — CodeResultRecorded real shape
-# ---------------------------------------------------------------------------
 
 
 async def test_code_result_recorded_shape_serialized(monkeypatch, capsys):
@@ -248,9 +238,7 @@ async def test_code_result_recorded_shape_serialized(monkeypatch, capsys):
     # in export_dir persistence tests below).
 
 
-# ---------------------------------------------------------------------------
 # export_dir persistence — sourced from args, not result model
-# ---------------------------------------------------------------------------
 
 
 async def test_export_dir_persisted_from_args_coding(monkeypatch, capsys):
@@ -453,9 +441,7 @@ async def test_export_dir_none_when_not_passed(monkeypatch, capsys):
     assert completed[0]["export_dir"] is None
 
 
-# ---------------------------------------------------------------------------
 # Cancellation handling — BaseException paths
-# ---------------------------------------------------------------------------
 
 
 async def test_cancelled_error_marks_row_cancelled(monkeypatch):
@@ -583,9 +569,7 @@ async def test_keyboard_interrupt_marks_row_cancelled(monkeypatch):
     assert close_count[0] == 1
 
 
-# ---------------------------------------------------------------------------
 # StateDB persistence paths
-# ---------------------------------------------------------------------------
 
 
 async def test_db_insert_called_on_success(monkeypatch, capsys):
@@ -683,9 +667,7 @@ async def test_no_persist_skips_db(monkeypatch, capsys):
     assert not db_opened, "StateDB.open() was called despite --no-persist"
 
 
-# ---------------------------------------------------------------------------
 # Import-failure closes the DB
-# ---------------------------------------------------------------------------
 
 
 async def test_import_failure_closes_db(monkeypatch):
@@ -743,9 +725,7 @@ async def test_import_failure_closes_db(monkeypatch):
     assert any(c["status"] == "failed" for c in update_calls)
 
 
-# ---------------------------------------------------------------------------
 # run_engine dispatch (synchronous entry point)
-# ---------------------------------------------------------------------------
 
 
 def test_run_engine_dispatches_run_subcommand(monkeypatch):
@@ -790,9 +770,7 @@ def test_run_engine_unknown_subcommand_returns_1(monkeypatch):
     assert rc == 1
 
 
-# ---------------------------------------------------------------------------
 # Main entrypoint: 'engine' command is routed in main()
-# ---------------------------------------------------------------------------
 
 
 def test_main_routes_engine_command(monkeypatch):
@@ -831,9 +809,7 @@ def test_main_routes_engine_command(monkeypatch):
     assert run_engine_calls[0].command == "engine"
 
 
-# ---------------------------------------------------------------------------
 # Signal persistence integration: engine run → session_signals table
-# ---------------------------------------------------------------------------
 
 
 async def test_engine_run_signals_land_in_session_signals(tmp_path):

--- a/tests/cli/test_engine_emission_diagnostics.py
+++ b/tests/cli/test_engine_emission_diagnostics.py
@@ -11,9 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _build_args(**kwargs) -> argparse.Namespace:
@@ -56,9 +54,7 @@ class MockStateDB:
         self.update_calls.append({"run_id": run_id, "status": status, "error": error})
 
 
-# ---------------------------------------------------------------------------
 # Engine CLI: emission_missing events → error column on completed row
-# ---------------------------------------------------------------------------
 
 
 async def test_emission_failures_written_to_db_error_on_completed(monkeypatch):
@@ -165,9 +161,7 @@ async def test_engine_without_emission_failures_attr_error_column_stays_null(mon
     assert completed[0]["error"] is None
 
 
-# ---------------------------------------------------------------------------
 # EngineRun._emission_failures accumulation
-# ---------------------------------------------------------------------------
 
 
 def _make_minimal_engine_run() -> Any:
@@ -272,9 +266,7 @@ async def test_operate_with_repair_no_failure_when_arrived(monkeypatch):
     )
 
 
-# ---------------------------------------------------------------------------
 # Real StateDB: completed + error coexist in engine_runs table
-# ---------------------------------------------------------------------------
 
 
 async def test_completed_run_with_error_column_in_real_db(tmp_path):
@@ -310,11 +302,9 @@ async def test_completed_run_with_error_column_in_real_db(tmp_path):
     )
 
 
-# ---------------------------------------------------------------------------
 # INTEGRATION: real Engine subclass whose _run() calls operate_with_repair
 # with a branch that never emits — verifies the full Engine.run() → CLI
 # read-site handoff that the mock-based tests above could not catch.
-# ---------------------------------------------------------------------------
 
 
 class _NeverEmitBranch:

--- a/tests/cli/test_heartbeat.py
+++ b/tests/cli/test_heartbeat.py
@@ -14,7 +14,7 @@ import pytest
 
 from lionagi.cli.orchestrate import flow as flow_mod
 
-# ── Unit tests for the heartbeat loop logic ──────────────────────────────────
+# Unit tests for the heartbeat loop logic
 
 
 @pytest.mark.asyncio
@@ -514,7 +514,7 @@ async def test_heartbeat_does_not_fire_before_interval():
     assert fires == []
 
 
-# ── flow.py integration: _record_segment includes last_heartbeat_at ───────────
+# flow.py integration: _record_segment includes last_heartbeat_at
 
 
 def test_op_segment_schema_includes_heartbeat_field():

--- a/tests/cli/test_hooks_cli.py
+++ b/tests/cli/test_hooks_cli.py
@@ -257,9 +257,7 @@ def test_import_non_posix_fallback_refuses_symlinked_lionagi_directory(
     assert (project_dir / ".lionagi").is_symlink()
 
 
-# ---------------------------------------------------------------------------
 # `li hooks trust`
-# ---------------------------------------------------------------------------
 
 
 def test_trust_lists_and_records_pending_commands(capsys, tmp_path, monkeypatch):
@@ -384,9 +382,7 @@ def test_trust_rejects_various_malformed_argv_shapes(capsys, tmp_path, bad_comma
     assert compute_command_hash(bad_command) not in trusted
 
 
-# ---------------------------------------------------------------------------
 # Content-pinned trust records (Issue 3 fix), exercised through the CLI.
-# ---------------------------------------------------------------------------
 
 
 def test_trust_rejects_unresolvable_executable_instead_of_recording_it(capsys, tmp_path):

--- a/tests/cli/test_id_resolution.py
+++ b/tests/cli/test_id_resolution.py
@@ -59,7 +59,7 @@ async def _seed_invocation(db: StateDB, invocation_id: str) -> None:
     )
 
 
-# ── across kinds ──────────────────────────────────────────────────────────────
+# across kinds
 
 
 async def test_a_prefix_that_fits_two_kinds_is_refused(db_path: Path):
@@ -104,7 +104,7 @@ async def test_an_unambiguous_prefix_still_resolves(db_path: Path):
     assert row["id"] == FIRST
 
 
-# ── inside one kind ───────────────────────────────────────────────────────────
+# inside one kind
 
 
 async def test_a_prefix_that_fits_two_rows_of_one_kind_is_refused(db_path: Path):
@@ -118,7 +118,7 @@ async def test_a_prefix_that_fits_two_rows_of_one_kind_is_refused(db_path: Path)
     assert "session" in str(caught.value)
 
 
-# ── case ──────────────────────────────────────────────────────────────────────
+# case
 
 
 async def test_an_upper_cased_prefix_does_not_match_a_lower_cased_id(db_path: Path):
@@ -135,7 +135,7 @@ async def test_an_upper_cased_prefix_does_not_match_a_lower_cased_id(db_path: Pa
         assert await resolve_entity(db, SHARED.upper()) is None
 
 
-# ── branch files ──────────────────────────────────────────────────────────────
+# branch files
 
 
 @pytest.fixture
@@ -191,7 +191,7 @@ def test_find_branch_takes_an_exact_id_from_an_older_run(runs_root: Path):
     assert (run_id, path) == ("run-old", older)
 
 
-# ── run directories ───────────────────────────────────────────────────────────
+# run directories
 
 
 def test_run_dir_lookup_refuses_a_prefix_that_fits_two_runs(
@@ -230,7 +230,7 @@ def test_run_dir_lookup_still_resolves_an_exact_id(tmp_path: Path, monkeypatch: 
     assert run_dir.state_root == exact
 
 
-# ── team files ────────────────────────────────────────────────────────────────
+# team files
 
 
 @pytest.fixture
@@ -271,7 +271,7 @@ def test_team_lookup_settles_on_an_id_or_a_name(teams_dir: Path):
     assert _team_file("two") == second
 
 
-# ── the resolvers the CLI surfaces actually call ──────────────────────────────
+# the resolvers the CLI surfaces actually call
 
 
 @pytest.mark.parametrize(
@@ -343,7 +343,7 @@ async def test_the_monitor_detail_resolver_still_takes_an_exact_id(db_path: Path
         assert (await _find_entity(db, SECOND))[0] == "invocation"
 
 
-# ── run id: a separate id space, not part of the generic resolver ─────────────
+# run id: a separate id space, not part of the generic resolver
 #
 # Run ids (cli/_runs.py, one directory per run) are not primary keys
 # `_util.resolve_entity` searches — they are mirrored onto sessions only

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -34,7 +34,7 @@ from lionagi.cli.kill import (
 from lionagi.state.db import StateDB
 from lionagi.state.reasons import RunReasons
 
-# ── Fixtures ───────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -131,7 +131,7 @@ async def _seed_play(
     return play_id
 
 
-# ── _pid_alive ─────────────────────────────────────────────────────────────────
+# _pid_alive
 
 
 def test_pid_alive_returns_false_for_nonexistent_pid():
@@ -156,7 +156,7 @@ def test_pid_alive_treats_permission_error_as_alive():
         assert _pid_alive(1234) is True
 
 
-# ── _terminate_pid ─────────────────────────────────────────────────────────────
+# _terminate_pid
 
 
 def test_terminate_pid_returns_already_dead_for_missing_pid():
@@ -208,7 +208,7 @@ def test_terminate_pid_escalates_to_sigkill(monkeypatch: pytest.MonkeyPatch):
     assert _signal.SIGKILL in sigs_sent
 
 
-# ── _terminate_pid identity checks ───────────────────────────────────────────
+# _terminate_pid identity checks
 
 
 def test_terminate_pid_identity_mismatch_no_signal_sent(
@@ -277,7 +277,7 @@ def test_terminate_pid_identity_match_sends_signal(
     assert result in ("sigterm", "sigkill")
 
 
-# ── A real, unreaped child ────────────────────────────────────────────────────
+# A real, unreaped child
 #
 # Everything below uses a process this test actually started. A SIGTERMed child
 # whose parent has not called wait() is a zombie: it holds its pid, so `kill -0`
@@ -695,7 +695,7 @@ async def test_do_kill_invocation_without_pid_create_time_does_not_signal(
         assert row["status"] == "running", "must not cancel a row whose kill was refused"
 
 
-# ── current_pid_markers (launch-time recording) ───────────────────────────────
+# current_pid_markers (launch-time recording)
 
 
 def test_current_pid_markers_records_own_pid():
@@ -751,7 +751,7 @@ async def test_kill_one_skips_recycled_pid_via_create_time(
         ] == "running", "must not cancel a recycled PID"
 
 
-# ── _resolve_entity ────────────────────────────────────────────────────────────
+# _resolve_entity
 
 
 async def test_resolve_entity_by_full_uuid(temp_db_path: Path):
@@ -800,7 +800,7 @@ async def test_resolve_entity_finds_show(temp_db_path: Path):
         assert entity_type == "show"
 
 
-# ── _persist_cancel ────────────────────────────────────────────────────────────
+# _persist_cancel
 
 
 async def test_persist_cancel_sets_status_cancelled(temp_db_path: Path):
@@ -901,7 +901,7 @@ async def test_persist_cancel_show_sets_aborted(temp_db_path: Path):
         assert row["status"] == "aborted"
 
 
-# ── _kill_one ──────────────────────────────────────────────────────────────────
+# _kill_one
 
 
 async def test_kill_one_no_pid(temp_db_path: Path):
@@ -961,7 +961,7 @@ async def test_kill_one_force_kill_uses_force_kill_reason(
         assert tr["reason_code"] == RunReasons.CANCELLED_FORCE_KILL
 
 
-# ── _do_kill (end-to-end) ─────────────────────────────────────────────────────
+# _do_kill (end-to-end)
 
 
 async def test_do_kill_by_full_id(temp_db_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -1005,7 +1005,7 @@ async def test_do_kill_non_running_returns_1(temp_db_path: Path):
     assert rc == 1
 
 
-# ── _do_kill_all_stale ────────────────────────────────────────────────────────
+# _do_kill_all_stale
 
 
 async def test_do_kill_all_stale_cancels_dead_pid(
@@ -1589,7 +1589,7 @@ async def test_do_kill_all_stale_process_vanishing_mid_check_does_not_abort_swee
             ] == "cancelled", "vanished processes are stale; BOTH rows must be swept"
 
 
-# ── cascade kill ───────────────────────────────────────────────────────────────
+# cascade kill
 
 
 async def test_list_running_children_show_behavior_is_unchanged(temp_db_path: Path):
@@ -1974,7 +1974,7 @@ async def test_do_kill_recursive_invocation_cancels_child_sessions(temp_db_path:
     }
 
 
-# ── CLI wiring smoke test ──────────────────────────────────────────────────────
+# CLI wiring smoke test
 
 
 def test_kill_subparser_registered():
@@ -2070,7 +2070,7 @@ def test_kill_all_stale_subparser_flags():
         Path(tmp_path).unlink(missing_ok=True)
 
 
-# ── plays and shows excluded from sweep ──────────────────────────────────────
+# plays and shows excluded from sweep
 
 
 async def test_do_kill_all_stale_does_NOT_touch_show_at_all(
@@ -2265,7 +2265,7 @@ class TestTerminatePidIdentityRevalidation:
         assert sent == [signal.SIGTERM, signal.SIGKILL]
 
 
-# ── Ambiguous short-id prefixes ────────────────────────────────────────────────
+# Ambiguous short-id prefixes
 #
 # A prefix that matches two rows must never resolve to "whichever came first":
 # `li kill` would then signal a process the caller never named.

--- a/tests/cli/test_machine_envelope.py
+++ b/tests/cli/test_machine_envelope.py
@@ -49,7 +49,7 @@ def _one_object(out: str) -> dict:
     return json.loads(lines[0])
 
 
-# ── The envelope ────────────────────────────────────────────────────────────
+# The envelope
 
 
 def test_a_success_carries_data_and_no_error(capfd):
@@ -102,7 +102,7 @@ def test_a_malformed_envelope_is_refused_before_it_is_written(malformed):
         machine.validate_envelope(malformed)
 
 
-# ── The closed error vocabulary ─────────────────────────────────────────────
+# The closed error vocabulary
 
 
 def test_the_error_kinds_are_exactly_the_contract_set():
@@ -154,7 +154,7 @@ def test_an_unexpected_crash_becomes_an_envelope(capfd, monkeypatch):
     assert "something nobody anticipated" in envelope["error"]["message"]
 
 
-# ── Exactly one JSON object on stdout ───────────────────────────────────────
+# Exactly one JSON object on stdout
 
 
 def test_nothing_else_reaches_stdout(capfd, monkeypatch):
@@ -267,7 +267,7 @@ def test_one_object_on_stdout_end_to_end():
     assert envelope["contract_version"] == machine.CONTRACT_VERSION
 
 
-# ── D7: absence and failure do not share an encoding ────────────────────────
+# D7: absence and failure do not share an encoding
 
 
 def test_an_empty_read_and_a_failed_read_are_different_answers(tmp_path):
@@ -350,7 +350,7 @@ def test_no_runs_at_all_is_an_established_answer(capfd, monkeypatch, tmp_path):
     }
 
 
-# ── D8: which signal answers ────────────────────────────────────────────────
+# D8: which signal answers
 
 
 def test_a_refusal_still_exits_zero(capfd):
@@ -438,7 +438,7 @@ def test_78_survives_end_to_end_under_the_machine_flag():
     assert proc.stdout.strip() == ""
 
 
-# ── the machine path leaves SIGPIPE where the interpreter put it ────────────
+# the machine path leaves SIGPIPE where the interpreter put it
 
 
 def _sigpipe_disposition_after(*argv: str) -> str:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -209,7 +209,7 @@ def test_handle_play_shortcut_passthrough_for_non_play():
     assert result == argv
 
 
-# ─── ADR-0064 D3: `li play check` pre-flight artifact contract ───
+# ADR-0064 D3: `li play check` pre-flight artifact contract
 
 
 def test_play_check_no_args_prints_usage(capsys):
@@ -341,7 +341,7 @@ def test_play_check_playbook_without_contract(tmp_path, monkeypatch, capsys):
     assert "no `artifacts:` block declared" in out
 
 
-# ─── `li play <name> --help` surfaces forwarded global flags ───
+# `li play <name> --help` surfaces forwarded global flags
 
 
 def test_play_help_shows_common_flags(tmp_path, monkeypatch, capsys):
@@ -380,7 +380,7 @@ def test_play_flag_before_name_includes_usage(caplog):
     assert "Usage" in full_msg or "li play" in full_msg
 
 
-# ─── package-init laziness: lionagi.cli must not eagerly import main ───
+# package-init laziness: lionagi.cli must not eagerly import main
 
 
 def test_cli_package_init_is_lazy():

--- a/tests/cli/test_mcp_set_reaches_every_cli_provider.py
+++ b/tests/cli/test_mcp_set_reaches_every_cli_provider.py
@@ -60,9 +60,7 @@ def _assert_secret_is_off_the_wire(kwargs: dict, args: list[str], codex_home) ->
     assert args[args.index("-p") + 1] == kwargs["profile"]
 
 
-# ---------------------------------------------------------------------------
 # The transports themselves: what an empty set means to each of them.
-# ---------------------------------------------------------------------------
 
 
 def test_an_empty_exclusive_set_is_strict_for_the_claude_transport():
@@ -93,9 +91,7 @@ def test_a_provider_without_a_transport_reports_that_it_carried_nothing():
     assert kwargs == {}
 
 
-# ---------------------------------------------------------------------------
 # Site 1 — the plain `li agent` leg (build_chat_model).
-# ---------------------------------------------------------------------------
 
 
 def test_plain_leg_hands_a_codex_request_the_resolved_set(codex_home):
@@ -156,9 +152,7 @@ def test_plain_leg_empty_set_is_the_whole_set_on_both_transports(codex_home):
     assert claude.endpoint.config.kwargs["strict_mcp_config"] is True
 
 
-# ---------------------------------------------------------------------------
 # Site 2 — the resumed leg.
-# ---------------------------------------------------------------------------
 
 
 def _wire_resume_stubs(monkeypatch, tmp_path: Path, provider: str, model: str) -> str:
@@ -319,9 +313,7 @@ async def test_resumed_antigravity_leg_rejects_an_explicit_server_set(monkeypatc
         )
 
 
-# ---------------------------------------------------------------------------
 # Site 3 — the flow / fanout worker.
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -38,7 +38,7 @@ from lionagi.state.db import StateDB
 SID = "11111111-2222-3333-4444-555555555555"
 
 
-# ── Event builders (verified Claude JSONL shapes) ────────────────────────────
+# Event builders (verified Claude JSONL shapes)
 
 
 def _user_text(uuid: str, text: str, *, ts: str = "2026-06-20T00:00:00.000Z") -> dict:
@@ -86,7 +86,7 @@ def _db_content(msg) -> dict:
     return json.loads(c) if isinstance(c, str) else c
 
 
-# ── messages_for_event: mapping + ordering + linkage ─────────────────────────
+# messages_for_event: mapping + ordering + linkage
 
 
 def test_user_text_maps_to_single_instruction() -> None:
@@ -211,7 +211,7 @@ def test_deterministic_ids_are_idempotent() -> None:
     assert ids1 == ids2
 
 
-# ── mirror_session: idempotent write + status lifecycle ──────────────────────
+# mirror_session: idempotent write + status lifecycle
 
 
 def _conversation() -> list[dict]:
@@ -404,7 +404,7 @@ async def test_mirror_session_is_idempotent(temp_db_path: Path) -> None:
     assert first == second  # no duplicate appends
 
 
-# ── link_escalation_session: escalation-leg mirror attribution ──────────────
+# link_escalation_session: escalation-leg mirror attribution
 
 
 @pytest.mark.asyncio
@@ -856,7 +856,7 @@ async def test_mirror_session_empty_no_session(temp_db_path: Path) -> None:
     assert row is None
 
 
-# ── watcher passes: session-level liveness across multiple files ─────────────
+# watcher passes: session-level liveness across multiple files
 
 
 def _iso(dt: datetime) -> str:
@@ -1012,7 +1012,7 @@ async def test_mirror_forever_retries_after_connection_open_failure(
     assert alive, "tail died on a transient open failure instead of retrying"
 
 
-# ── watcher helpers: tailing + parsing ───────────────────────────────────────
+# watcher helpers: tailing + parsing
 
 
 def test_read_new_events_buffers_partial_line(tmp_path: Path) -> None:
@@ -1103,7 +1103,7 @@ def test_since_window_argparse_type() -> None:
         _since_window("")  # empty is rejected at the CLI boundary (default=None handles "all")
 
 
-# ── project attribution fallback ─────────────────────────────────────────────
+# project attribution fallback
 
 
 def test_fallback_project_uses_folder_name_when_dir_exists(tmp_path: Path) -> None:
@@ -1137,7 +1137,7 @@ def test_derive_metadata_others_when_cwd_gone() -> None:
 
 
 def test_derive_metadata_captures_raw_cwd_as_artifact_root(tmp_path: Path) -> None:
-    # issue #2848: the raw cwd (not the bucketed project name) is the session's
+    # the raw cwd (not the bucketed project name) is the session's
     # artifact root -- every file the CLI touched lives under it.
     work = tmp_path / "my-workspace"
     work.mkdir()
@@ -1175,7 +1175,7 @@ async def test_mirror_session_backfills_missing_project(temp_db_path: Path) -> N
 
 @pytest.mark.asyncio
 async def test_mirror_session_writes_artifacts_path_from_cwd(temp_db_path: Path) -> None:
-    # issue #2848: a mirrored CLI session's cwd is its artifact root -- the run
+    # a mirrored CLI session's cwd is its artifact root -- the run
     # file viewer is otherwise structurally dead for every mirrored session.
     events = _conversation()
     async with StateDB() as db:
@@ -1204,7 +1204,7 @@ async def test_mirror_session_does_not_clobber_an_existing_artifacts_path(
     assert row["artifacts_path"] == "/work/first-guess"
 
 
-# ── conversation-lineage detector ────────────────────────────────────────────
+# conversation-lineage detector
 
 
 def _lineage_event(uid: str, euid: str, parent: str | None, role: str, text: str) -> dict:
@@ -1342,7 +1342,7 @@ async def test_idle_session_backfilled_with_project(temp_db_path: Path, tmp_path
 async def test_idle_session_backfilled_with_artifacts_path_even_when_project_already_set(
     temp_db_path: Path, tmp_path: Path
 ) -> None:
-    # issue #2848: the dominant NULL-artifacts_path population is sessions the
+    # the dominant NULL-artifacts_path population is sessions the
     # mirror already attributed a project to (in an earlier process) before this
     # fix existed -- artifacts_path must backfill on its own, not only when
     # project is also missing.
@@ -1447,7 +1447,7 @@ async def test_peek_head_skips_non_dict_head_line(temp_db_path: Path, tmp_path: 
     assert row["status"] == "completed"
 
 
-# ── restart durability: derived state persisted with the cursor ──────────────
+# restart durability: derived state persisted with the cursor
 
 
 @pytest.mark.asyncio
@@ -1574,7 +1574,7 @@ async def test_codex_file_that_mirrors_nothing_is_reported_not_skipped(tmp_path,
     assert state.barren_reported
 
 
-# ── Orchestrated codex rollouts (headless `codex exec`) ──────────────────────
+# Orchestrated codex rollouts (headless `codex exec`)
 
 
 def _codex_rollout_lines(uid: str, originator: str) -> str:
@@ -1727,7 +1727,7 @@ async def test_interactive_rollout_still_mirrors(tmp_path):
 
 
 async def test_interactive_rollout_records_artifacts_path_from_header_cwd(tmp_path):
-    # issue #2848: the session_meta header's cwd is the rollout's artifact root,
+    # the session_meta header's cwd is the rollout's artifact root,
     # the same gap claude_mirror had.
     from lionagi.cli.mirror import _FileState, _mirror_one_codex
     from lionagi.state.codex_mirror import session_db_id as codex_sid
@@ -2248,7 +2248,7 @@ async def test_a_failed_prior_stem_absorption_also_leaves_the_file_eligible(tmp_
     assert calls == [uid, stem, uid, stem], f"absorption ids across both passes: {calls}"
 
 
-# ── Bounded preview + source pointer codec (mirror_spec.md) ──────────────────
+# Bounded preview + source pointer codec (mirror_spec.md)
 
 
 def _source_line_for(raw: bytes, path: Path) -> SourceLine:
@@ -2609,12 +2609,12 @@ def test_config_omitted_preview_chars_defaults_to_500(monkeypatch):
     assert config_mod.MIRROR_PREVIEW_CHARS == 500
 
 
-# ── Live-path mirror bounding: oversized ingestion through the three real
+# Live-path mirror bounding: oversized ingestion through the three real
 # writers (claude_mirror.py, codex_mirror.py, cli/mirror.py). A unit test on
 # the codec alone (above) does not prove these are wired; each test here
 # writes an oversized transcript to disk and reads the row back out of a real
 # StateDB after it went through the module's own tailer, never constructing
-# the pointer by hand. ──────────────────────────────────────────────────────
+# the pointer by hand.
 
 _OVERSIZED_TEXT = "z" * 5000  # far beyond MIRROR_PREVIEW_CHARS default (500)
 

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -57,7 +57,7 @@ class _FakeStdout:
         return self._is_tty
 
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -173,7 +173,7 @@ async def _make_play(
     return play_id
 
 
-# ── Unit: formatting helpers ──────────────────────────────────────────────────
+# Unit: formatting helpers
 
 
 def test_elapsed_none_start():
@@ -257,7 +257,7 @@ def test_pid_alive_nonexistent():
     assert result is False or result is None  # platform-dependent
 
 
-# ── Unit: table formatting ────────────────────────────────────────────────────
+# Unit: table formatting
 
 
 def test_format_table_empty():
@@ -426,7 +426,7 @@ def test_format_table_non_tty_caps_pathological_width(monkeypatch: pytest.Monkey
     assert len(short_line) < 10 * _NON_TTY_MAX_COL_WIDTH
 
 
-# ── Unit: row builders ────────────────────────────────────────────────────────
+# Unit: row builders
 
 
 def test_session_to_row():
@@ -600,7 +600,7 @@ def test_play_to_row_orphan_no_session_project_falls_back():
     assert row["project"] == "-"
 
 
-# ── Integration: DB-backed list_running ───────────────────────────────────────
+# Integration: DB-backed list_running
 
 
 @pytest.mark.asyncio
@@ -933,7 +933,7 @@ async def test_gather_table_rows_since_filter(temp_db_path: Path) -> None:
     assert not any(sid_old[:16] in i for i in ids)
 
 
-# ── Regression: --since widens the status filter to terminal states ───────────
+# Regression: --since widens the status filter to terminal states
 #
 # `--since` used to only ever AND a time bound on top of a running-only
 # filter, so a session that finished (however recently) could never appear
@@ -1021,7 +1021,7 @@ async def test_since_shows_terminal_show(temp_db_path: Path) -> None:
     assert show_id[:16] not in [r["id"] for r in rows_default]
 
 
-# ── Integration: _find_entity ─────────────────────────────────────────────────
+# Integration: _find_entity
 
 
 @pytest.mark.asyncio
@@ -1088,7 +1088,7 @@ async def test_find_entity_not_found(temp_db_path: Path) -> None:
     assert result is None
 
 
-# ── Integration: _run_table and _run_detail ───────────────────────────────────
+# Integration: _run_table and _run_detail
 
 
 @pytest.mark.asyncio
@@ -1272,7 +1272,7 @@ async def test_run_detail_show(temp_db_path: Path) -> None:
     assert "implement-auth" in output
 
 
-# ── Show detail: how a play's status is classified into a marker ──────────────
+# Show detail: how a play's status is classified into a marker
 
 
 class _PlayRowsDB:
@@ -1374,7 +1374,7 @@ async def test_run_detail_not_found(temp_db_path: Path) -> None:
     assert "not found" in output.lower() or "error" in output.lower()
 
 
-# ── Regression: detail view shows playbook name ───────────────────────────────
+# Regression: detail view shows playbook name
 
 
 @pytest.mark.asyncio
@@ -1400,7 +1400,7 @@ async def test_run_detail_session_no_playbook_name_omits_line(temp_db_path: Path
     assert "playbook:" not in output
 
 
-# ── Regression: branch (agent leg) sub-step visibility ────────────────────────
+# Regression: branch (agent leg) sub-step visibility
 
 
 async def _add_branch(db: StateDB, session_id: str, *, name: str, status: str = "running") -> str:
@@ -1463,7 +1463,7 @@ async def test_run_detail_no_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     assert "state.db" in output or "not found" in output.lower() or "error" in output.lower()
 
 
-# ── Integration: argparse wiring ─────────────────────────────────────────────
+# Integration: argparse wiring
 
 
 def test_add_monitor_subparser():
@@ -1521,10 +1521,10 @@ def test_main_registers_monitor():
     assert "monitor" in result.stdout.lower() or "observe" in result.stdout.lower()
 
 
-# ── Watch mode: SIGINT terminates cleanly ─────────────────────────────────────
+# Watch mode: SIGINT terminates cleanly
 
 
-# ── Regression: --type play filter ───────────────────────────────────────────
+# Regression: --type play filter
 
 
 @pytest.mark.asyncio
@@ -1562,7 +1562,7 @@ async def test_type_play_filter_includes_both_sessions_and_plays(temp_db_path: P
     assert play_row_id[:16] in ids, "play table row not in --type play results"
 
 
-# ── Regression: direct `li play` runs (no plays-table row) via --since ────────
+# Regression: direct `li play` runs (no plays-table row) via --since
 #
 # `create_play` has no production caller on the direct `li play NAME` path —
 # a completed direct play exists only as a session row with
@@ -1630,7 +1630,7 @@ async def test_since_no_double_listing_in_all_view(temp_db_path: Path) -> None:
     assert play_sess_id[:16] not in ids
 
 
-# ── Regression: dedup must not hide sessions from views without a play section ─
+# Regression: dedup must not hide sessions from views without a play section
 #
 # The play-vs-session dedup lives in _gather_table_rows and applies only when
 # the plays section is actually being rendered. A SQL-level exclusion would
@@ -1741,7 +1741,7 @@ def test_watch_loop_recomputes_since_every_tick(monkeypatch: pytest.MonkeyPatch)
     assert captured == [100.0, 200.0], "each tick must use a freshly derived cutoff"
 
 
-# ── Regression: AGENTS column ────────────────────────────────────────────────
+# Regression: AGENTS column
 
 
 @pytest.mark.asyncio
@@ -1810,7 +1810,7 @@ async def test_play_agents_column_reflects_branch_count(temp_db_path: Path) -> N
     assert play_rows[0]["agents"] == "1", f"expected agents='1', got {play_rows[0]['agents']!r}"
 
 
-# ── Regression: background correlation handle ─────────────────────────────────
+# Regression: background correlation handle
 
 
 def test_session_id_env_var_used_as_session_id(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1873,7 +1873,7 @@ def test_background_hint_includes_session_id(
     assert "li monitor" in combined, f"Expected 'li monitor <id>' hint in output, got:\n{combined}"
 
 
-# ── Watch mode: SIGINT terminates cleanly ─────────────────────────────────────
+# Watch mode: SIGINT terminates cleanly
 
 
 def test_watch_mode_sigint_clean(temp_db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1908,7 +1908,7 @@ def test_watch_mode_sigint_clean(temp_db_path: Path, monkeypatch: pytest.MonkeyP
     assert exit_code == 0
 
 
-# ── Ambiguous short-id prefixes ───────────────────────────────────────────────
+# Ambiguous short-id prefixes
 
 
 async def _make_session_with_id(db: StateDB, sid: str) -> str:
@@ -2025,7 +2025,7 @@ def test_watch_loop_ambiguous_prefix_exits_unknown(
     assert exit_code == EXIT_UNKNOWN
 
 
-# ── Watch mode: SIGTERM during a refresh ──────────────────────────────────────
+# Watch mode: SIGTERM during a refresh
 #
 # run_async installs its own signal handlers for the duration of the call, so a
 # signal delivered inside a refresh surfaces as SigtermInterrupt/KeyboardInterrupt
@@ -2119,7 +2119,7 @@ def test_watch_loop_leaves_unrestorable_handlers_alone(monkeypatch: pytest.Monke
     assert installed == []
 
 
-# ── Regression: a play awaiting a gate decision is not running ────────────────
+# Regression: a play awaiting a gate decision is not running
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -34,7 +34,7 @@ from lionagi.cli.monitor import (
 from lionagi.cli.status import EXIT_RUNNING, EXIT_UNKNOWN
 from lionagi.state.db import SCHEDULE_RUN_TERMINAL_STATUSES, StateDB
 
-# ── Fixtures ────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -114,7 +114,7 @@ async def _set_fields(db: StateDB, table: str, id_: str, **fields: Any) -> None:
     await db.execute(f"UPDATE {table} SET {sets} WHERE id = ?", (*fields.values(), id_))
 
 
-# ── _split_watched_ids ───────────────────────────────────────────────────────
+# _split_watched_ids
 
 
 def test_split_watched_ids_multiple_positional_tokens():
@@ -141,7 +141,7 @@ def test_split_watched_ids_drops_empty_pieces():
     assert _split_watched_ids(["a,,b", ""]) == ["a", "b"]
 
 
-# ── _format_wait_line ────────────────────────────────────────────────────────
+# _format_wait_line
 
 
 def test_format_wait_line_contains_all_fields():
@@ -160,7 +160,7 @@ def test_format_wait_line_none_exit_code_renders_dash():
     assert "exit_code=-" in line
 
 
-# ── _resolve_schedule_run ────────────────────────────────────────────────────
+# _resolve_schedule_run
 
 
 @pytest.mark.asyncio
@@ -190,7 +190,7 @@ async def test_resolve_schedule_run_not_found_returns_none(temp_db_path: Path) -
         assert row is None
 
 
-# ── _resolve_watched_runs: bounded creation-grace retry ─────────────────────
+# _resolve_watched_runs: bounded creation-grace retry
 #
 # fire_now() hands a run_id to its caller before the fired occurrence row is
 # durably written (the fire itself runs as a background task) — resolving
@@ -250,7 +250,7 @@ async def test_resolve_watched_runs_gives_up_after_grace_period(temp_db_path: Pa
     assert unresolved == ["never-created"]
 
 
-# ── _poll_pending_once (the testable inner tick — no real sleeps needed) ────
+# _poll_pending_once (the testable inner tick — no real sleeps needed)
 
 
 @pytest.mark.asyncio
@@ -433,7 +433,7 @@ async def test_poll_pending_once_row_vanished_mid_wait_resolves_as_failure(
     assert "disappeared" in caplog.text.lower()
 
 
-# ── _advance_chains (the testable chain-follow tick — no real sleeps needed) ─
+# _advance_chains (the testable chain-follow tick — no real sleeps needed)
 #
 # Mirrors _poll_pending_once's testing style: direct calls with DB mutations
 # in between, driving the exact same pending/done/chain_state a real
@@ -677,7 +677,7 @@ async def test_advance_chains_multi_hop_chain_followed_to_final_link(
     assert child2_id in out
 
 
-# ── _dispatch_wait: bounded wait, no --follow ────────────────────────────────
+# _dispatch_wait: bounded wait, no --follow
 
 
 @pytest.mark.asyncio
@@ -897,7 +897,7 @@ async def test_dispatch_wait_keyboard_interrupt_after_tick_mutates_state_still_r
     assert exit_code == 1
 
 
-# ── _dispatch_wait: chain-following (li monitor run's default; --no-chain) ──
+# _dispatch_wait: chain-following (li monitor run's default; --no-chain)
 
 
 @pytest.mark.asyncio
@@ -1129,7 +1129,7 @@ async def test_dispatch_wait_deep_chain_follows_handoff_past_terminal_child(
     assert out.count(grandchild_id) == 1
 
 
-# ── _query_schedule_runs_since (the --follow baseline boundary, deterministic) ──
+# _query_schedule_runs_since (the --follow baseline boundary, deterministic)
 
 
 @pytest.mark.asyncio
@@ -1159,7 +1159,7 @@ async def test_query_schedule_runs_since_empty_when_nothing_newer(temp_db_path: 
     assert new_rows == []
 
 
-# ── _dispatch_wait: --follow (baseline-first tail behavior) ─────────────────
+# _dispatch_wait: --follow (baseline-first tail behavior)
 
 
 @pytest.mark.asyncio
@@ -1249,7 +1249,7 @@ async def test_dispatch_wait_follow_ignores_pre_existing_runs_reports_only_new(
     assert pre_existing_id not in out  # existed before baseline: never re-reported
 
 
-# ── argv parsing: `--run` flag form + `--interval`/`--follow` on the main parser ──
+# argv parsing: `--run` flag form + `--interval`/`--follow` on the main parser
 
 
 def test_add_monitor_subparser_run_flag_and_new_options():
@@ -1343,7 +1343,7 @@ def test_add_monitor_subparser_existing_dashboard_args_unaffected():
     assert args.watch
 
 
-# ── run_monitor_wait: the `li monitor run <id>...` positional entry point ───
+# run_monitor_wait: the `li monitor run <id>...` positional entry point
 
 
 @pytest.mark.asyncio
@@ -1438,10 +1438,10 @@ def test_run_monitor_wait_empty_string_token_rejected_as_usage_error():
     assert exc_info.value.code == 2
 
 
-# ── CLI wiring: `li monitor run --help` / `li monitor --help` subprocess ────
+# CLI wiring: `li monitor run --help` / `li monitor --help` subprocess
 
 
-# ── ADR-0035 regression: `li monitor run` output format is untouched ───────
+# ADR-0035 regression: `li monitor run` output format is untouched
 
 
 @pytest.mark.asyncio
@@ -1495,8 +1495,8 @@ def test_cli_monitor_help_still_shows_dashboard_usage():
     assert "--watch" in result.stdout
 
 
-# ── li monitor run: resolving agent session ids (issue: profile-typed agent
-# sessions previously errored with "schedule_run not found") ────────────────
+# li monitor run: resolving agent session ids. Profile-typed agent sessions
+# previously errored with "schedule_run not found".
 
 
 async def _make_agent_session(db: StateDB, *, status: str = "completed") -> str:
@@ -1587,7 +1587,7 @@ async def test_dispatch_wait_agent_session_still_running_returns_exit_running(
     assert exit_code == EXIT_RUNNING
 
 
-# ── li monitor run: linked_engine_session_id drill-in + bounded --max-wait ──
+# li monitor run: linked_engine_session_id drill-in + bounded --max-wait
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_providers.py
+++ b/tests/cli/test_providers.py
@@ -51,7 +51,7 @@ def test_build_imodel_from_spec_maps_effort_and_yolo_without_network(monkeypatch
     assert kwargs.get("cli_display_theme") == "dark"
 
 
-# ── resolve_persisted_effort — tests against the helper directly ──────────
+# resolve_persisted_effort — tests against the helper directly
 # These test the actual production function, not a hand-rolled copy of the
 # agent.py logic. Moving the PROVIDERS_NO_EFFORT reset back under the iModel
 # guard in the helper will break these tests immediately.
@@ -167,7 +167,7 @@ def test_module_invariant_three_way_disjoint_including_effort_via_model_name():
     assert not (PROVIDER_EFFORT_KWARG.keys() & PROVIDERS_EFFORT_VIA_MODEL_NAME)
 
 
-# ── gemini-code / agy effort folding ───────────────────────────────────────
+# gemini-code / agy effort folding
 # agy (Antigravity CLI) has no effort flag/kwarg — --effort must fold into
 # the resolved --model name suffix instead (see resolve_agy_model). These
 # cover the CLI-integration layer (build_chat_model / resolve_persisted_effort);
@@ -262,7 +262,7 @@ def test_resolve_persisted_effort_gemini_code_keeps_requested_effort():
     assert result == "high", f"expected requested effort to persist for gemini-code, got {result!r}"
 
 
-# ── mixed-case --effort on effort-via-model-name paths ─
+# mixed-case --effort on effort-via-model-name paths
 # All clamp tables (_clamp_codex_effort, _clamp_claude_effort,
 # _GEMINI_EFFORT_CLAMP) are lowercase-keyed. A mixed-case --effort silently
 # misclamps instead of raising (worst on gemini: "High" -> "Medium" fallback).
@@ -327,7 +327,7 @@ def test_build_imodel_from_spec_mixed_case_xhigh_clamps_claude_to_high(monkeypat
     assert captor.captures[0].get("effort") == "high"
 
 
-# ── model-dependent codex effort ceilings ─
+# model-dependent codex effort ceilings
 # Codex effort support varies by model: the gpt-5.6 family accepts max
 # (sol/terra also ultra); every earlier model tops out at xhigh. The clamp
 # must key on the target model, and unrecognized (future) models must pass
@@ -512,7 +512,7 @@ def test_slash_profile_miss_includes_available_plugin_profiles(monkeypatch, tmp_
     assert "Available: myplugin/reviewer" in message
 
 
-# ── Vendor model ids are not lionagi specs ────────────────────────────────
+# Vendor model ids are not lionagi specs
 # The trailing-effort convention belongs to lionagi's own provider/model-effort
 # grammar. A model id borrowed whole from another vendor's catalogue — reached
 # through a codex config profile naming its own model_provider — ends in

--- a/tests/cli/test_resume_reopens_session.py
+++ b/tests/cli/test_resume_reopens_session.py
@@ -321,11 +321,11 @@ async def test_a_session_deleted_while_the_resume_waited_is_not_an_error(temp_db
 
 @pytest.mark.asyncio
 async def test_a_resumed_leg_links_its_session_to_its_own_invocation(temp_db_path):
-    """Issue #2767: a resumed leg reopens the branch's existing session row
-    instead of inserting a new one, so create_session's ON CONFLICT DO
-    NOTHING never runs for it and the resume's invocation_id was silently
-    dropped. The invocation that actually drove the resume must still be
-    able to find the session it drove.
+    """A resumed leg reopens the branch's existing session row instead of
+    inserting a new one, so create_session's ON CONFLICT DO NOTHING never
+    runs for it and the resume's invocation_id was silently dropped. The
+    invocation that actually drove the resume must still be able to find the
+    session it drove.
     """
     from lionagi import Branch
     from lionagi.cli._runs import setup_agent_persist, teardown_agent_persist

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -280,9 +280,7 @@ def test_schedule_trigger_wait_flag_parses():
     assert args.wait is True
 
 
-# ---------------------------------------------------------------------------
 # run_schedule dispatch: runs/run/status/trigger --wait
-# ---------------------------------------------------------------------------
 
 
 def test_schedule_runs_limit_out_of_range_rejected(monkeypatch, capsys):
@@ -582,9 +580,7 @@ def test_schedule_status_wait_polls_until_terminal(monkeypatch):
     assert len(calls) == 3
 
 
-# ---------------------------------------------------------------------------
 # trigger --wait: grace-period retry across the fire-now-before-insert race
-# ---------------------------------------------------------------------------
 
 
 def test_schedule_trigger_without_wait_unchanged(monkeypatch, capsys):
@@ -863,9 +859,7 @@ def test_base_url_no_warning_without_api_suffix(monkeypatch, caplog):
     assert not [r for r in caplog.records if "LIONAGI_STUDIO_URL" in r.message]
 
 
-# ---------------------------------------------------------------------------
 # _cmd_create: --project auto-detect from cwd (scheduler spawn-cwd fix)
-# ---------------------------------------------------------------------------
 
 
 def _run_create(monkeypatch, extra_args: list[str], api_response: dict | None = None) -> dict:
@@ -956,9 +950,7 @@ def test_schedule_create_auto_detect_exception_silently_skipped(monkeypatch):
     assert "action_project" not in outcome["body"]
 
 
-# ---------------------------------------------------------------------------
 # _cmd_create: --cwd (ADR-0070 delta 1 -- persisted execution root)
-# ---------------------------------------------------------------------------
 
 
 def test_schedule_create_explicit_cwd_used_as_is(monkeypatch, tmp_path):
@@ -1016,9 +1008,7 @@ def test_schedule_create_with_resolved_project_omits_cwd_fallback(monkeypatch):
     assert "action_cwd" not in outcome["body"]
 
 
-# ---------------------------------------------------------------------------
 # _cmd_create: --on-success / --on-fail chain flags
-# ---------------------------------------------------------------------------
 
 
 def test_schedule_create_on_success_round_trips_to_body(monkeypatch):
@@ -1215,7 +1205,6 @@ def test_schedule_create_without_chain_flags_omits_fields(monkeypatch):
     assert "on_fail" not in outcome["body"]
 
 
-# ---------------------------------------------------------------------------
 # _cmd_create: nested chain_action validation (recursive)
 #
 # The engine fires a chain_action via a shallow merge (`{**schedule,
@@ -1223,7 +1212,6 @@ def test_schedule_create_without_chain_flags_omits_fields(monkeypatch):
 # on_success/on_fail rides the exact same merge one level deeper when its
 # parent's run completes. Validation must recurse into those nested actions,
 # not just check the top level.
-# ---------------------------------------------------------------------------
 
 
 def test_schedule_create_nested_on_success_unknown_key_rejected(monkeypatch, capsys):
@@ -1337,9 +1325,7 @@ def test_schedule_create_nested_chain_missing_on_success_warns(monkeypatch):
     assert "re-fire" in warnings[0]
 
 
-# ---------------------------------------------------------------------------
 # _cmd_create: --once / --max-runs (one-shot semantics)
-# ---------------------------------------------------------------------------
 
 
 def test_schedule_create_once_maps_to_max_runs_1(monkeypatch):
@@ -1450,9 +1436,7 @@ def test_schedule_list_shows_remaining_runs(monkeypatch, capsys):
     assert "runs left" not in unlimited_line
 
 
-# ---------------------------------------------------------------------------
 # Cron far-out warning (date-pinned one-shot footgun)
-# ---------------------------------------------------------------------------
 
 
 def test_warn_if_cron_far_out_warns_beyond_360_days(monkeypatch):
@@ -1501,9 +1485,7 @@ def test_warn_if_cron_far_out_no_croniter_is_noop(monkeypatch):
     sched_mod._warn_if_cron_far_out("0 0 29 2 *")
 
 
-# ---------------------------------------------------------------------------
 # Near-miss flag suggestions (li schedule ...)
-# ---------------------------------------------------------------------------
 
 
 def test_suggest_schedule_flag_synonym_map():
@@ -1595,9 +1577,7 @@ def test_li_schedule_recognized_flags_still_dispatch(monkeypatch):
     assert rc == 0
 
 
-# ---------------------------------------------------------------------------
 # Help epilogs render for every subcommand
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -1624,9 +1604,7 @@ def test_schedule_create_help_repeats_shallow_merge_caveat(capsys):
     assert "shallow-merge" in out or "shallow merge" in out
 
 
-# ---------------------------------------------------------------------------
 # li schedule: surplus non-flag arguments must error (rc=2), not be ignored
-# ---------------------------------------------------------------------------
 
 
 def test_li_schedule_surplus_non_flag_argument_errors(monkeypatch, capsys):
@@ -1679,9 +1657,7 @@ def test_li_schedule_mixed_dash_and_bare_extras_both_reported(monkeypatch, capsy
     assert "stray-token" in err
 
 
-# ---------------------------------------------------------------------------
 # _cmd_create: github / github_poll trigger authoring
-# ---------------------------------------------------------------------------
 
 
 def _run_create_argv(monkeypatch, argv_tail: list[str], api_response: dict | None = None) -> dict:
@@ -1823,9 +1799,7 @@ def test_schedule_create_zero_poll_interval_errors(monkeypatch, capsys):
     assert "must be a positive integer" in capsys.readouterr().err
 
 
-# ---------------------------------------------------------------------------
 # _cmd_create: --max-cost-usd / --max-tokens spend-budget flags
-# ---------------------------------------------------------------------------
 
 
 def test_schedule_create_max_cost_usd_wired_to_budget_usd(monkeypatch):
@@ -1866,9 +1840,7 @@ def test_schedule_create_zero_max_cost_usd_errors(monkeypatch, capsys):
     assert "finite positive number" in capsys.readouterr().err
 
 
-# ---------------------------------------------------------------------------
 # _cmd_create: --threshold-config metric threshold alert flag
-# ---------------------------------------------------------------------------
 
 
 def test_schedule_create_threshold_config_flag_parses():
@@ -1974,9 +1946,7 @@ def test_schedule_create_zero_max_tokens_errors(monkeypatch, capsys):
     assert "must be a positive integer" in capsys.readouterr().err
 
 
-# ---------------------------------------------------------------------------
 # `li schedule validate` / `li schedule apply` — declarative ScheduleSet CLI
-# ---------------------------------------------------------------------------
 
 
 def _parse_schedule_args(argv_tail: list[str]):

--- a/tests/cli/test_schedule_quick_create.py
+++ b/tests/cli/test_schedule_quick_create.py
@@ -59,9 +59,7 @@ async def _get_or_none(name: str) -> dict | None:
         return await db.get_schedule_by_name(name)
 
 
-# ---------------------------------------------------------------------------
 # Per-kind happy paths
-# ---------------------------------------------------------------------------
 
 
 def test_quick_create_agent_at_trigger(temp_db_path, agent_profile, capsys):
@@ -192,9 +190,7 @@ def test_quick_create_command_argv_form(temp_db_path, agent_profile, monkeypatch
     assert row["action_command_args"] == ["full"]
 
 
-# ---------------------------------------------------------------------------
 # --once sugar
-# ---------------------------------------------------------------------------
 
 
 def test_quick_create_once_is_max_runs_one(temp_db_path, agent_profile):
@@ -227,9 +223,7 @@ def test_quick_create_once_and_max_runs_mutually_exclusive(temp_db_path, agent_p
     assert "mutually exclusive" in capsys.readouterr().err
 
 
-# ---------------------------------------------------------------------------
 # Trigger validation failure surfaces -- each rejects with zero DB writes
-# ---------------------------------------------------------------------------
 
 
 def test_quick_create_bad_cron_expression_rejected(temp_db_path, agent_profile, capsys):
@@ -306,9 +300,7 @@ def test_quick_create_malformed_github_filter_rejected(temp_db_path, agent_profi
     assert "unknown key" in capsys.readouterr().err
 
 
-# ---------------------------------------------------------------------------
 # Command target: never a shell string
-# ---------------------------------------------------------------------------
 
 
 def test_quick_create_command_requires_trailing_separator(temp_db_path, agent_profile, capsys):
@@ -329,9 +321,7 @@ def test_quick_create_command_rejects_single_shell_string_token(
     assert asyncio.run(_get_or_none("shell-like")) is None
 
 
-# ---------------------------------------------------------------------------
 # Name qualification: <project>/<name> when a project is detected
-# ---------------------------------------------------------------------------
 
 
 def test_quick_create_qualifies_name_with_detected_project(temp_db_path, agent_profile):
@@ -346,9 +336,7 @@ def test_quick_create_qualifies_name_with_detected_project(temp_db_path, agent_p
     assert row["action_project"] == "demo"
 
 
-# ---------------------------------------------------------------------------
 # Duplicate-name collisions (self and cross-owner-from-apply)
-# ---------------------------------------------------------------------------
 
 
 def test_quick_create_duplicate_name_rejected(temp_db_path, agent_profile, capsys):
@@ -403,9 +391,7 @@ schedules:
         asyncio.run(_apply())
 
 
-# ---------------------------------------------------------------------------
 # Additive compatibility: the legacy flat `create` form is untouched
-# ---------------------------------------------------------------------------
 
 
 def test_legacy_create_dispatch_unaffected_by_quick_create_kinds(monkeypatch):

--- a/tests/cli/test_scheduler_flow_yaml.py
+++ b/tests/cli/test_scheduler_flow_yaml.py
@@ -13,9 +13,7 @@ import pytest
 
 import lionagi.state.db as state_db_mod
 
-# ---------------------------------------------------------------------------
 # subprocess.build_argv tests
-# ---------------------------------------------------------------------------
 
 
 def _minimal_schedule(**kwargs) -> dict:
@@ -114,9 +112,7 @@ def test_build_argv_flow_yaml_cleanup_on_spawn():
     assert not os.path.exists(tmp_path)
 
 
-# ---------------------------------------------------------------------------
 # Creation-time YAML validation tests
-# ---------------------------------------------------------------------------
 
 
 def test_validate_flow_yaml_spec_accepts_valid_spec():
@@ -288,9 +284,7 @@ def test_create_schedule_route_storage_failure_is_not_409(tmp_path, monkeypatch)
     assert r.status_code == 500
 
 
-# ---------------------------------------------------------------------------
 # Lifecycle / status parity test
-# ---------------------------------------------------------------------------
 
 
 def test_flow_yaml_lifecycle_parity_with_play():
@@ -333,9 +327,7 @@ def test_flow_yaml_lifecycle_parity_with_play():
             os.unlink(yaml_tmp)
 
 
-# ---------------------------------------------------------------------------
 # CLI parser tests
-# ---------------------------------------------------------------------------
 
 
 def test_cli_flow_yaml_choice_accepted():
@@ -351,9 +343,7 @@ def test_cli_flow_yaml_choice_accepted():
     assert args.action_kind == "flow_yaml"
 
 
-# ---------------------------------------------------------------------------
 # Persistence round-trip test
-# ---------------------------------------------------------------------------
 
 
 def test_flow_yaml_db_roundtrip():
@@ -404,9 +394,7 @@ def test_flow_yaml_db_roundtrip():
     asyncio.run(_run())
 
 
-# ---------------------------------------------------------------------------
 # Regression tests: tmp-file lifecycle under cancellation / exception
-# ---------------------------------------------------------------------------
 
 
 def test_spawn_and_wait_cancellation_cleans_tmp_file():
@@ -487,9 +475,7 @@ def test_fire_pre_spawn_exception_cleans_tmp_file():
     assert not os.path.exists(tmp_path), "tmp file must be removed after pre-spawn exception"
 
 
-# ---------------------------------------------------------------------------
 # Regression tests: legacy schedules table migration
-# ---------------------------------------------------------------------------
 
 
 def test_legacy_schedules_table_upgraded_and_flow_yaml_insert_succeeds():
@@ -623,9 +609,7 @@ def test_legacy_rebuild_yields_full_canonical_columns():
     asyncio.run(_run())
 
 
-# ---------------------------------------------------------------------------
 # Regression tests: PATCH validation
-# ---------------------------------------------------------------------------
 
 
 def test_update_schedule_rejects_patch_to_flow_yaml_without_yaml():

--- a/tests/cli/test_smart_staleness.py
+++ b/tests/cli/test_smart_staleness.py
@@ -25,7 +25,7 @@ def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return db_path
 
 
-# ── Seed helpers ──────────────────────────────────────────────────────────────
+# Seed helpers
 
 
 async def _seed_session(db: StateDB, *, status: str = "running") -> str:
@@ -63,7 +63,7 @@ async def _link_play_session(db: StateDB, play_id: str, session_id: str) -> None
     await db.execute("UPDATE plays SET session_id = ? WHERE id = ?", (session_id, play_id))
 
 
-# ── _play_child_stale ─────────────────────────────────────────────────────────
+# _play_child_stale
 
 
 async def test_play_child_stale_no_session_id(temp_db_path: Path):
@@ -108,7 +108,7 @@ async def test_play_child_stale_with_failed_session(temp_db_path: Path):
         assert await _play_child_stale(db, row)
 
 
-# ── _show_children_all_terminal ───────────────────────────────────────────────
+# _show_children_all_terminal
 
 
 async def test_show_children_all_terminal_no_plays(temp_db_path: Path):
@@ -144,7 +144,7 @@ async def test_show_children_mixed_active_and_terminal(temp_db_path: Path):
         assert not await _show_children_all_terminal(db, show_id)
 
 
-# ── Integration: _do_kill_all_stale with child-derived staleness ─────────────
+# Integration: _do_kill_all_stale with child-derived staleness
 
 
 async def test_do_kill_all_stale_sweeps_play_with_dead_session(

--- a/tests/cli/test_state_commands.py
+++ b/tests/cli/test_state_commands.py
@@ -25,7 +25,7 @@ from lionagi.cli.state import (
 )
 from lionagi.state.db import StateDB
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -118,7 +118,7 @@ async def _seed_session_with_messages(
     return sid, msg_ids
 
 
-# ── _format_bytes ─────────────────────────────────────────────────────────────
+# _format_bytes
 
 
 def test_format_bytes_handles_each_unit():
@@ -129,7 +129,7 @@ def test_format_bytes_handles_each_unit():
     assert "TiB" in _format_bytes(2 * 1024**4)
 
 
-# ── _list_sessions (li state ls) ──────────────────────────────────────────────
+# _list_sessions (li state ls)
 
 
 async def test_ls_prints_empty_message_when_no_sessions(
@@ -188,7 +188,7 @@ async def test_ls_status_filter(
     assert "open" not in out
 
 
-# ── _print_stats (li state stats) ─────────────────────────────────────────────
+# _print_stats (li state stats)
 
 
 async def test_stats_reports_no_db_message_when_missing(
@@ -232,7 +232,7 @@ async def test_stats_reports_row_counts_and_pragmas(
     assert "busy_timeout" in out
 
 
-# ── _checkpoint (li state checkpoint) ─────────────────────────────────────────
+# _checkpoint (li state checkpoint)
 
 
 async def test_checkpoint_returns_summary_string(temp_db_path: Path):
@@ -257,7 +257,7 @@ async def test_checkpoint_each_mode_runs(temp_db_path: Path, mode: str):
     assert "log_pages=" in result
 
 
-# ── _vacuum (li state vacuum) ─────────────────────────────────────────────────
+# _vacuum (li state vacuum)
 
 
 async def test_vacuum_runs_without_error(temp_db_path: Path):
@@ -274,7 +274,7 @@ async def test_vacuum_runs_without_error(temp_db_path: Path):
     assert n == 1
 
 
-# ── _prune (li state prune) ───────────────────────────────────────────────────
+# _prune (li state prune)
 
 
 async def test_prune_dry_run_does_not_delete(temp_db_path: Path):
@@ -587,7 +587,7 @@ async def test_dry_run_message_count_is_the_count_the_real_prune_deletes(
         assert (await db.get_session(keeper_sid)) is not None
 
 
-# ── _doctor (li state doctor) ────────────────────────────────────────────────
+# _doctor (li state doctor)
 
 
 async def test_doctor_dry_run_does_not_modify_status(temp_db_path: Path):
@@ -854,7 +854,7 @@ async def test_doctor_with_failed_new_status(temp_db_path: Path):
     assert s["status"] == "failed"
 
 
-# ── _import_one_run: a row born terminal must carry a real duration_ms ────────
+# _import_one_run: a row born terminal must carry a real duration_ms
 
 
 async def test_import_of_a_completed_run_derives_duration_ms(temp_db_path: Path, tmp_path: Path):

--- a/tests/cli/test_state_null_content.py
+++ b/tests/cli/test_state_null_content.py
@@ -3,17 +3,17 @@
 
 """Reclaiming a message body has to stay distinguishable from never having one.
 
-The prune selects sessions. The bytes live on messages, and a message any
-surviving progression still names is kept whatever its age, so a store can be
-almost entirely message content, have every message inside the keep-window, and
-give a prune nothing to delete. This command selects on the axis the bytes are
-actually on.
+The prune selects sessions, but the bytes live on messages, and a message any
+surviving progression still names is kept whatever its age — so a store can
+be almost entirely message content, with every message inside the
+keep-window, and give a prune nothing to delete. This command selects on the
+axis the bytes are actually on.
 
-The condition that shapes it: an emptied body is indistinguishable from a turn
-that genuinely produced nothing, and nothing downstream has a second source for
-that distinction, so the two would collapse into one state permanently. A
-reclaimed body therefore carries a marker, and the arms that matter most here
-assert the difference is visible AT THE CONSUMER rather than at the writer --
+An emptied body is otherwise indistinguishable from a turn that genuinely
+produced nothing, and nothing downstream has a second source for that
+distinction, so the two would collapse into one state permanently. A
+reclaimed body therefore carries a marker, and the tests that matter most
+here assert the difference is visible at the consumer, not just the writer —
 the writer knowing what it wrote is not the property anyone depends on.
 
 No LLM and no network: these run against a temp SQLite file.

--- a/tests/cli/test_stats.py
+++ b/tests/cli/test_stats.py
@@ -73,7 +73,7 @@ def _stats_args(*, since: str = "7d", group_by: str = "project,kind", as_json: b
     )
 
 
-# ── _validate_group_by ───────────────────────────────────────────────────────
+# _validate_group_by
 
 
 def test_validate_group_by_accepts_all_known_keys():
@@ -108,7 +108,7 @@ def test_validate_group_by_rejects_empty():
         _validate_group_by("")
 
 
-# ── aggregation + grouping ───────────────────────────────────────────────────
+# aggregation + grouping
 
 
 @pytest.mark.asyncio
@@ -179,7 +179,7 @@ async def test_null_group_value_renders_null_in_json(temp_db_path: Path):
     assert payload[0]["kind"] is None
 
 
-# ── --since boundary ──────────────────────────────────────────────────────────
+# --since boundary
 
 
 @pytest.mark.asyncio
@@ -209,7 +209,7 @@ async def test_since_filter_excludes_stale_runs(temp_db_path: Path):
     assert total == 1
 
 
-# ── JSON field names (downstream ADR hardcodes these) ────────────────────────
+# JSON field names (downstream ADR hardcodes these)
 
 
 @pytest.mark.asyncio
@@ -233,7 +233,7 @@ async def test_json_field_names_are_stable(temp_db_path: Path):
     assert isinstance(payload[0]["last_at"], str)
 
 
-# ── empty-DB behavior ─────────────────────────────────────────────────────────
+# empty-DB behavior
 
 
 @pytest.mark.asyncio
@@ -251,7 +251,7 @@ def test_rows_for_json_empty():
     assert _rows_for_json([], ["project"]) == []
 
 
-# ── run_stats() CLI dispatch ──────────────────────────────────────────────────
+# run_stats() CLI dispatch
 
 
 def test_run_stats_unknown_group_by_key_exits_nonzero(
@@ -316,7 +316,7 @@ def test_run_stats_empty_db_table_mode(temp_db_path: Path, capsys):
     assert "no runs" in captured.out
 
 
-# ── read-only contract: li stats never applies schema/migrations ────────────
+# read-only contract: li stats never applies schema/migrations
 
 
 def test_run_stats_never_invokes_apply_schema(temp_db_path: Path, capsys, monkeypatch):
@@ -352,7 +352,7 @@ def test_run_stats_nonexistent_db_path_does_not_create_file(temp_db_path: Path, 
     assert not temp_db_path.exists()
 
 
-# ── --since must reject non-positive windows (0d, -1d, ...) ─────────────────
+# --since must reject non-positive windows (0d, -1d, ...)
 
 
 def test_reject_non_positive_since_rejects_zero():

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -35,7 +35,7 @@ from lionagi.cli.status import (
 from lionagi.state.db import StateDB
 from lionagi.state.reasons import RunReasons
 
-# ── Fixtures ────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -168,7 +168,7 @@ async def _set_fields(db: StateDB, table: str, id_: str, **fields) -> None:
     await db.execute(f"UPDATE {table} SET {sets} WHERE id = ?", (*fields.values(), id_))  # noqa: S608
 
 
-# ── Unit: _classify ───────────────────────────────────────────────────────
+# Unit: _classify
 
 
 def test_classify_session_success():
@@ -220,7 +220,7 @@ def test_classify_play_running_states(status):
     assert _classify("play", status) == (False, "running", EXIT_RUNNING)
 
 
-# ── Unit: _detect_degraded ──────────────────────────────────────────────────
+# Unit: _detect_degraded
 
 
 def test_detect_degraded_healthy_completed():
@@ -282,7 +282,7 @@ def test_detect_degraded_play_success_scoped_to_backing_session():
     assert degraded is True
 
 
-# ── Integration: entity resolution ──────────────────────────────────────────
+# Integration: entity resolution
 
 
 @pytest.mark.asyncio
@@ -398,7 +398,7 @@ async def test_resolve_agent_target_unknown_branch_shaped_id_returns_none(temp_d
     assert result is None
 
 
-# ── Integration: the mandated scenarios ──────────────────────────────────────
+# Integration: the mandated scenarios
 
 
 @pytest.mark.asyncio
@@ -619,7 +619,7 @@ async def test_cli_agent_status_resolves_printed_resume_id(temp_db_path: Path):
     assert view["branch_id"] == branch_id
 
 
-# ── Integration: degraded marker wired through _build_view ─────────────────
+# Integration: degraded marker wired through _build_view
 
 
 @pytest.mark.asyncio
@@ -665,7 +665,7 @@ async def test_view_not_degraded_for_imported_fs_mirror(temp_db_path: Path):
     assert view["degraded"] is False
 
 
-# ── Integration: --audit-degraded ────────────────────────────────────────────
+# Integration: --audit-degraded
 
 
 @pytest.mark.asyncio
@@ -713,7 +713,7 @@ async def test_audit_degraded_counts_sessions_and_plays(temp_db_path: Path):
     assert result["total_degraded"] == 3
 
 
-# ── Integration: argparse wiring / dispatch ─────────────────────────────────
+# Integration: argparse wiring / dispatch
 
 
 @pytest.mark.asyncio
@@ -788,7 +788,7 @@ def test_cli_play_status_help_subprocess():
     assert "audit-degraded" in result.stdout.lower()
 
 
-# ── pending_controls (ADR-0069 D1: session_controls transport) ─────────────
+# pending_controls (ADR-0069 D1: session_controls transport)
 
 
 @pytest.mark.asyncio
@@ -891,7 +891,7 @@ def test_cli_ctl_msg_help_subprocess():
     assert "text" in result.stdout.lower()
 
 
-# ── Integration: `li o ctl status` real argparse tree wiring ───────────────
+# Integration: `li o ctl status` real argparse tree wiring
 #
 # The tests above exercise `run_ctl_status()` with a hand-built
 # `argparse.Namespace` (test_run_ctl_status_dispatches_generic_lookup) or hit
@@ -1002,7 +1002,7 @@ def test_main_o_ctl_status_unknown_flag_is_argparse_error(temp_db_path: Path) ->
     assert exc_info.value.code == 2
 
 
-# ── Ambiguous short-id prefixes ─────────────────────────────────────────────
+# Ambiguous short-id prefixes
 #
 # Every status resolution stage (agent, play, generic) goes through the same
 # shared resolver, so a prefix matching two rows is reported, never guessed.

--- a/tests/cli/test_store_url_masking.py
+++ b/tests/cli/test_store_url_masking.py
@@ -3,31 +3,26 @@
 
 """No operator-facing string names the store with its password still in it.
 
-A store URL is a credential when the store is a server. Every command that
-reports which store it consulted, and every refusal that says why it could not
-open one, prints that URL, and those strings land in terminal scrollback, CI
-logs and machine-mode JSON that gets stored.
+A store URL is a credential when the store is a server. Commands that report
+which store they consulted, or refuse to open one, print that URL, and those
+strings land in terminal scrollback, CI logs, and stored machine-mode JSON.
 
-Two channels carry the same secret and both are asserted here. The URL is the
-obvious one. The other is an exception's own message, which is a separate
-string built by separate code and is unaffected by masking the field beside it.
+Two channels carry the same secret: the URL itself, and an exception's own
+message, which is separate code and unaffected by masking the field beside it.
 
-The end-to-end tests run the real CLI in a subprocess and read **stdout and
-stderr separately**, because "it did not appear" is only worth something once
-you have said where you looked. Each of them also asserts the masked form is
-present, which is what distinguishes a command that ran and masked from a
-command that never reached the store at all: an early probe of this fix
-mistyped the invocation, got a clean password check from six commands that all
-answered "no such command", and read as a pass.
+The end-to-end tests run the real CLI in a subprocess and read stdout and
+stderr separately, so "it did not appear" says where. Each also asserts the
+masked form is present, to distinguish a command that ran and masked from one
+that never reached the store — an early probe of this fix mistyped the
+invocation, got a clean password check from commands that all answered "no
+such command", and read as a pass.
 
 A store URL with no scheme is read as a filesystem path, so a credential in
-one puts a password in a real path. That is both how it evades a masker that
-only parses URLs, and why the branch that looks like it has nothing to hide is
-the one that leaked. The shape reaches a store setting only through the ``./``
-spelling now, since a bare ``user:secret@host/db`` is refused before it
-resolves, so that is the spelling the store-setting arms use. The masker is
-still asked about the bare form directly: it is handed strings built by
-drivers and by older logs, not only strings that passed our own validation.
+one puts a password in a real path — evading a masker that only parses URLs.
+That shape reaches a store setting only through the ``./`` spelling, since a
+bare ``user:secret@host/db`` is refused before it resolves; the masker is
+still tested against the bare form directly, since it is handed strings built
+by drivers and older logs, not only strings that passed our own validation.
 """
 
 from __future__ import annotations
@@ -67,7 +62,7 @@ def _assert_masked(text: str, where: str) -> None:
     )
 
 
-# ── the masker itself ────────────────────────────────────────────────────────
+# the masker itself
 
 
 def test_a_url_with_no_scheme_is_masked_too():
@@ -116,7 +111,7 @@ def test_strings_with_no_credential_are_returned_unchanged(untouched):
     assert mask_db_url(untouched) == untouched
 
 
-# ── per sink ─────────────────────────────────────────────────────────────────
+# per sink
 
 
 def test_the_absent_store_refusal_names_a_masked_store(monkeypatch):
@@ -338,7 +333,7 @@ async def test_the_monitor_detail_masks_a_message_that_quotes_the_store(monkeypa
     _assert_masked(await _run_detail("some-entity"), "the monitor detail's error line")
 
 
-# ── end to end, both channels named ──────────────────────────────────────────
+# end to end, both channels named
 
 
 def _run_cli(args: list[str], url: str, cwd) -> subprocess.CompletedProcess:

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -112,7 +112,7 @@ def test_studio_bare_uses_default_port(monkeypatch):
     assert kwargs.get("port") == 8765
 
 
-# ─── frontend-mode flags: --web (default) / --docker / --no-frontend ────────
+# frontend-mode flags: --web (default) / --docker / --no-frontend
 
 
 def test_studio_bare_defaults_to_hosted_web_mode(capsys):
@@ -337,7 +337,7 @@ def test_studio_cross_level_mode_flags_are_mutually_exclusive():
         assert exc_info.value.code == 2
 
 
-# ─── studio cwd / module resolution ─────────────
+# studio cwd / module resolution
 
 
 def test_find_repo_root_returns_path_from_source_checkout():
@@ -387,7 +387,7 @@ def test_ensure_apps_importable_adds_repo_root_to_sys_path(monkeypatch):
     assert root_str in sys.path
 
 
-# ─── _is_build_stale staleness predicate ─────────────────────────────────────
+# _is_build_stale staleness predicate
 
 
 def _write_marker(frontend_dir):
@@ -541,7 +541,7 @@ def test_is_build_stale_postcss_config_triggers_rebuild(tmp_path):
     assert _is_build_stale(tmp_path) is True
 
 
-# ─── _needs_npm_install tests ─────────────────────────────────────────────────
+# _needs_npm_install tests
 
 
 def test_needs_npm_install_when_node_modules_absent(tmp_path):

--- a/tests/cli/test_studio_mounts.py
+++ b/tests/cli/test_studio_mounts.py
@@ -7,9 +7,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-# ---------------------------------------------------------------------------
 # Unit tests for the pure helper functions
-# ---------------------------------------------------------------------------
 
 
 class TestIsMountAllowed:
@@ -81,9 +79,7 @@ class TestIsMountAllowed:
         assert _is_mount_allowed(Path("/proc/1/mem"), [home]) is False
 
 
-# ---------------------------------------------------------------------------
 # Attack scenario: symlink escape is rejected before docker argv is built
-# ---------------------------------------------------------------------------
 
 
 class TestSymlinkEscapeIsRejected:
@@ -180,9 +176,7 @@ class TestSymlinkEscapeIsRejected:
         assert "does_not_exist" not in argv_str
 
 
-# ---------------------------------------------------------------------------
 # Unit tests for _mount_allowed_roots
-# ---------------------------------------------------------------------------
 
 
 class TestMountAllowedRoots:

--- a/tests/cli/test_team_lifecycle.py
+++ b/tests/cli/test_team_lifecycle.py
@@ -38,7 +38,7 @@ def _make_team(team_id: str, members: list[str], messages: list[dict] | None = N
     )
 
 
-# ── compute_quiescence: pure predicate ──────────────────────────────────────
+# compute_quiescence: pure predicate
 
 
 class TestComputeQuiescence:
@@ -294,7 +294,7 @@ class TestComputeQuiescence:
         assert not state.quiescent
 
 
-# ── post_done_signal / post_finished_signal / post_wakeup_signal ───────────
+# post_done_signal / post_finished_signal / post_wakeup_signal
 
 
 class TestSignalWriters:
@@ -364,7 +364,7 @@ class TestSignalWriters:
         assert "alice" in data["messages"][0]["read_by"]
 
 
-# ── read_team_json / _load_team / cmd_list: shared-flock reads ─────────────
+# read_team_json / _load_team / cmd_list: shared-flock reads
 
 
 class TestReadTeamJson:
@@ -407,7 +407,7 @@ class TestReadTeamJson:
         assert "r3" in out
 
 
-# ── flock-safety under concurrent writers ───────────────────────────────────
+# flock-safety under concurrent writers
 
 
 class TestConcurrentWrites:
@@ -519,7 +519,7 @@ class TestConcurrentWrites:
         assert len(data["messages"]) == 20 * len(workers)
 
 
-# ── machine result: create / show / send / receive ──────────────────────────
+# machine result: create / show / send / receive
 
 
 class TestMachineResult:

--- a/tests/cli/test_teardown_duration_ms.py
+++ b/tests/cli/test_teardown_duration_ms.py
@@ -57,11 +57,11 @@ async def test_teardown_common_populates_duration_ms_from_started_at(db, monkeyp
 
 
 async def test_teardown_common_populates_duration_ms_on_zero_turn_timeout(db, monkeypatch):
-    """The exact #2495 shape: a session that timed out with no message ever
-    appended -- the progression row exists (created alongside the session)
-    but its collection is empty, so num_turns/input_tokens stay 0 and
-    duration_ms was previously the only field that could have said where the
-    time went, yet was itself always NULL."""
+    """A session that timed out with no message ever appended: the progression
+    row exists (created alongside the session) but its collection is empty,
+    so num_turns/input_tokens stay 0 and duration_ms was previously the only
+    field that could have said where the time went, yet was itself always
+    NULL."""
     sid = "sess-duration-zero-turn"
     started_at = 1_700_000_000.0
     await db.create_progression("prog-zero-turn")

--- a/tests/cli/test_wait.py
+++ b/tests/cli/test_wait.py
@@ -17,7 +17,7 @@ from lionagi.cli.wait import format_wait_line, run_wait, wait_for_terminal
 from lionagi.state.db import StateDB
 from lionagi.state.reasons import RunReasons
 
-# ── Fixtures ────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -110,7 +110,7 @@ async def _make_schedule_run(
     return rid
 
 
-# ── format_wait_line ─────────────────────────────────────────────────────────
+# format_wait_line
 
 
 def test_format_wait_line_is_one_frozen_tab_delimited_line() -> None:
@@ -142,7 +142,7 @@ def test_format_wait_line_uses_dash_for_missing_exit_code_and_artifact_dir() -> 
     assert line == "abc123\tstatus=failed\treason=unknown\tartifact_dir=-\texit_code=-"
 
 
-# ── Acceptance: play + session, correct reason + resolvable artifact_dir ────
+# Acceptance: play + session, correct reason + resolvable artifact_dir
 
 
 @pytest.mark.asyncio
@@ -259,7 +259,7 @@ async def test_wait_for_terminal_on_mixed_play_and_session_ids(temp_db_path: Pat
     assert {o["kind"] for o in outcomes} == {"play", "session"}
 
 
-# ── Acceptance: completed-empty gets its own reason, not a bare status ──────
+# Acceptance: completed-empty gets its own reason, not a bare status
 
 
 @pytest.mark.asyncio
@@ -280,7 +280,7 @@ async def test_completed_empty_session_yields_no_evidence_reason(temp_db_path: P
     assert outcomes[0]["reason"] == "run.completed_empty.no_evidence"
 
 
-# ── run_wait: the CLI entry point ───────────────────────────────────────────
+# run_wait: the CLI entry point
 
 
 def test_run_wait_prints_contract_line_for_terminal_session(
@@ -339,7 +339,7 @@ def test_run_wait_requires_at_least_one_id(temp_db_path: Path) -> None:
         run_wait([])
 
 
-# ── Ambiguous short-id prefixes ─────────────────────────────────────────────
+# Ambiguous short-id prefixes
 
 
 async def _make_session_with_id(db: StateDB, sid: str, *, status: str = "running") -> str:


### PR DESCRIPTION
Strip decorative comment banners/box-drawing section dividers (196+290 lines across the suite), tighten narrative docstrings to keep the WHY (regression cause, deliberate non-coverage, surprising constructions) while cutting restated-test-name and setup-narration prose, and remove internal tracking references (issue numbers, audit round/finding labels) that leaked into committed docstrings and comments.

No executable code changed: every touched file was verified with doc-trim-tools/ast_equal.py against HEAD (docstrings stripped, ASTs compared) both before and after ruff format/check --fix.

Scope: tests/cli/*.py only (96 files), excluding tests/cli/orchestrate/ which is owned by another workstream. cli/*root* prose: 5936 -> 5597 lines (12.7% -> 12.1% of the scope).