### PR TITLE
docs(tests): trim narration in tests root/scripts/fixtures/misc suites

### DIFF
--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -90,3 +90,62 @@ The required lane retains `--dist loadfile`. Some test files mutate process
 environment and module state, so file affinity is part of isolation. Duration
 data should be reviewed for stragglers before proposing `loadgroup`; a change
 also requires explicit `xdist_group` markers for every state-leaking file.
+
+## Run directory isolation
+
+`lionagi._paths` reads `LIONAGI_HOME` once, at import, and derives `RUNS_ROOT`
+from it; several modules then bind those two constants into their own
+namespace by name. `tests/conftest.py` redirects `LIONAGI_HOME` to a fresh
+temporary directory before anything else in the suite can import `lionagi`,
+so that every test's run-directory writes (manifests, branch snapshots,
+stream buffers) land in a throwaway location instead of interleaving with a
+developer's real store or a persistent CI one. The redirect has to sit above
+every other import in `conftest.py`, because once `lionagi._paths` is
+imported the constants it derived are fixed for the process.
+
+The value is overwritten unconditionally rather than only filled in when
+absent. `LIONAGI_HOME` is an ordinary production variable that plenty of
+shells and CI environments already set for reasons unrelated to the suite;
+deferring to an existing value would let that ambient setting silently turn
+isolation off. `LIONAGI_TEST_HOME` is the deliberate way through this: when
+set, the suite adopts it as `LIONAGI_HOME` and writes there instead of a
+throwaway directory. Anything written under it survives the run — it is not
+cleaned up — so it exists for a case that actually wants the suite pointed at
+a specific, inspectable directory. When neither is a concern, the suite
+allocates a temp directory and registers its removal with `atexit`.
+
+Cleanup runs after pytest has already reported the session's result, so a
+failure there has nowhere left to be an assertion. `_remove_test_home`
+therefore never raises: it catches `OSError` and `RecursionError` (the latter
+because `shutil.rmtree` descends recursively and a sufficiently deep tree
+exhausts the stack without the filesystem objecting to anything) and writes
+the surviving root and the underlying error to stderr instead. Nothing wider
+is caught — a bug inside the cleanup call itself (a `TypeError` from a
+misused API, say) is left to propagate rather than being reported as a
+directory the machine refused to delete.
+
+`tests/test_run_directory_isolation.py` verifies this from the outside, since
+by the time a test is running inside the suite the redirect has already
+happened and the original environment is gone. It launches a second pytest
+process with `LIONAGI_HOME` pre-set to a disposable directory (through a
+`probe` fixture that writes a throwaway test file under a dot-directory in
+`tests/`, so real `conftest.py` discovery still applies to it, and runs it
+with `-n0` to avoid xdist startup overhead for a single test) and reads back
+what the child process actually bound `_paths.LIONAGI_HOME` and
+`_paths.RUNS_ROOT` to. That is also how the suite verifies its own
+`atexit` cleanup: only a second process can observe what a first one wrote to
+stderr on the way out.
+
+One probe simulates a root that cannot be removed at all, using file
+permissions: `chmod(0o500)` on a subdirectory makes it impossible for the
+owning process to unlink the entry inside, so `rmtree` walks in and stops.
+The probe records the paths it is about to lock *before* locking them, so a
+caller can find and clear them even if the probe process hangs or is killed
+before it can report anything else. Recovery (`_recover_reported_roots`)
+processes every recorded root even after one fails: it collects failures
+and raises them together at the end rather than stopping at the first one,
+because a loop that stops early would strand every later root with nothing
+left to unlock it. The per-record exception handling is deliberately broad —
+everything caught is named in the consolidated failure — so an unrelated
+error can't decide silently that the remaining roots aren't worth
+attempting.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,32 +1,9 @@
 # tests/conftest.py
 
-# ── Run directory isolation ─────────────────────────────────────────────
-#
-# Must stay above every other import in this file. ``lionagi._paths`` reads
-# ``LIONAGI_HOME`` once, at import, and derives ``RUNS_ROOT`` from it; seven
-# modules then bind those two constants into their own namespace by name. So
-# the value has to be in the environment before the first of those imports
-# runs, and this conftest is the earliest code the suite loads.
-#
-# Without it, isolating the run directory is opt-in per test file: a test that
-# calls ``allocate_run`` writes a manifest, branch snapshots and stream buffers
-# into whichever run directory the machine is actually using, interleaved with
-# the ones a person's own work depends on. Redirecting the root here makes
-# isolation the default, and covers modules added later for free — patching
-# the constants after import would have to name every consumer.
-#
-# ``LIONAGI_HOME`` is the ordinary production variable: it is what a person sets
-# to point their own work at a particular store, and it is set in plenty of
-# shells and CI environments for reasons that have nothing to do with the suite.
-# So it is overwritten unconditionally rather than only when absent. Deferring to
-# it would let an ambient value silently switch the suite back to writing into
-# somebody's real store, and the boundary a test suite draws around itself must
-# not be something the environment can turn off by accident.
-#
-# ``LIONAGI_TEST_HOME`` is the deliberate way through, for an integration case
-# that needs the suite pointed at a specific directory. Setting it means the
-# suite writes outside the root it owns and cleans up: whatever lands under that
-# directory stays there after the run, interleaved with anything already in it.
+# Run directory isolation: must stay above every other import in this file,
+# since lionagi._paths binds LIONAGI_HOME/RUNS_ROOT at import time. See
+# docs/internals/ci.md#run-directory-isolation for why the redirect is
+# unconditional and what LIONAGI_TEST_HOME is for.
 import atexit
 import os
 import shutil
@@ -35,30 +12,13 @@ import tempfile
 
 
 def _remove_test_home(root):
-    """Delete the suite's temporary root, and say so on stderr if it survives.
+    """Delete the suite's temporary root; report to stderr rather than raise if it survives.
 
-    Cleanup runs from ``atexit``, after the session pytest reported on is over,
-    so there is nothing left to fail: raising here would produce an unraisable
-    traceback attached to no test and could only confuse the result a reader
-    already has. Swallowing the error is worse — a permission problem, a busy
-    file or a full filesystem leaves a directory behind and the suite says
-    nothing, so a boundary the suite draws around itself is one it cannot
-    report on when it leaks.
-
-    So the failure is a message rather than an exception: it names the root
-    that is still on disk and the error that stopped the removal, which is what
-    a person needs to find it and clear it. Only the removal is guarded --
-    anything else escapes, because a bug in this function is not a cleanup
-    failure and should not be dressed up as one.
-
-    ``OSError`` is what the filesystem raises: permissions, a busy file, a full
-    disk. ``RecursionError`` is what the walk itself raises -- ``rmtree``
-    descends recursively, so a tree deep enough to exhaust the stack fails
-    without the filesystem objecting to anything. Both leave the root on disk
-    and both are the caller's to clear, so both get the message. Nothing wider:
-    a bare ``except Exception`` would also swallow a ``TypeError`` or a
-    ``NameError`` from this function itself and report a bug here as a
-    directory the machine refused to delete.
+    Runs from ``atexit`` after the session pytest reported on is over, so a
+    raised exception here has no test to attach to. Only OSError/RecursionError
+    (permissions, a busy file, a full disk, or rmtree exhausting the stack on a
+    deep tree) are turned into a message; anything else is a bug in this
+    function, not a cleanup failure, and is left to propagate.
     """
     try:
         shutil.rmtree(root)
@@ -111,26 +71,18 @@ def pytest_collection_modifyitems(items):
 def _keep_the_interpreter_default_sigpipe():
     """Stop one test's signal policy from following every later test.
 
-    The CLI sets ``SIGPIPE`` to ``SIG_DFL`` on entry, which is right for a
-    command in a pipeline: ``li ... | head`` should die quietly when head
-    leaves rather than spew a traceback. But ``signal.signal`` is
-    process-wide and permanent, and a test that drives the CLI in-process
-    hands that disposition to every test that runs after it in the same
-    worker.
-
-    Python's own default is ``SIG_IGN``, which turns a write to a broken pipe
-    into an ``OSError`` that the writer can catch. Several things running
-    under test rely on that, asyncio among them: closing an event loop
-    closes the read end of its self-pipe before the write end, so a thread
-    handing back a result in that window writes to a pipe whose peer is
-    already gone. Asyncio expects the ``OSError`` and swallows it. Under
-    ``SIG_DFL`` the kernel delivers the signal first and the process is gone
-    instead, taking its buffered output with it -- no traceback, no failing
-    assertion, just a worker that stopped, blamed on whichever test it
-    happened to be holding.
-
-    Restoring the disposition after each test costs nothing and keeps that
-    failure inside the test that actually changes the policy.
+    The CLI sets SIGPIPE to SIG_DFL on entry (so `li ... | head` dies quietly
+    when head exits, instead of a traceback), but signal.signal is
+    process-wide and permanent, so a test that drives the CLI in-process
+    would otherwise hand that disposition to every later test in the worker.
+    That matters because Python's default, SIG_IGN, is what several things
+    under test rely on -- asyncio's event-loop shutdown writes to its
+    self-pipe's write end after the read end is closed, expects the
+    resulting OSError, and swallows it. Under SIG_DFL the kernel kills the
+    process on that write instead: no traceback, no failing assertion, just
+    a worker that stopped, blamed on whichever test it happened to be
+    holding. Restoring the disposition after each test keeps that failure
+    mode inside the test that actually changes the policy.
     """
     import signal
 

--- a/tests/fixtures/test_mock_factory.py
+++ b/tests/fixtures/test_mock_factory.py
@@ -13,7 +13,6 @@ from lionagi.testing import (
 
 
 def test_mock_factory_creates_branch():
-    """Test that mock factory can create a basic branch."""
     branch = LionAGIMockFactory.create_mocked_branch(
         name="SimpleTestBranch", response="Simple test response"
     )
@@ -25,7 +24,6 @@ def test_mock_factory_creates_branch():
 
 
 def test_mock_factory_creates_imodel():
-    """Test that mock factory can create an iModel."""
     imodel = LionAGIMockFactory.create_mocked_imodel(
         provider="openai", model="gpt-4o-mini", response="Test response"
     )
@@ -37,7 +35,6 @@ def test_mock_factory_creates_imodel():
 
 @pytest.mark.asyncio
 async def test_async_branch_communication():
-    """Test async communication with mocked branch."""
     branch = LionAGIMockFactory.create_mocked_branch(response="Async communication test")
 
     # Test async communication
@@ -46,7 +43,6 @@ async def test_async_branch_communication():
 
 
 def test_test_data_loading():
-    """Test that test data loading works."""
     # Test loading conversation data
     conversations = load_test_data("sample_conversations")
     assert "basic_chat" in conversations
@@ -63,7 +59,6 @@ def test_test_data_loading():
 
 @pytest.mark.asyncio
 async def test_async_helpers():
-    """Test async helper utilities."""
     # Test simple async condition
     condition_met = False
 
@@ -85,7 +80,6 @@ async def test_async_helpers():
 
 
 def test_validation_helpers_node():
-    """Test validation helpers with Node objects."""
     branch = LionAGIMockFactory.create_mocked_branch()
 
     # Test node validation - should not raise exception
@@ -93,7 +87,6 @@ def test_validation_helpers_node():
 
 
 def test_validation_helpers_api_response():
-    """Test validation helpers with API responses."""
     api_call = LionAGIMockFactory.create_api_calling_mock()
 
     # Test API response validation
@@ -101,7 +94,6 @@ def test_validation_helpers_api_response():
 
 
 def test_error_response_creation():
-    """Test error response mock creation."""
     error_response = LionAGIMockFactory.create_error_response_mock(
         error_message="Test error", error_code="test_error"
     )
@@ -113,7 +105,6 @@ def test_error_response_creation():
 
 @pytest.mark.asyncio
 async def test_end_to_end_simple():
-    """Simple end-to-end test using infrastructure components."""
     # Create branch with custom response
     branch = LionAGIMockFactory.create_mocked_branch(
         name="E2EBranch", response="End-to-end test response"

--- a/tests/integration/test_orchestration_integration.py
+++ b/tests/integration/test_orchestration_integration.py
@@ -10,8 +10,6 @@ import inspect
 
 import pytest
 
-# ── Test 1: cancelled_exc_classes safe to call outside loop ──────────────────
-
 
 def test_cancelled_exc_safe_outside_loop():
     """cancelled_exc_classes() must not raise when called from a sync context (no running event loop)."""
@@ -41,9 +39,6 @@ def test_is_cancelled_false_for_non_cancel():
     assert is_cancelled(RuntimeError()) is False
 
 
-# ── Test 2: cache_cancelled_exc_class populates the cache ────────────────────
-
-
 async def test_cancelled_exc_cache_populated_after_explicit_cache():
     """cache_cancelled_exc_class() inside an event loop populates the module cache."""
     from lionagi.ln.concurrency import errors as _err_mod
@@ -62,9 +57,6 @@ async def test_cancelled_exc_cache_populated_after_explicit_cache():
     finally:
         # Restore original state
         _err_mod._CANCELLED_EXC_CLASS = original
-
-
-# ── Test 3: aggregation_sources in metadata, NOT in parameters ───────────────
 
 
 def test_aggregation_params_in_metadata_not_parameters():
@@ -130,9 +122,6 @@ def test_aggregation_params_in_metadata_not_parameters():
         assert "instruction" in params
 
 
-# ── Test 4: _on_bus_spawn is async ───────────────────────────────────────────
-
-
 def test_on_bus_spawn_is_async():
     """ReactiveExecutor._on_bus_spawn must be async so session.observe() emit gathers it as a coro."""
     from lionagi.operations.flow import ReactiveExecutor
@@ -140,9 +129,6 @@ def test_on_bus_spawn_is_async():
     assert inspect.iscoroutinefunction(ReactiveExecutor._on_bus_spawn), (
         "ReactiveExecutor._on_bus_spawn must be a coroutine function (async def)"
     )
-
-
-# ── Test 5: Session has hooks property returning HookBus ─────────────────────
 
 
 def test_session_has_hooks_property():
@@ -175,9 +161,6 @@ def test_session_hooks_identity_stable():
     bus2 = session.hooks
 
     assert bus1 is bus2, "session.hooks must return the same HookBus instance on repeated access"
-
-
-# ── Test 6: Branch gets hooks from session via include_branches ───────────────
 
 
 def test_branch_gets_hooks_from_session():
@@ -215,9 +198,6 @@ def test_branch_gets_hooks_when_added_after_bus_init():
 
     assert b1._hooks is bus
     assert b2._hooks is bus
-
-
-# ── Test 7: both execute() and execute_stream() use the public observer property ──
 
 
 def test_reactive_executor_uses_public_observer_property():
@@ -263,9 +243,6 @@ def test_reactive_executor_uses_public_observer_property():
         )
 
 
-# ── Test 8: _wait_for_dependencies reads aggregation_sources from metadata ────
-
-
 def test_flow_aggregation_wait_reads_metadata():
     """DependencyAwareExecutor._wait_for_dependencies reads aggregation_sources
     from operation.metadata (not operation.parameters).
@@ -294,9 +271,6 @@ def test_flow_aggregation_wait_reads_metadata():
     assert 'parameters.get("aggregation_sources"' not in source, (
         "_wait_for_dependencies must not read aggregation_sources from operation.parameters"
     )
-
-
-# ── Test 9: CLI error handler imports cancelled_exc_classes (not get_cancelled_exc_class) ──
 
 
 def test_error_handler_uses_cached_exc_class():
@@ -350,9 +324,6 @@ def test_error_handler_uses_cached_exc_class():
     )
 
 
-# ── Test 10: HookBus lifecycle — default hooks are registered ────────────────
-
-
 def test_hook_bus_lifecycle_integration():
     """Session.hooks returns a properly-wired bus with all DEFAULT_HOOKS registered.
 
@@ -402,9 +373,6 @@ def test_hook_bus_handlers_for_returns_shallow_copy():
     assert len(bus.handlers_for(HookPoint.SESSION_START)) == original_len, (
         "handlers_for() must return a shallow copy — mutating it must not affect the bus"
     )
-
-
-# ── Test 11: aggregation metadata survives graph round-trip ──────────────────
 
 
 def test_aggregation_metadata_survives_without_parameters_leak():

--- a/tests/marketplace_lint.py
+++ b/tests/marketplace_lint.py
@@ -12,9 +12,7 @@ from pathlib import Path
 
 import pytest
 
-# ---------------------------------------------------------------------------
 # File discovery
-# ---------------------------------------------------------------------------
 
 _REPO_ROOT = Path(__file__).parent.parent
 _MARKETPLACE_ROOT = _REPO_ROOT / "marketplace"
@@ -29,9 +27,7 @@ def get_skill_files() -> list[Path]:
 
 _SKILL_FILES = get_skill_files()
 
-# ---------------------------------------------------------------------------
 # Regexes
-# ---------------------------------------------------------------------------
 
 # mcp__server__verb  (e.g. mcp__khive__recall, mcp__lore__compose)
 _MCP_RE = re.compile(r"\bmcp__([a-z0-9_-]+)__([a-z_]+)\b")
@@ -50,9 +46,7 @@ _NOHUP_RE = re.compile(r"\bnohup\b")
 # lambda namespace references  lambda:<name>
 _LAMBDA_RE = re.compile(r"\blambda:([a-z][a-z0-9_-]*)\b")
 
-# ---------------------------------------------------------------------------
 # Allowed sets
-# ---------------------------------------------------------------------------
 
 # Canonical khive verbs (from ADR + server registration)
 _KNOWN_KHIVE_VERBS: frozenset[str] = frozenset(
@@ -121,22 +115,17 @@ _KNOWN_MCP_SERVERS: frozenset[str] = frozenset(
 
 
 # Top-level `li` subcommands. The registry half is READ FROM THE CLI, not
-# listed here: a hand-maintained copy goes stale in the direction that rejects
-# true documentation, and it did. It named eleven while the CLI registered
-# twenty-three, so a skill correctly documenting `li monitor` or `li runs`
-# failed this check while nothing re-derived the list.
+# hand-listed here: a hand-maintained copy previously named eleven while the
+# CLI registered twenty-three, falsely rejecting skills that correctly
+# documented `li monitor` or `li runs`.
 #
-# The shims below cannot be derived the same way. Each is dispatched by an
-# `_argv[0] == "..."` branch in main() ahead of argparse, so all three are
-# absent from `li --help` and from the typed CLI seed registry while being real commands
-# with their own usage output. Deriving alone would reject them.
-#
-# This list is still hand-maintained, and it was short by `wait` on its first
-# outing, which produced the same false rejection the registry half had just
-# been fixed to stop producing. So it does not stand alone:
+# The shims below can't be derived the same way -- each is dispatched by an
+# `argv[0] == "..."` branch in main() ahead of argparse, so all three are
+# absent from `li --help` and the typed CLI seed registry despite being real
+# commands. This list is still hand-maintained (it was once short by `wait`,
+# the same false-rejection failure mode), so it does not stand alone:
 # test_pre_parse_shims_are_all_declared re-derives the branches from main()'s
-# source and fails when a new one appears. Hand-maintained is survivable; hand
-# maintained with nothing detecting drift is what went wrong twice.
+# source and fails when a new one appears undeclared.
 _PRE_PARSE_SHIMS: frozenset[str] = frozenset({"play", "skill", "wait"})
 
 
@@ -172,9 +161,7 @@ _CANONICAL_LAMBDAS: frozenset[str] = frozenset(
     }
 )
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _read(path: Path) -> str:
@@ -188,9 +175,7 @@ def _rel(path: Path) -> str:
         return str(path)
 
 
-# ---------------------------------------------------------------------------
 # Tests
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("path", _SKILL_FILES, ids=[_rel(p) for p in _SKILL_FILES])
@@ -351,17 +336,17 @@ def test_op_name_extractor_finds_quoted_ops() -> None:
 def test_documented_mcp_verbs_are_runnable_on_the_published_server() -> None:
     """Every verb the bundle shows in an `op` position must be one the server runs.
 
-    Two failure modes this catches, both of which read as correct documentation.
-    A verb that does not exist at all, and — the one a plain catalog membership
-    check would miss — a verb the catalog names only to decline, with a reason.
-    `team.send` and `invoke.start` are named that way: present in `help=true`
-    output, refused when called. So membership is checked against the runnable
-    registry and declined names are rejected explicitly rather than by omission.
+    Two failure modes, both of which read as correct documentation: a verb
+    that doesn't exist at all, and -- the one a plain catalog membership
+    check would miss -- a verb the catalog names only to decline, with a
+    reason (`team.send`, `invoke.start`: present in `help=true` output,
+    refused when called). So membership is checked against the runnable
+    registry and declined names are rejected explicitly, not by omission.
 
-    The registry is read from the installed lionagi rather than listed here. A
-    hand-kept copy of someone else's catalog goes stale in whichever direction
-    nobody is watching, which is how this file's `li` subcommand list went wrong
-    twice.
+    The registry is read from the installed lionagi rather than listed here
+    -- a hand-kept copy of someone else's catalog goes stale in whichever
+    direction nobody is watching, which is how this file's own `li`
+    subcommand list went wrong before.
     """
     from lionagi.mcp.verbs import ABSENT, VERBS
 
@@ -487,20 +472,20 @@ def _playbook_in_args(window: str) -> str | None:
     return m.group(1) if m else None
 
 
-# The two spellings the bundle actually uses for a help call whose argument is an
-# object: `help={...}` as a parameter, and `"help": {...}` as a JSON key. Written
-# as an enumeration of the supported forms rather than as "the letters `help`
-# minus whatever I remembered to exclude". A subtractive pattern is unbounded —
-# `nothelp` and `not-help` are two instances of a class with no last member, and
-# each is a fabricated source wearing a real one's shape. Requiring the brace is
-# part of the enumeration too: a `help` *string* field, which every playbook
-# declares per argument, is followed by a quote and matches neither form.
+# The two spellings the bundle actually uses for a help call whose argument
+# is an object: `help={...}` as a parameter, and `"help": {...}` as a JSON
+# key. Written as an enumeration of supported forms rather than "the letters
+# `help` minus whatever I remembered to exclude" -- a subtractive pattern is
+# unbounded (`nothelp`, `not-help` are fabricated sources wearing a real
+# one's shape). Requiring the brace matters too: a `help` *string* field,
+# which every playbook declares per argument, is followed by a quote and
+# matches neither form.
 #
-# The parameter form's left boundary is "not a character a name is made of",
-# which is a closed set, rather than a list of separators to reject, which is not.
-# Enumerating the *allowed* separators would have to cover every character the
-# bundle's prose and code fences put in front of a call (a space, a backtick, a
-# paren), and missing one rejects a real source.
+# The parameter form's left boundary is "not a character a name is made of"
+# (a closed set) rather than a list of separators to reject (not closed --
+# enumerating allowed separators would have to cover every character the
+# bundle's prose and code fences put in front of a call, and missing one
+# rejects a real source).
 _NAME_CHAR = r"A-Za-z0-9_.\-"
 _HELP_OBJECT = re.compile(
     rf"""(?:
@@ -514,16 +499,16 @@ _HELP_OBJECT = re.compile(
 def _qualified_help_sources(source: str) -> set[tuple[str, str]]:
     """Every (verb, playbook) pair named together inside one `help` call.
 
-    A call has to name both to be a usable source, so the pair is the unit, and
-    both names must come from the *same* object. Reading them from anywhere on
-    the line instead lets an unrelated `help` field sit next to sibling `verb`
-    and `playbook` keys and fabricate a pair no call ever named — which passes
-    the rule below on an example that the server then refuses.
+    A call has to name both to be a usable source, so the pair is the unit,
+    and both names must come from the *same* object -- reading them from
+    anywhere on the line would let an unrelated `help` field sit next to
+    sibling `verb`/`playbook` keys and fabricate a pair no call ever named,
+    passing the rule below on an example the server then refuses.
 
-    A call spanning lines is read as naming nothing, which fails loudly rather
-    than binding a playbook from the next line. That direction is deliberate. The
-    bundle writes these on one line, and a false negative is a visible failure
-    while a false positive ships a fingerprint that does not resolve.
+    A call spanning lines is read as naming nothing (deliberately, rather
+    than binding a playbook from the next line): the bundle writes these on
+    one line, and a false negative is a visible failure while a false
+    positive ships a fingerprint that doesn't resolve.
     """
     plain = source.replace("\\", "")
     pairs: set[tuple[str, str]] = set()
@@ -656,15 +641,12 @@ def test_documented_submit_ops_carry_a_schema_fingerprint() -> None:
     """Every documented `*.submit` op must show the fingerprint it has to carry.
 
     The server requires it as a **sibling of `args`** on every spawn verb and
-    refuses an op without one, so an example that omits it does not start a run.
-    An example that nests it inside `args` is worse: the key is not read there,
-    the identical refusal repeats, and the failure reads as idempotent rather
-    than as a misplaced key — so nesting is rejected here too.
-
-    Which verbs need one is read from the server's own registry rather than
-    listed, since 'the spawn verbs' is a fact about the release, not about this
-    file. The verb-name check above cannot catch this: an op naming a real verb
-    and omitting a mandatory sibling passes it while being unusable.
+    refuses an op without one. Nesting it inside `args` is worse: the key
+    isn't read there, the identical refusal repeats, and the failure reads
+    as idempotent rather than as a misplaced key -- so nesting is rejected
+    here too. Which verbs need one is read from the server's own registry
+    rather than listed, since "the spawn verbs" is a fact about the release,
+    not about this file.
     """
     from lionagi.mcp.verbs import VERBS
 
@@ -756,37 +738,30 @@ def test_a_playbook_qualified_schema_has_its_own_fingerprint(
 def test_a_playbook_bearing_example_names_a_playbook_qualified_help_source() -> None:
     """A fingerprint from the wrong schema is refused as surely as a missing one.
 
-    `play.submit` and `flow.submit` resolve the named playbook's own arguments
-    into their schema, so the fingerprint differs per playbook. An example that
-    names a playbook in `args` while pointing the reader at an unqualified
-    `help='play.submit'` yields `stale_schema`: a real fingerprint, from a real
-    help call, for a different schema. That is worse than a missing one, because
-    the reader has no reason to suspect the value they copied.
+    `play.submit`/`flow.submit` resolve the named playbook's own arguments
+    into their schema, so the fingerprint differs per playbook. An example
+    that names a playbook in `args` while pointing at an unqualified
+    `help='play.submit'` yields `stale_schema`: a real fingerprint, from a
+    real help call, for a different schema -- worse than a missing one, since
+    the reader has no reason to suspect the value they copied. The check
+    above can't see this (a fingerprint is present and correctly positioned),
+    so both rules are needed.
 
-    The check above cannot see this — a fingerprint is present and correctly
-    positioned in exactly these cases. Both rules are needed, and this one is
-    the reason the first one is not sufficient.
+    The source must be bound to the op by **both** names: requiring only that
+    some playbook-qualified call appear nearby would pass an example whose
+    source names a *different* playbook -- exactly the failure being
+    guarded. So the (verb, playbook) pair from the help call must equal the
+    pair the op itself names, checked in order: (1) the op's own
+    `schema_fingerprint` value self-binds and needs nothing else; (2)
+    otherwise the enclosing section, since a placeholder reading "from the
+    help call above" is correct exactly when the call above it is the right
+    one.
 
-    The source has to be bound to the op by **both** names. Requiring only that
-    some playbook-qualified call appear nearby passes an example whose source
-    names a *different* playbook, which is the very failure being guarded: the
-    reader follows a real qualified call, gets a real fingerprint, and the op is
-    refused. So the pair (verb, playbook) from the help call must equal the pair
-    the op itself names.
-
-    Two arms, preferred in order:
-
-    1. The op's own `schema_fingerprint` value names the call. Self-binding: no
-       other example can satisfy it.
-    2. Otherwise the enclosing section, because a placeholder reading "from the
-       help call above" is correct exactly when the call above it is the right
-       one.
-
-    Two residual limits, stated rather than closed, both of which fail loudly.
-    Within one section this cannot tell which of two correct-for-something calls a
-    prose placeholder points at; closing that needs a structured per-example
-    annotation, not a tighter pattern. And a help call written across lines names
-    nothing, so an example relying on one is reported as having no source.
+    Two residual limits, stated rather than closed: within one section this
+    can't tell which of two correct-for-something calls a prose placeholder
+    points at (closing that needs a structured per-example annotation, not a
+    tighter pattern), and a help call written across lines names nothing, so
+    an example relying on one is reported as having no source.
     """
     from lionagi.mcp.verbs import VERBS
 
@@ -862,43 +837,39 @@ _PROMPT_NEEDS_CWD = re.compile(
 def test_a_spawn_example_whose_prompt_names_a_path_passes_cwd() -> None:
     """A run that must read the caller's files has to be told where they are.
 
-    An omitted `cwd` resolves to the server's own directory. An example whose
-    prompt says to read `_intent.md` therefore starts the run somewhere that file
-    does not exist, and the run reports on evidence it never saw — the failure is a
-    verdict formed from absence, not an error.
+    An omitted `cwd` resolves to the server's own directory, so an example
+    whose prompt says to read `_intent.md` starts the run somewhere that
+    file doesn't exist -- the run reports on evidence it never saw, a
+    verdict formed from absence rather than an error.
 
-    **This is a net, not a proof, and the distinction is load-bearing.** Prompts are
-    prose, so there is no closed set of ways to say "read my files" — unlike a help
-    call, which has exactly two spellings and can therefore be enumerated. Four
-    sites of this class have been found so far, two by review and two by sweeping,
-    and each widening of the pattern is a hole closed rather than the last hole. So
-    what this rule does is stop a *known* phrasing from regressing; it does not
-    certify that every example needing a `cwd` has one. That check is the author's.
+    **This is a net, not a proof.** Prompts are prose, so there is no closed
+    set of ways to say "read my files," unlike a help call, which has
+    exactly two spellings and can be enumerated. This rule stops a *known*
+    phrasing from regressing; it does not certify every example needing a
+    `cwd` has one -- that check is the author's.
 
-    Two later sites were of a different shape and this rule does not see them: a
-    `prompt` whose whole value was `src/auth/`, and a playbook's typed `target`
-    argument. Both are fixed in the bundle and both carry an explicit `cwd`.
+    Two known sites are of a different shape this rule doesn't see: a
+    `prompt` whose whole value was `src/auth/`, and a playbook's typed
+    `target` argument. Both are fixed in the bundle with an explicit `cwd`.
+    A second rule was written for that shape and then removed: an argument
+    whose *entire* value is a relative path is decidable in a way a path
+    inside prose is not, but deciding which argument values an example
+    passes means reading quoted strings out of JSON-ish documentation
+    samples, and a regex cannot do that reliably -- successive attempts each
+    missed a different edge case (a hand-written extension list's gaps, an
+    array element, a filename containing `]`, an escaped quote). A real
+    parser would close the class but would only cover one of the two known
+    examples, since the other isn't valid JSON. A rule that advertises
+    closure it doesn't have is worse than one that admits it's a net,
+    because a reader stops checking -- so what guards this class now is this
+    heuristic, the two fixed examples as documented pattern, and author
+    judgment. If it regresses, write a parser or accept the limit; don't add
+    a third regex.
 
-    A second rule was written for that shape and then removed, and the reason is
-    worth keeping so it is not written again. The idea was sound: an argument whose
-    *entire* value is a relative path is decidable in a way a path inside prose is
-    not, so it could carry a closed boundary. But the layer underneath it could not.
-    Deciding which argument values an example passes means reading quoted strings out
-    of JSON-ish documentation samples, and a regex cannot do that: successive versions
-    missed a hand-written extension list's gaps, then every element of an array, then
-    a filename containing `]`, then an escaped quote. Each fix was correct and each
-    left the class open. A real parser would have been closed and would also have
-    covered only one of the two examples, since the other is not valid JSON.
-
-    So the boundary was honest and the substrate was not, and a rule that advertises
-    closure it does not have is worse than one that admits it is a net, because a
-    reader stops checking. What guards this class now is this heuristic, the two
-    fixed examples standing as the documented pattern, and author judgment. If it
-    regresses, write a parser or accept the limit — do not add a third regex.
-
-    Most spawn examples legitimately omit `cwd` — a minimal quick-start does not
-    need one — so requiring it everywhere would put a placeholder path in every
-    teaching example. That is why this is a pattern over prompts at all.
+    Most spawn examples legitimately omit `cwd` (a minimal quick-start
+    doesn't need one), so requiring it everywhere would put a placeholder
+    path in every teaching example -- hence a pattern over prompts, not a
+    blanket requirement.
     """
     from lionagi.mcp.verbs import VERBS
 
@@ -1004,23 +975,19 @@ def test_lambda_names_are_canonical(path: Path) -> None:
         )
 
 
-# ---------------------------------------------------------------------------
-# Agent frontmatter grammar
+# Agent frontmatter grammar.
 #
-# validate_manifests.py hand-rolls its frontmatter grammar because ci.sh runs it
-# on the bare system interpreter, where no YAML parser is available. This suite
-# runs under uv, so it is where that grammar is pinned against a real parser.
+# validate_manifests.py hand-rolls its frontmatter grammar because ci.sh runs
+# it on the bare system interpreter, where no YAML parser is available. This
+# suite runs under uv, so it is where that grammar is pinned against a real
+# parser. The grammar is narrower than YAML on purpose: the one invariant is
+# that it must never accept a document a parser would reject; rejecting a
+# form that is legal YAML is a judgement call, recorded below with a
+# category from a closed set.
 #
-# The grammar is narrower than YAML on purpose, so exactly one direction is an
-# invariant: it must never accept a document a parser would reject. The opposite
-# direction is a judgement call per form, so every form rejected despite being
-# legal YAML is recorded below with a category drawn from a closed set.
-#
-# The corpus is a CROSS PRODUCT, not a list of remembered cases. A hand-picked
-# table is an enumeration: it reads as complete while being short, and two
-# review rounds found forms such a table had omitted. Generating fence x key x
-# value combinations covers pairings nobody thought to write down.
-# ---------------------------------------------------------------------------
+# The corpus below is a CROSS PRODUCT of fence x key x value forms, not a
+# hand-picked list -- a hand-picked table reads as complete while omitting
+# combinations nobody thought to write down.
 
 _SCRIPTS_DIR = str(_MARKETPLACE_ROOT / "scripts")
 
@@ -1363,17 +1330,18 @@ def _swept_values() -> list[str]:
 def _parser_says(document: str) -> bool:
     """Whether a real parser finds a top-level non-empty string description.
 
-    The whole document is handed to the parser, body included, and that is deliberate:
-    it means YAML's own ``---`` document splitting decides where the frontmatter ends,
-    so the fence rules are checked by something other than the code being tested. An
-    oracle that split on fences using the grammar's own logic could not catch a fence
-    defect at all, and two of this lane's findings were fence defects.
+    The whole document is handed to the parser, body included, deliberately:
+    YAML's own ``---`` document splitting decides where the frontmatter ends,
+    so the fence rules are checked by something other than the code being
+    tested -- an oracle that split on fences using the grammar's own logic
+    couldn't catch a fence defect at all, and this lane has found real ones.
 
-    The price is a precondition: it is only a valid oracle for a document whose body is
-    inert as YAML. Every generated corpus here uses the body ``body``, and
-    ``_sweep_for_false_passes`` asserts that rather than trusting it, because a real
-    markdown body routinely is not valid YAML — an asterisk in prose reads as an alias
-    and the parser refuses the file. Use ``_parser_says_of_block`` for real files.
+    The price is a precondition: this is only a valid oracle for a document
+    whose body is inert as YAML. Every generated corpus here uses the body
+    ``body``, and ``_sweep_for_false_passes`` asserts that rather than
+    trusting it, since a real markdown body routinely is not valid YAML (an
+    asterisk in prose reads as an alias and the parser refuses the file).
+    Use ``_parser_says_of_block`` for real files.
     """
     import yaml
 
@@ -1500,22 +1468,21 @@ _LINE_BREAKS = ["\n", "\r\n", "\r"]
 def test_every_yaml_line_break_is_read_the_same_way() -> None:
     """The three sequences a parser treats as a line break, in every combination.
 
-    This is the axis the corpora held constant. Everything else here varies *content* while
-    terminating every line with ``\\n``, so a file that uses a different terminator was
-    outside every sweep, and a CR-only file is valid YAML whose frontmatter loads.
+    This is the axis the corpora held constant elsewhere: everything else
+    here varies *content* while terminating every line with ``\\n``, so a
+    file using a different terminator was outside every other sweep, and a
+    CR-only file is valid YAML whose frontmatter loads. This is not "a real
+    file was rejected": ``Path.read_text`` applies universal newlines, so
+    the **file** path never sees a lone CR, it arrives already translated.
+    The defect was in the text function that every one of these sweeps
+    measures, which was being held to something *stricter than the
+    product*: the file path and the text-function path disagreed on CR-only
+    input, and here the file path was right.
 
-    What that cost is worth stating precisely, because it is NOT "a real file was rejected".
-    ``Path.read_text`` applies universal newlines, so the **file** path never sees a lone CR:
-    it arrives already translated and the wrapper answered correctly throughout. The defect
-    was in the text function, which is the surface every one of these sweeps measures. So a
-    whole class of input was being measured against something *stricter than the product*, and
-    the two entry points disagreed about it. That is the same hazard as a rule measured apart
-    from its live route, arriving from the other side: here the route was right and the
-    measured function was wrong.
-
-    Both directions are asserted for each mix, since the risk runs both ways: missing a
-    terminator rejects a good file, and normalising too eagerly would accept a bad one. A CR
-    *inside* a value must stay rejected, which is the case the last row covers.
+    Both directions are asserted for each mix, since the risk runs both
+    ways: missing a terminator rejects a good file, and normalising too
+    eagerly would accept a bad one. A CR *inside* a value must stay
+    rejected, which is the case the last row covers.
     """
     grammar = _grammar_check()
     disagreements = []
@@ -1676,18 +1643,16 @@ def test_shipped_agents_agree_with_a_parser() -> None:
 def test_shipped_skills_are_outside_the_grammar_and_outside_its_subject() -> None:
     """A measured limit, pinned so that widening the grammar has to face it.
 
-    The validator reads descriptions under ``agents/`` only; skills are checked for
-    existence and never parsed. So this is not a live failure, and it is worth pinning
-    anyway, because the number is the argument: the grammar rejects **every** shipped
-    skill file, not an unusual one. They all write ``description: >`` folded over several
-    lines and carry an ``allowed-tools: [...]`` flow sequence, and both of those are
-    recorded narrowings.
-
-    That makes the folded-scalar narrowing much more expensive than the narrowing table
-    alone suggests, and anyone pointing this check at skills has to widen the grammar
-    first. This test fails the moment either of those things changes, which is the point:
-    it turns a cost that is currently invisible into one that has to be dealt with
-    deliberately.
+    The validator reads descriptions under ``agents/`` only; skills are
+    checked for existence and never parsed, so this is not a live failure --
+    it's worth pinning anyway because the number is the argument: the
+    grammar rejects **every** shipped skill file, not an unusual one. They
+    all write ``description: >`` folded over several lines and carry an
+    ``allowed-tools: [...]`` flow sequence, both recorded narrowings, which
+    makes the folded-scalar narrowing much more expensive than the
+    narrowing table alone suggests. This test fails the moment either of
+    those things changes, turning a cost that is currently invisible into
+    one that has to be dealt with deliberately.
     """
     skills = sorted((_MARKETPLACE_ROOT / "orchestrate" / "skills").glob("*/SKILL.md"))
     assert len(skills) >= 5, f"only {len(skills)} skill files found — the count below is the claim"
@@ -1761,17 +1726,16 @@ def test_unreadable_file_is_reported_rather_than_raised(tmp_path: Path) -> None:
     assert _frontmatter_problem(good) == ""
 
 
-# ---------------------------------------------------------------------------
-# mcpServers gate
+# mcpServers gate.
 #
-# `validate_manifests.py` checks a plugin.json's `mcpServers` block is a dict and
-# each entry inside it is too, before ever calling a dict method on either. The
-# per-plugin branch and the standalone-scan branch share one gate function, so a
-# non-object value (a string, a list) is reported as FAIL rather than raising
-# AttributeError from `.get(...)` on something that is not a dict. Both branches
-# are exercised end to end here, broken on purpose and then restored, because a
-# clean run cannot tell a check that passed from a check that never looked.
-# ---------------------------------------------------------------------------
+# validate_manifests.py checks a plugin.json's mcpServers block is a dict and
+# each entry inside it is too, before ever calling a dict method on either --
+# a non-object value (a string, a list) is reported as FAIL rather than
+# raising AttributeError from `.get(...)` on something that is not a dict.
+# Both the per-plugin and standalone-scan branches share this gate function
+# and are exercised end to end here, broken on purpose and then restored,
+# since a clean run can't tell a check that passed from one that never
+# looked.
 
 
 def _mcp_gate():

--- a/tests/scripts/test_ci_flake_hardening.py
+++ b/tests/scripts/test_ci_flake_hardening.py
@@ -414,24 +414,18 @@ def test_required_ci_wrapper_excludes_only_performance_and_quarantine() -> None:
 
 
 def test_worker_restart_is_disabled_by_the_project_config(request: pytest.FixtureRequest) -> None:
-    # Read the effective ini configuration rather than the text of any one
-    # file. A caller who never runs scripts/ci.sh -- `pytest tests/` typed by
-    # hand, an editor's runner, a tool that shells out -- inherits addopts and
-    # nothing else, so asserting the flag's presence in the wrapper proves
-    # nothing about that caller. Going through pytest's own config also keeps
-    # the assertion true if the settings move to another ini source.
+    # Reads the effective ini configuration rather than the text of any one
+    # file, since a caller who never runs scripts/ci.sh (a hand-typed `pytest
+    # tests/`, an editor's runner) inherits addopts and nothing else -- so
+    # asserting the flag's presence in the wrapper proves nothing about that
+    # caller. This covers every ordinary invocation from the repository; a
+    # caller that selects a different config with `pytest -c <file>` is
+    # protected only if that file sets the flag itself.
     #
-    # Scope, stated because the name would otherwise overpromise: this covers
-    # callers that discover the project's pytest configuration, which is every
-    # ordinary invocation from the repository. A caller that selects a different
-    # config with `pytest -c <file>` uses that file's addopts instead, so it is
-    # protected only if that file sets the flag itself; otherwise xdist's
-    # restarting default applies. Nothing set here can reach such a caller.
-    #
-    # Without this, a crashed worker is restarted and the replacement may never
-    # be scheduled, leaving the run blocked in the controller with no test name
-    # and no timeout able to fire: pytest-timeout watches test bodies, and a
-    # controller waiting on a worker channel is not inside one.
+    # Without this, a crashed worker is restarted and the replacement may
+    # never be scheduled, leaving the run blocked in the controller with no
+    # test name and no timeout able to fire: pytest-timeout watches test
+    # bodies, and a controller waiting on a worker channel is not inside one.
     assert "--max-worker-restart=0" in request.config.getini("addopts")
 
 

--- a/tests/scripts/test_ci_hygiene.py
+++ b/tests/scripts/test_ci_hygiene.py
@@ -155,9 +155,9 @@ def test_internal_identifier_in_notebook_markdown_is_rejected(public_repo: Path)
 def test_python_lambda_without_space_in_python_source_is_accepted(
     public_repo: Path, relative_path: Path, source: str
 ) -> None:
-    # Regression for #2149: the .py handling added to close the gap must not
-    # trip on Python's own zero-arg `lambda:` closure syntax written as real
-    # code (as opposed to a leaked namespace identifier in a comment/string).
+    # The .py handling added to close the notebook-only gap must not trip on
+    # Python's own zero-arg `lambda:` closure syntax written as real code (as
+    # opposed to a leaked namespace identifier in a comment/string).
     (public_repo / relative_path).write_text(source)
 
     result = _run_hygiene(public_repo)
@@ -174,10 +174,10 @@ def test_python_lambda_without_space_in_python_source_is_accepted(
     ],
 )
 def test_internal_identifier_in_python_source_is_rejected(public_repo: Path, source: str) -> None:
-    # Regression for #2149: a leaked internal namespace identifier in a .py
-    # comment, string literal, or docstring under docs/notebooks/cookbooks
-    # must fail the gate -- previously the `-g '!*.py'` exclusion let it
-    # through silently with no replacement scan.
+    # A leaked internal namespace identifier in a .py comment, string
+    # literal, or docstring under docs/notebooks/cookbooks must fail the
+    # gate -- a prior `-g '!*.py'` exclusion let it through silently with no
+    # replacement scan.
     (public_repo / "cookbooks" / "example.py").write_text(source)
 
     result = _run_hygiene(public_repo)
@@ -216,9 +216,9 @@ def test_internal_identifier_in_fstring_literal_segment_is_rejected(
     ],
 )
 def test_bare_founder_name_mention_is_rejected(public_repo: Path, content: str) -> None:
-    # Regression for #2150: the founder-name check previously only matched
-    # the possessive "Ocean's" and missed bare mentions -- exactly the leak
-    # shape #2115 hand-fixed throughout docs/_archive/.
+    # The founder-name check previously only matched the possessive form and
+    # missed bare mentions -- the same leak shape once hand-fixed throughout
+    # docs/_archive/.
     (public_repo / "docs" / "example.md").write_text(content)
 
     result = _run_hygiene(public_repo)
@@ -289,9 +289,9 @@ def test_geographic_ocean_prose_is_accepted(public_repo: Path) -> None:
     ],
 )
 def test_founder_public_byline_is_not_rejected(public_repo: Path, content: str) -> None:
-    # False-positive guard for #2150: the founder's own public credit lines
-    # (author bylines, the mkdocs.yml copyright notice) must keep passing
-    # once the check widens past the possessive-only pattern.
+    # False-positive guard: the founder's own public credit lines (author
+    # bylines, the mkdocs.yml copyright notice) must keep passing once the
+    # check widens past the possessive-only pattern.
     (public_repo / "docs" / "example.md").write_text(content)
 
     result = _run_hygiene(public_repo)

--- a/tests/test_class_registry.py
+++ b/tests/test_class_registry.py
@@ -5,12 +5,10 @@ and lion_class round-trips (both fully-qualified and legacy short names)."""
 
 import pytest
 
-# ---------------------------------------------------------------------------
 # Module-level Node subclasses
 # These classes MUST live here (module scope) so that their __module__ and
 # __qualname__ produce a valid importable fully-qualified name that
 # Element.from_dict can resolve via LION_CLASS_REGISTRY or import_module.
-# ---------------------------------------------------------------------------
 # Imported at module level; the import triggers no registration by itself
 # (Node.__pydantic_init_subclass__ fires only for *subclasses* of Node).
 from lionagi.protocols.graph.node import Node
@@ -76,22 +74,16 @@ class _LenBefore(Node):
     """Used for registry-length-stable test."""
 
 
-# ---------------------------------------------------------------------------
-# Autouse fixtures: registry isolation
-#
-# Two layers, because pollution happens at two times:
-#
-# 1. Import time — the module-level Node subclasses above are registered by
-#    Node.__pydantic_init_subclass__ the moment this file is imported, BEFORE
-#    any fixture runs.  A per-test snapshot can't see a pre-import state, so a
-#    module-scoped finalizer removes every registry entry whose class was
-#    defined in this module once the module's tests finish.  Without it, all
-#    test-only keys leak to later test modules on the same xdist worker.
-#
-# 2. Test time — individual tests mutate the registry (deleting keys,
-#    registering type()-created collisions).  A per-test snapshot/restore
-#    guarantees those mutations never outlive the test, even on failure.
-# ---------------------------------------------------------------------------
+# Autouse fixtures: registry isolation, in two layers because pollution
+# happens at two times. (1) Import time: the module-level Node subclasses
+# above register via Node.__pydantic_init_subclass__ the moment this file is
+# imported, before any fixture runs, so a per-test snapshot can't see a
+# pre-import state -- a module-scoped finalizer removes every registry entry
+# defined in this module once its tests finish, or test-only keys leak to
+# later modules on the same xdist worker. (2) Test time: individual tests
+# mutate the registry (deleting keys, registering type()-created
+# collisions); a per-test snapshot/restore keeps those mutations from
+# outliving the test, even on failure.
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -128,9 +120,7 @@ def _registry_snapshot():
         LION_CLASS_REGISTRY.update(registry_snapshot)
 
 
-# ---------------------------------------------------------------------------
 # 1. LION_CLASS_REGISTRY population via Node.__pydantic_init_subclass__
-# ---------------------------------------------------------------------------
 
 
 class TestNodeSubclassRegistration:
@@ -172,9 +162,7 @@ class TestNodeSubclassRegistration:
         assert node_full not in LION_CLASS_REGISTRY
 
 
-# ---------------------------------------------------------------------------
 # 2. get_class: hit (direct registry lookup)
-# ---------------------------------------------------------------------------
 
 
 class TestGetClassHit:
@@ -203,9 +191,7 @@ class TestGetClassHit:
         assert isinstance(inst, _InstantiateNode)
 
 
-# ---------------------------------------------------------------------------
 # 3. get_class: miss behavior (unknown name)
-# ---------------------------------------------------------------------------
 
 
 class TestGetClassMiss:
@@ -238,8 +224,7 @@ class TestGetClassMiss:
             get_class("lionagi.protocols.generic.element.NoSuchClass_xyz")
 
 
-# ---------------------------------------------------------------------------
-# 4. get_class: legacy short-name resolution via built-in modules
+# get_class: legacy short-name resolution via built-in modules.
 #
 # Persisted `lion_class` metadata predating the full-qualified-name
 # convention stores a bare class name (e.g. "Instruction") instead of a
@@ -247,7 +232,6 @@ class TestGetClassMiss:
 # scan, by importing the fixed set of built-in modules and looking the name
 # up as a module attribute (or, for Node subclasses, via LION_CLASS_REGISTRY
 # after that import triggers registration).
-# ---------------------------------------------------------------------------
 
 
 class TestGetClassShortNameFallback:
@@ -308,9 +292,7 @@ class TestGetClassShortNameFallback:
         assert result is Log
 
 
-# ---------------------------------------------------------------------------
 # 5. get_class: dotted-path import fallback (fully-qualified names)
-# ---------------------------------------------------------------------------
 
 
 class TestGetClassDottedPathFallback:
@@ -349,15 +331,12 @@ class TestGetClassDottedPathFallback:
             class_registry.get_class("broken.module.UniqueRegistryClass")
 
 
-# ---------------------------------------------------------------------------
-# 6. Duplicate-name handling: last writer wins (overwrite semantics — pinned)
+# Duplicate-name handling: last writer wins (overwrite semantics, pinned).
 #
 # Tests exercise the real registration hook (Node.__pydantic_init_subclass__)
 # by creating two classes with the same __name__ using type() in function
-# scope.  Because pydantic's __pydantic_init_subclass__ fires on each class
-# statement / type() call, both classes are registered under the same key
-# (their full-qualified name derives from __module__ + __qualname__).
-# The second registration silently overwrites the first — last-writer-wins.
+# scope, so both register under the same key (derived from __module__ +
+# __qualname__) and the second silently overwrites the first.
 #
 # NOTE: classes created with bare type() get __module__ == "abc" (pydantic's
 # ModelMetaclass construction runs through abc machinery, and the frame-based
@@ -365,7 +344,6 @@ class TestGetClassDottedPathFallback:
 # Two distinct type() calls sharing the same __name__ still collide on exactly
 # the same registry key — exactly the scenario we want.  The per-test snapshot
 # fixture restores these keys afterwards.
-# ---------------------------------------------------------------------------
 
 
 class TestDuplicateNameHandling:
@@ -440,9 +418,7 @@ class TestDuplicateNameHandling:
         assert len(LION_CLASS_REGISTRY) == size_before
 
 
-# ---------------------------------------------------------------------------
 # 7. Polymorphic round-trip (python mode)
-# ---------------------------------------------------------------------------
 
 
 class TestPolymorphicRoundTrip:
@@ -511,9 +487,7 @@ class TestPolymorphicRoundTrip:
         assert restored.id == inst.id
 
 
-# ---------------------------------------------------------------------------
 # 8. db-mode round-trip (node_metadata key)
-# ---------------------------------------------------------------------------
 
 
 class TestDbModeRoundTrip:
@@ -548,15 +522,13 @@ class TestDbModeRoundTrip:
         assert restored.content == "db-content-check"
 
 
-# ---------------------------------------------------------------------------
-# 9. Legacy short-name lion_class round-trip for built-in message classes
+# Legacy short-name lion_class round-trip for built-in message classes.
 #
 # HARD CONSTRAINT: old persisted `lion_class` strings must keep round-
 # tripping whether they store the fully-qualified dotted path
 # (e.g. "lionagi.protocols.messages.instruction.Instruction") or the bare
 # legacy short name (e.g. "Instruction"), for every built-in Element/Node
 # subclass that ships with lionagi.
-# ---------------------------------------------------------------------------
 
 
 def _short_name_round_trip(inst):
@@ -699,14 +671,12 @@ class TestLegacyShortNameMessageRoundTrip:
         assert restored.content == "plain node"
 
 
-# ---------------------------------------------------------------------------
-# 10. Message Pile round-trip with mixed full/short lion_class entries
+# Message Pile round-trip with mixed full/short lion_class entries.
 #
 # Branch/session state persists its message history as a Pile of messages;
 # Pile.from_dict / _validate_collections deserializes each item via
 # Element.from_dict. This exercises the whole stack (Pile -> Element.from_dict
 # -> get_class) the way a real Branch snapshot load would.
-# ---------------------------------------------------------------------------
 
 
 class TestMessagePileRoundTrip:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,10 +13,7 @@ from lionagi.config import AppSettings, CacheConfig, settings
 
 
 class TestCacheConfig:
-    """Tests for CacheConfig class."""
-
     def test_default_values(self):
-        """Test CacheConfig default values."""
         config = CacheConfig()
         assert config.ttl == 300
         assert config.key is None
@@ -24,14 +21,12 @@ class TestCacheConfig:
         assert config.alias is None
 
     def test_custom_values(self):
-        """Test CacheConfig with custom values."""
         config = CacheConfig(ttl=600, key="test_key", namespace="test_ns")
         assert config.ttl == 600
         assert config.key == "test_key"
         assert config.namespace == "test_ns"
 
     def test_as_kwargs_excludes_unserialisable(self):
-        """Test as_kwargs removes unserialisable callables."""
         config = CacheConfig(
             ttl=300,
             key="test",
@@ -48,34 +43,27 @@ class TestCacheConfig:
         assert "plugins" not in kwargs
 
     def test_as_kwargs_excludes_none(self):
-        """Test as_kwargs excludes None values."""
         config = CacheConfig(ttl=300, key=None, namespace=None)
         kwargs = config.as_kwargs()
         assert "key" not in kwargs
         assert "namespace" not in kwargs
 
     def test_as_kwargs_includes_alias(self):
-        """Test as_kwargs includes alias when set."""
         config = CacheConfig(alias="my_cache")
         kwargs = config.as_kwargs()
         assert kwargs["alias"] == "my_cache"
 
 
 class TestAppSettings:
-    """Tests for AppSettings class."""
-
     def test_singleton_pattern(self):
-        """Test AppSettings maintains singleton instance."""
         assert AppSettings._instance is settings
         assert settings is not None
 
     def test_frozen_settings(self):
-        """Test settings are frozen and cannot be modified."""
         with pytest.raises(ValidationError):  # ValidationError from Pydantic
             settings.OPENAI_DEFAULT_MODEL = "gpt-5"
 
     def test_default_values(self):
-        """Test default configuration values."""
         config = AppSettings()
         assert config.OPENAI_DEFAULT_MODEL == "gpt-4.1-mini"
         assert config.LIONAGI_EMBEDDING_PROVIDER == "openai"
@@ -84,7 +72,6 @@ class TestAppSettings:
         assert config.LIONAGI_CHAT_MODEL == "gpt-4.1-mini"
 
     def test_storage_defaults(self):
-        """Test storage default values."""
         config = AppSettings()
         assert config.LIONAGI_AUTO_STORE_EVENT is False
         assert config.LIONAGI_STORAGE_PROVIDER == "async_qdrant"
@@ -93,7 +80,6 @@ class TestAppSettings:
         assert config.LIONAGI_DEFAULT_QDRANT_COLLECTION == "event_logs"
 
     def test_log_defaults(self):
-        """Test log configuration default values."""
         config = AppSettings()
         assert config.LOG_PERSIST_DIR == "./data/logs"
         assert config.LOG_SUBFOLDER is None
@@ -106,7 +92,6 @@ class TestAppSettings:
         assert config.LOG_CLEAR_AFTER_DUMP is True
 
     def test_log_config_property(self):
-        """Test LOG_CONFIG property returns correct dict."""
         config = AppSettings()
         log_config = config.LOG_CONFIG
         assert log_config["persist_dir"] == "./data/logs"
@@ -119,13 +104,11 @@ class TestAppSettings:
         assert log_config["clear_after_dump"] is True
 
     def test_aiocache_config_default(self):
-        """Test aiocache_config default factory."""
         config = AppSettings()
         assert isinstance(config.aiocache_config, CacheConfig)
         assert config.aiocache_config.ttl == 300
 
     def test_api_keys_default_to_none_without_env(self):
-        """Test API keys default to None when no env vars set."""
         # Note: This test may not pass if environment has API keys set
         # Testing that the field can be None or SecretStr
         config = AppSettings()
@@ -136,22 +119,17 @@ class TestAppSettings:
 
 
 class TestGetSecret:
-    """Tests for get_secret method."""
-
     def test_get_secret_with_secret_str(self):
-        """Test get_secret with SecretStr value."""
         config = AppSettings(OPENAI_API_KEY=SecretStr("test_key_123"))
         result = config.get_secret("OPENAI_API_KEY")
         assert result == "test_key_123"
 
     def test_get_secret_missing_key_raises_error(self):
-        """Test get_secret with non-existent key raises AttributeError."""
         config = AppSettings()
         with pytest.raises(AttributeError, match="not found in settings"):
             config.get_secret("NONEXISTENT_KEY")
 
     def test_get_secret_none_value_raises_error(self):
-        """Test get_secret with None value raises ValueError."""
         # Create config explicitly with None for a key
         config = AppSettings(PERPLEXITY_API_KEY=None)
         # Only test if the key is actually None
@@ -164,19 +142,16 @@ class TestGetSecret:
             assert isinstance(result, str)
 
     def test_get_secret_ollama_returns_ollama(self):
-        """Test get_secret for Ollama returns 'ollama' even if None."""
         config = AppSettings()
         result = config.get_secret("OLLAMA_API_KEY")
         assert result == "ollama"
 
     def test_get_secret_ollama_missing_returns_ollama(self):
-        """Test get_secret for missing Ollama key returns 'ollama'."""
         config = AppSettings()
         result = config.get_secret("some_ollama_key")
         assert result == "ollama"
 
     def test_get_secret_string_value(self):
-        """Test get_secret with plain string value."""
         # Create a config with a custom string value
         # Note: In practice, API keys should be SecretStr
         with patch.dict(os.environ, {"OPENAI_API_KEY": "plain_text_key"}, clear=False):
@@ -187,79 +162,61 @@ class TestGetSecret:
 
 
 class TestEnvironmentVariableLoading:
-    """Tests for environment variable loading."""
-
     def test_load_from_env_openai_key(self):
-        """Test loading OPENAI_API_KEY from environment."""
         with patch.dict(os.environ, {"OPENAI_API_KEY": "env_key_123"}, clear=False):
             config = AppSettings()
             if config.OPENAI_API_KEY is not None:
                 assert config.get_secret("OPENAI_API_KEY") == "env_key_123"
 
     def test_load_from_env_custom_model(self):
-        """Test loading custom model from environment."""
         with patch.dict(os.environ, {"OPENAI_DEFAULT_MODEL": "gpt-4"}, clear=False):
             config = AppSettings()
             assert config.OPENAI_DEFAULT_MODEL == "gpt-4"
 
     def test_case_insensitive_loading(self):
-        """Test case-insensitive environment variable loading."""
         with patch.dict(os.environ, {"openai_default_model": "custom-model"}, clear=False):
             config = AppSettings()
             assert config.OPENAI_DEFAULT_MODEL == "custom-model"
 
     def test_extra_fields_ignored(self):
-        """Test extra environment variables are ignored."""
         with patch.dict(os.environ, {"UNKNOWN_SETTING": "value"}, clear=False):
             config = AppSettings()
             assert not hasattr(config, "UNKNOWN_SETTING")
 
 
 class TestEnvFileLoading:
-    """Tests for .env file loading."""
-
     def test_env_file_paths_configured(self):
-        """Test .env file paths are configured."""
         assert ".env" in AppSettings.model_config["env_file"]
         assert ".env.local" in AppSettings.model_config["env_file"]
         assert ".secrets.env" in AppSettings.model_config["env_file"]
 
     def test_env_file_encoding(self):
-        """Test env file encoding is utf-8."""
         assert AppSettings.model_config["env_file_encoding"] == "utf-8"
 
     def test_case_sensitive_config(self):
-        """Test case sensitivity configuration."""
         assert AppSettings.model_config["case_sensitive"] is False
 
     def test_extra_config(self):
-        """Test extra fields configuration."""
         assert AppSettings.model_config["extra"] == "ignore"
 
 
 class TestSettingsIntegration:
-    """Integration tests for settings usage."""
-
     def test_settings_is_frozen_instance(self):
-        """Test global settings instance is frozen."""
         assert isinstance(settings, AppSettings)
         with pytest.raises(ValidationError):
             settings.OPENAI_DEFAULT_MODEL = "new-model"
 
     def test_cache_config_from_settings(self):
-        """Test cache config can be accessed from settings."""
         assert hasattr(settings, "aiocache_config")
         kwargs = settings.aiocache_config.as_kwargs()
         assert isinstance(kwargs, dict)
 
     def test_log_config_from_settings(self):
-        """Test log config can be accessed from settings."""
         log_config = settings.LOG_CONFIG
         assert "persist_dir" in log_config
         assert "capacity" in log_config
 
     def test_multiple_api_keys_independent(self):
-        """Test multiple API keys can be set independently."""
         with patch.dict(
             os.environ,
             {
@@ -275,23 +232,18 @@ class TestSettingsIntegration:
 
 
 class TestSecretStrHandling:
-    """Tests for SecretStr handling."""
-
     def test_secret_str_created_from_env(self):
-        """Test SecretStr is created from environment."""
         with patch.dict(os.environ, {"OPENAI_API_KEY": "secret_value"}, clear=False):
             config = AppSettings()
             if config.OPENAI_API_KEY is not None:
                 assert isinstance(config.OPENAI_API_KEY, SecretStr)
 
     def test_secret_str_not_exposed_in_repr(self):
-        """Test SecretStr value not exposed in repr."""
         config = AppSettings(OPENAI_API_KEY=SecretStr("secret"))
         repr_str = repr(config)
         assert "secret" not in repr_str.lower() or "**" in repr_str
 
     def test_secret_str_get_value(self):
-        """Test SecretStr value retrieval."""
         secret = SecretStr("my_secret")
         config = AppSettings(OPENAI_API_KEY=secret)
         assert config.get_secret("OPENAI_API_KEY") == "my_secret"
@@ -324,6 +276,5 @@ def test_provider_defaults(provider, model_key, default_model):
     ],
 )
 def test_log_configuration_defaults(log_key, expected_value):
-    """Test log configuration default values."""
     config = AppSettings()
     assert getattr(config, log_key) == expected_value

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -44,10 +44,7 @@ _EXPECTED_ALL = (
 
 
 class TestLionError:
-    """Tests for base LionError class."""
-
     def test_default_initialization(self):
-        """Test error with default values."""
         error = LionError()
         assert str(error) == "LionAGI error"
         assert error.message == "LionAGI error"
@@ -55,31 +52,26 @@ class TestLionError:
         assert error.status_code == 500
 
     def test_custom_message(self):
-        """Test error with custom message."""
         error = LionError("Custom error message")
         assert str(error) == "Custom error message"
         assert error.message == "Custom error message"
 
     def test_with_details(self):
-        """Test error with details dictionary."""
         details = {"key": "value", "count": 42}
         error = LionError("Error", details=details)
         assert error.details == details
 
     def test_with_status_code(self):
-        """Test error with custom status code."""
         error = LionError("Error", status_code=404)
         assert error.status_code == 404
 
     def test_with_cause(self):
-        """Test error with underlying cause."""
         cause = ValueError("Original error")
         error = LionError("Wrapped error", cause=cause)
         assert error.get_cause() is cause
         assert error.__cause__ is cause
 
     def test_to_dict_basic(self):
-        """Test serialization to dictionary."""
         error = LionError("Test error", status_code=400)
         result = error.to_dict()
         assert result == {
@@ -89,13 +81,11 @@ class TestLionError:
         }
 
     def test_to_dict_with_details(self):
-        """Test serialization with details."""
         error = LionError("Error", details={"field": "value"})
         result = error.to_dict()
         assert result["details"] == {"field": "value"}
 
     def test_to_dict_with_cause(self):
-        """Test serialization including cause."""
         cause = ValueError("Root cause")
         error = LionError("Error", cause=cause)
         result = error.to_dict(include_cause=True)
@@ -103,63 +93,51 @@ class TestLionError:
         assert "ValueError" in result["cause"]
 
     def test_to_dict_without_cause(self):
-        """Test serialization excluding cause by default."""
         cause = ValueError("Root cause")
         error = LionError("Error", cause=cause)
         result = error.to_dict(include_cause=False)
         assert "cause" not in result
 
     def test_from_value_basic(self):
-        """Test creating error from value."""
         error = LionError.from_value(42)
         assert error.details["value"] == 42
         assert error.details["type"] == "int"
 
     def test_from_value_with_expected(self):
-        """Test creating error with expected type."""
         error = LionError.from_value(42, expected="str")
         assert error.details["expected"] == "str"
         assert error.details["value"] == 42
 
     def test_from_value_with_message(self):
-        """Test creating error with custom message."""
         error = LionError.from_value(42, message="Invalid value")
         assert error.message == "Invalid value"
 
     def test_from_value_with_cause(self):
-        """Test creating error with cause."""
         cause = TypeError("Type mismatch")
         error = LionError.from_value(42, cause=cause)
         assert error.get_cause() is cause
 
     def test_from_value_with_extra_details(self):
-        """Test creating error with extra details."""
         error = LionError.from_value(42, field="age", min_value=0)
         assert error.details["field"] == "age"
         assert error.details["min_value"] == 0
 
     def test_get_cause_no_cause(self):
-        """Test get_cause when no cause exists."""
         error = LionError("Error")
         assert error.get_cause() is None
 
 
 class TestValidationError:
-    """Tests for ValidationError class."""
-
     def test_default_message(self):
-        """Test ValidationError default message."""
         error = ValidationError()
         assert error.message == "Validation failed"
         assert error.status_code == 422
 
     def test_custom_message(self):
-        """Test ValidationError with custom message."""
         error = ValidationError("Invalid input")
         assert error.message == "Invalid input"
 
     def test_inheritance(self):
-        """Test ValidationError inherits from LionError and ValueError."""
         error = ValidationError()
         assert isinstance(error, LionError)
         assert isinstance(error, ValueError)
@@ -167,88 +145,66 @@ class TestValidationError:
 
 
 class TestNotFoundError:
-    """Tests for NotFoundError class."""
-
     def test_default_message(self):
-        """Test NotFoundError default message."""
         error = NotFoundError()
         assert error.message == "Item not found"
         assert error.status_code == 404
 
     def test_with_details(self):
-        """Test NotFoundError with item details."""
         error = NotFoundError("User not found", details={"user_id": "123"})
         assert error.details["user_id"] == "123"
 
     def test_inheritance(self):
-        """Test NotFoundError inherits from LionError."""
         error = NotFoundError()
         assert isinstance(error, LionError)
 
 
 class TestExistsError:
-    """Tests for ExistsError class."""
-
     def test_default_message(self):
-        """Test ExistsError default message."""
         error = ExistsError()
         assert error.message == "Item already exists"
         assert error.status_code == 409
 
     def test_inheritance(self):
-        """Test ExistsError inherits from LionError."""
         error = ExistsError()
         assert isinstance(error, LionError)
 
 
 class TestObservationError:
-    """Tests for ObservationError class."""
-
     def test_default_message(self):
-        """Test ObservationError default message."""
         error = ObservationError()
         assert error.message == "Observation failed"
         assert error.status_code == 500
 
     def test_inheritance(self):
-        """Test ObservationError inherits from LionError."""
         error = ObservationError()
         assert isinstance(error, LionError)
 
 
 class TestResourceError:
-    """Tests for ResourceError class."""
-
     def test_default_message(self):
-        """Test ResourceError default message."""
         error = ResourceError()
         assert error.message == "Resource error"
         assert error.status_code == 429
 
     def test_inheritance(self):
-        """Test ResourceError inherits from LionError."""
         error = ResourceError()
         assert isinstance(error, LionError)
 
 
 class TestRateLimitError:
-    """Tests for RateLimitError class."""
-
     def test_initialization(self):
-        """Test RateLimitError requires retry_after."""
         error = RateLimitError(retry_after=60.0)
         assert error.retry_after == 60.0
         assert error.message == "Rate limit exceeded"
         assert error.status_code == 429
 
     def test_with_message(self):
-        """Test RateLimitError with custom message."""
         error = RateLimitError(retry_after=30.0, message="Too many requests")
         assert error.message == "Too many requests"
         assert error.retry_after == 30.0
 
     def test_retry_after_value(self):
-        """Test retry_after attribute stores correct value."""
         error = RateLimitError(retry_after=60.0)
         assert error.retry_after == 60.0
         # Retry after can be accessed but is set via __setattr__
@@ -256,90 +212,68 @@ class TestRateLimitError:
         assert error2.retry_after == 120.5
 
     def test_inheritance(self):
-        """Test RateLimitError inherits from LionError."""
         error = RateLimitError(retry_after=60.0)
         assert isinstance(error, LionError)
 
 
 class TestRelationError:
-    """Tests for RelationError class."""
-
     def test_initialization(self):
-        """Test RelationError initialization."""
         error = RelationError("Relation failed")
         assert error.message == "Relation failed"
 
     def test_default_message(self):
-        """Test RelationError uses base default message."""
         error = RelationError()
         assert error.message == "LionAGI error"
 
     def test_inheritance(self):
-        """Test RelationError inherits from LionError."""
         error = RelationError()
         assert isinstance(error, LionError)
 
 
 class TestOperationError:
-    """Tests for OperationError class."""
-
     def test_initialization(self):
-        """Test OperationError initialization."""
         error = OperationError("Operation failed")
         assert error.message == "Operation failed"
 
     def test_default_message(self):
-        """Test OperationError uses base default message."""
         error = OperationError()
         assert error.message == "LionAGI error"
 
     def test_inheritance(self):
-        """Test OperationError inherits from LionError and ValueError."""
         error = OperationError()
         assert isinstance(error, LionError)
         assert isinstance(error, ValueError)
 
 
 class TestExecutionError:
-    """Tests for ExecutionError class."""
-
     def test_initialization(self):
-        """Test ExecutionError initialization."""
         error = ExecutionError("Execution failed")
         assert error.message == "Execution failed"
 
     def test_default_message(self):
-        """Test ExecutionError uses base default message."""
         error = ExecutionError()
         assert error.message == "LionAGI error"
 
     def test_inheritance(self):
-        """Test ExecutionError inherits from LionError and RuntimeError."""
         error = ExecutionError()
         assert isinstance(error, LionError)
         assert isinstance(error, RuntimeError)
 
 
 class TestConfigurationError:
-    """Tests for ConfigurationError class."""
-
     def test_default_message(self):
         error = ConfigurationError()
         assert error.message == "Invalid configuration"
         assert error.status_code == 500
 
     def test_inheritance(self):
-        """Test ConfigurationError inherits from LionError and ValueError."""
         error = ConfigurationError("bad config")
         assert isinstance(error, LionError)
         assert isinstance(error, ValueError)
 
 
 class TestPublicSurface:
-    """Tests for the ``lionagi._errors`` module's declared public surface."""
-
     def test_all_matches_expected(self):
-        """``lionagi._errors.__all__`` contains exactly the declared public names."""
         mod = importlib.import_module("lionagi._errors")
         declared = set(mod.__all__)
         expected = set(_EXPECTED_ALL)
@@ -349,40 +283,30 @@ class TestPublicSurface:
         assert not extra, f"Undocumented names in __all__: {sorted(extra)}"
 
     def test_all_entries_importable(self):
-        """Every name in __all__ must resolve on the module."""
         mod = importlib.import_module("lionagi._errors")
         for name in mod.__all__:
             assert hasattr(mod, name), f"{name!r} declared in __all__ but not defined"
 
     def test_empty_outgoing_content_error_in_all(self):
-        """EmptyOutgoingContentError must be part of the public, catchable surface."""
         mod = importlib.import_module("lionagi._errors")
         assert "EmptyOutgoingContentError" in mod.__all__
 
     def test_empty_outgoing_content_error_inheritance(self):
-        """EmptyOutgoingContentError inherits from LionError and ValueError."""
         error = EmptyOutgoingContentError()
         assert isinstance(error, LionError)
         assert isinstance(error, ValueError)
 
 
 class TestAliases:
-    """Tests for error class aliases."""
-
     def test_item_not_found_alias(self):
-        """Test ItemNotFoundError is alias for NotFoundError."""
         assert ItemNotFoundError is NotFoundError
 
     def test_item_exists_alias(self):
-        """Test ItemExistsError is alias for ExistsError."""
         assert ItemExistsError is ExistsError
 
 
 class TestErrorChaining:
-    """Tests for error chaining and cause preservation."""
-
     def test_chain_multiple_errors(self):
-        """Test chaining multiple errors."""
         original = ValueError("Original")
         wrapped = ValidationError("Validation", cause=original)
         final = OperationError("Operation", cause=wrapped)
@@ -400,17 +324,13 @@ class TestErrorChaining:
 
 
 class TestErrorSlots:
-    """Tests for __slots__ memory efficiency."""
-
     def test_lion_error_has_slots(self):
-        """Test LionError defines slots for memory efficiency."""
         assert hasattr(LionError, "__slots__")
         assert "message" in LionError.__slots__
         assert "details" in LionError.__slots__
         assert "status_code" in LionError.__slots__
 
     def test_subclass_slots(self):
-        """Test subclasses define empty slots."""
         assert hasattr(ValidationError, "__slots__")
         assert ValidationError.__slots__ == ()
         assert hasattr(RateLimitError, "__slots__")
@@ -433,7 +353,6 @@ class TestErrorSlots:
     ],
 )
 def test_error_status_codes(error_class, expected_status):
-    """Test all error classes have correct default status codes."""
     if error_class == RateLimitError:
         error = error_class(retry_after=60.0)
     else:
@@ -457,7 +376,6 @@ def test_error_status_codes(error_class, expected_status):
     ],
 )
 def test_all_errors_are_exceptions(error_class):
-    """Test all error classes are proper exceptions."""
     if error_class == RateLimitError:
         error = error_class(retry_after=60.0)
     else:

--- a/tests/test_import_laziness.py
+++ b/tests/test_import_laziness.py
@@ -3,21 +3,16 @@
 
 """Import-time laziness regression gate.
 
-Guards against a specific regression class: lazy-import work that gets
-silently undone by a new top-level import. ``lionagi/__init__.py`` uses a
-``_LAZY_MAP`` + ``__getattr__`` scheme (see ``lionagi.ln._lazy_init``) so a
-bare ``import lionagi`` stays cheap -- provider SDKs, the CLI command tree,
-and the flow engine are only pulled in once a caller actually touches them.
-
-It is easy for a future change (a stray top-level import added to satisfy a
-type checker, a convenience re-export, a "just import it eagerly" shortcut
-somewhere deep in the import graph) to defeat that laziness without anyone
-noticing, because the symptom only shows up as slower startup and heavier
-memory for every consumer of the package -- it does not raise or fail a
-normal unit test. This module runs ``import lionagi`` in a fresh subprocess
-(so no other test can have already warmed ``sys.modules``) and pins today's
-known-good set of modules and timing, so a regression trips CI immediately
-instead of shipping silently.
+``lionagi/__init__.py`` uses a ``_LAZY_MAP`` + ``__getattr__`` scheme (see
+``lionagi.ln._lazy_init``) so a bare ``import lionagi`` stays cheap --
+provider SDKs, the CLI command tree, and the flow engine load only once a
+caller touches them. A stray top-level import (added for a type checker, a
+convenience re-export, an eager shortcut deep in the import graph) can defeat
+that without failing any normal unit test -- the only symptom is slower
+startup and heavier memory for every consumer. This module runs ``import
+lionagi`` in a fresh subprocess (so no other test has warmed
+``sys.modules``) and pins the known-good module set and timing, so a
+regression trips CI immediately.
 """
 
 from __future__ import annotations

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,8 +10,6 @@ from lionagi.ln import import_module
 
 
 class TestMainImports:
-    """Tests for main lionagi package imports."""
-
     # All exports from lionagi.__all__ (dunders first, then alphabetical).
     EXPECTED_EXPORTS = (
         "__version__",
@@ -78,12 +76,10 @@ class TestMainImports:
     )
 
     def test_all_exports_defined(self):
-        """Test that __all__ is defined and contains expected exports."""
         assert hasattr(lionagi, "__all__")
         assert lionagi.__all__ == self.EXPECTED_EXPORTS
 
     def test_all_exports_alphabetically_sorted(self):
-        """Dunder names first, then all regular names alphabetically sorted."""
         dunder_names = [name for name in lionagi.__all__ if name.startswith("__")]
         regular_names = [name for name in lionagi.__all__ if not name.startswith("__")]
 
@@ -103,18 +99,15 @@ class TestMainImports:
 
     @pytest.mark.parametrize("export_name", EXPECTED_EXPORTS)
     def test_import_all_exports(self, export_name):
-        """Test that each export in __all__ can be imported."""
         obj = import_module("lionagi", import_name=export_name)
         assert obj is not None
 
     @pytest.mark.parametrize("export_name", EXPECTED_EXPORTS)
     def test_getattr_all_exports(self, export_name):
-        """Test that each export can be accessed via getattr."""
         obj = getattr(lionagi, export_name)
         assert obj is not None
 
     def test_lazy_import_caching(self):
-        """Test that lazy imports are cached after first access."""
         # First access
         session1 = lionagi.Session
         # Second access should return cached version
@@ -122,26 +115,22 @@ class TestMainImports:
         assert session1 is session2
 
     def test_invalid_import_raises_attribute_error(self):
-        """Test that importing non-existent attribute raises AttributeError."""
         with pytest.raises(AttributeError, match="has no attribute"):
             _ = lionagi.NonExistentAttribute
 
     def test_pydantic_imports(self):
-        """Test that pydantic re-exports work correctly."""
         from pydantic import BaseModel, Field
 
         assert lionagi.BaseModel is BaseModel
         assert lionagi.Field is Field
 
     def test_ln_import(self):
-        """Test that ln submodule is directly importable."""
         from lionagi import ln
 
         assert hasattr(ln, "import_module")
         assert hasattr(ln, "types")
 
     def test_types_module_import(self):
-        """Test that types module is importable."""
         from lionagi import types
 
         assert types is not None
@@ -156,7 +145,6 @@ class TestMainImports:
         assert len(__version__) > 0
 
     def test_logger_import(self):
-        """Test that logger is importable."""
         from lionagi import logger
 
         assert logger is not None
@@ -164,7 +152,6 @@ class TestMainImports:
         assert hasattr(logger, "error")
 
     def test_data_classes_import(self):
-        """Test that ln.types data classes are importable."""
         from lionagi import DataClass, Params, Undefined, Unset
 
         assert DataClass is not None
@@ -174,10 +161,7 @@ class TestMainImports:
 
 
 class TestLazyLoadingBehavior:
-    """Tests for lazy loading mechanism."""
-
     def test_lazy_loading_on_first_access(self):
-        """Test that objects are loaded on first access."""
         # Access a lazy-loaded object
         branch = lionagi.Branch
         assert branch is not None
@@ -185,14 +169,12 @@ class TestLazyLoadingBehavior:
         assert "Branch" in vars(lionagi)
 
     def test_multiple_imports_same_object(self):
-        """Test that multiple imports return same cached object."""
         obj1 = lionagi.iModel
         obj2 = lionagi.iModel
         obj3 = lionagi.iModel
         assert obj1 is obj2 is obj3
 
     def test_all_protocol_types_importable(self):
-        """Test that all protocol types are importable."""
         from lionagi import Edge, Element, Event, Graph, Node, Pile, Progression
 
         assert Element is not None
@@ -204,14 +186,12 @@ class TestLazyLoadingBehavior:
         assert Event is not None
 
     def test_all_models_importable(self):
-        """Test that all model types are importable."""
         from lionagi import FieldModel, OperableModel
 
         assert FieldModel is not None
         assert OperableModel is not None
 
     def test_all_service_types_importable(self):
-        """Test that all service types are importable."""
         from lionagi import Broadcaster, HookedEvent, HookRegistry, iModel
 
         assert iModel is not None
@@ -220,7 +200,6 @@ class TestLazyLoadingBehavior:
         assert Broadcaster is not None
 
     def test_all_operation_types_importable(self):
-        """Test that all operation types are importable."""
         from lionagi import Builder, Operation, load_mcp_tools
 
         assert Builder is not None
@@ -228,7 +207,6 @@ class TestLazyLoadingBehavior:
         assert load_mcp_tools is not None
 
     def test_all_session_types_importable(self):
-        """Test that all session types are importable."""
         from lionagi import Branch, Session
 
         assert Session is not None

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -5,18 +5,12 @@
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Module-level import — intentionally NOT importorskip.
-#
-# A broken lionagi/__init__.py must FAIL the entire test module, not skip it.
-# Using importorskip here would mask exactly the regressions this file guards
-# against the regressions this file guards.
-# ---------------------------------------------------------------------------
+# Module-level import, intentionally NOT importorskip: a broken
+# lionagi/__init__.py must FAIL the entire test module, not skip it, or the
+# regressions this file guards against would be masked instead of caught.
 import lionagi as _lionagi  # noqa: E402 — must come after pytest import
 
-# ---------------------------------------------------------------------------
 # Sanity: pre-existing symbols — must always pass
-# ---------------------------------------------------------------------------
 
 
 class TestExistingPublicAPI:
@@ -31,7 +25,6 @@ class TestExistingPublicAPI:
         ],
     )
     def test_core_session_symbols_importable(self, symbol: str) -> None:
-        """Branch, Session, iModel must always be importable from lionagi."""
         import lionagi
 
         obj = getattr(lionagi, symbol)
@@ -53,35 +46,27 @@ class TestExistingPublicAPI:
         assert iModel is not None
 
 
-# ---------------------------------------------------------------------------
 # New: LNDL public API
-# ---------------------------------------------------------------------------
 
 
 class TestLndlPublicAPI:
-    """Verify lndl symbols are importable from the top-level lionagi package."""
-
     def test_lndloutput_importable(self) -> None:
-        """LNDLOutput must be importable from lionagi."""
         from lionagi import LNDLOutput  # noqa: F401
 
         assert LNDLOutput is not None
 
     def test_lndlerror_importable(self) -> None:
-        """LNDLError must be importable from lionagi."""
         from lionagi import LNDLError  # noqa: F401
 
         assert LNDLError is not None
 
     def test_get_lndl_system_prompt_importable(self) -> None:
-        """get_lndl_system_prompt must be importable from lionagi."""
         from lionagi import get_lndl_system_prompt  # noqa: F401
 
         assert get_lndl_system_prompt is not None
         assert callable(get_lndl_system_prompt)
 
     def test_get_lndl_system_prompt_returns_string(self) -> None:
-        """get_lndl_system_prompt() must return a non-empty string."""
         from lionagi import get_lndl_system_prompt
 
         result = get_lndl_system_prompt()
@@ -89,7 +74,6 @@ class TestLndlPublicAPI:
         assert len(result) > 0, "get_lndl_system_prompt() returned empty string"
 
     def test_lndloutput_is_correct_type(self) -> None:
-        """LNDLOutput from lionagi must be the canonical dataclass from lionagi.lndl."""
         from lionagi import LNDLOutput
         from lionagi.lndl import LNDLOutput as LNDLOutputDirect
 
@@ -99,7 +83,6 @@ class TestLndlPublicAPI:
         )
 
     def test_lndlerror_is_correct_type(self) -> None:
-        """LNDLError from lionagi must be the canonical exception from lionagi.lndl."""
         from lionagi import LNDLError
         from lionagi.lndl import LNDLError as LNDLErrorDirect
 
@@ -114,7 +97,6 @@ class TestLndlPublicAPI:
         ],
     )
     def test_lndl_symbols_in_all(self, symbol: str) -> None:
-        """Every lndl symbol must appear in lionagi.__all__."""
         import lionagi
 
         assert symbol in lionagi.__all__, (
@@ -123,14 +105,10 @@ class TestLndlPublicAPI:
         )
 
 
-# ---------------------------------------------------------------------------
 # New: Adapters public API
-# ---------------------------------------------------------------------------
 
 
 class TestAdaptersPublicAPI:
-    """Verify adapter symbols are importable from the top-level lionagi package."""
-
     def test_adapterregistry_importable(self) -> None:
         from lionagi import AdapterRegistry  # noqa: F401
 
@@ -157,7 +135,6 @@ class TestAdaptersPublicAPI:
         assert TomlAdapter is not None
 
     def test_adapterregistry_is_correct_type(self) -> None:
-        """AdapterRegistry from lionagi must be the canonical class from lionagi.adapters."""
         from lionagi import AdapterRegistry
         from lionagi.adapters import AdapterRegistry as AdapterRegistryDirect
 
@@ -201,7 +178,6 @@ class TestAdaptersPublicAPI:
         ],
     )
     def test_adapter_symbols_in_all(self, symbol: str) -> None:
-        """Every adapter symbol must appear in lionagi.__all__."""
         import lionagi
 
         assert symbol in lionagi.__all__, (
@@ -210,9 +186,7 @@ class TestAdaptersPublicAPI:
         )
 
 
-# ---------------------------------------------------------------------------
 # __all__ consistency: every symbol in __all__ must be importable
-# ---------------------------------------------------------------------------
 
 
 class TestAllConsistency:
@@ -237,7 +211,6 @@ class TestAllConsistency:
         list(_lionagi.__all__),
     )
     def test_all_symbol_importable_via_getattr(self, symbol: str) -> None:
-        """getattr(lionagi, symbol) must not raise for any symbol in __all__."""
         try:
             getattr(_lionagi, symbol)
         except (AttributeError, ImportError) as exc:
@@ -247,7 +220,6 @@ class TestAllConsistency:
             )
 
     def test_all_sorted_dunders_first(self) -> None:
-        """__all__ must be globally sorted: dunder names first, then regular names alphabetically."""
         import lionagi
 
         dunder_names = [n for n in lionagi.__all__ if n.startswith("__")]
@@ -267,7 +239,6 @@ class TestAllConsistency:
             )
 
     def test_all_no_duplicates(self) -> None:
-        """__all__ must not contain duplicate entries."""
         import lionagi
 
         seen: set[str] = set()
@@ -279,14 +250,10 @@ class TestAllConsistency:
         assert not duplicates, f"Duplicate entries in __all__: {duplicates}"
 
 
-# ---------------------------------------------------------------------------
 # Sub-module import paths (always pass)
-# ---------------------------------------------------------------------------
 
 
 class TestSubmoduleImportPaths:
-    """Verify lndl and adapters sub-packages are reachable via their own import paths."""
-
     def test_lndl_subpackage_importable(self) -> None:
         import lionagi.lndl as lndl_mod
 

--- a/tests/test_run_directory_isolation.py
+++ b/tests/test_run_directory_isolation.py
@@ -1,21 +1,9 @@
 """The suite's run directory must be its own, whatever the environment says.
 
-``tests/conftest.py`` redirects ``LIONAGI_HOME`` to a temporary directory before
-any lionagi import, because ``lionagi._paths`` reads it once at import and
-derives ``RUNS_ROOT`` from it. The redirect is only worth anything if it also
-holds when the invoking environment already sets ``LIONAGI_HOME`` — that is the
-case where a developer's real store, or a persistent CI one, is what the suite
-would otherwise write into, and it is the case a conftest that only fills in a
-missing value gets wrong while looking correct.
-
-Checking that from inside the running suite is not possible: by then the
-redirect has already happened and the original environment is gone. So this
-launches a second pytest with ``LIONAGI_HOME`` pre-set to a disposable
-directory and asks the collected code what it actually bound.
-
-The same subprocess is what makes the cleanup of that root observable: the
-removal runs at interpreter exit, after the session is over, so only a second
-process can watch a first one finish and read what it said on the way out.
+Verifies from the outside (a probe subprocess) that tests/conftest.py's
+LIONAGI_HOME redirect holds even when the invoking environment already sets
+LIONAGI_HOME. See docs/internals/ci.md#run-directory-isolation for the
+mechanism and why a subprocess is required to observe it.
 """
 
 import errno
@@ -35,7 +23,7 @@ _REPO_ROOT = _TESTS_DIR.parent
 
 # Reports the constants as lionagi bound them, from inside a suite that loaded
 # the real tests/conftest.py. Writes rather than prints so the answer survives
-# whatever pytest does to captured output.
+# pytest's output capture.
 _PROBE_TEST = """
 import json
 import os
@@ -57,16 +45,10 @@ def test_report_bound_paths():
 """
 
 
-# Makes the suite's own root impossible to delete, using nothing but file
-# permissions: a process cannot unlink an entry from a directory it may not
-# write to, so ``rmtree`` walks in and stops on the file inside. The reporting
-# path under test is left alone -- stubbing it would only prove the stub ran.
-#
-# The paths are written down BEFORE the lock goes on, and that order is the
-# point: from the instant this directory becomes unremovable there is a file on
-# disk naming it and naming what has to be undone. The caller can then clear it
-# up whatever happens next -- including the cases where the caller never
-# receives a result at all, because this process hung or was killed.
+# Makes the suite's own root impossible to delete via chmod(0o500) on a
+# subdirectory, so rmtree walks in and stops. Paths are written down BEFORE
+# the lock goes on, so a caller can find and clear the root even if this
+# process hangs or is killed before reporting anything else.
 _UNREMOVABLE_PROBE_TEST = """
 import json
 import os
@@ -88,18 +70,13 @@ def test_leave_the_run_directory_unremovable():
 def _undo_lock_and_remove(reported: dict) -> None:
     """Restore whatever a probe made unremovable, then delete its root.
 
-    Works from what the probe wrote down rather than from a live handle, so it
-    can run at any point after the probe locked the directory -- including
-    after a call that raised before it could hand anything back.
-
-    Raises when the root is still there afterwards, naming the path and the
-    error. Attempting the removal and reporting that as having removed it is
-    the failure this whole module exists to catch: a directory nothing can
-    delete stays on disk and the suite says nothing about it. The removal is
-    therefore unguarded -- the error the filesystem gives is the only thing
-    that tells a reader whether to fix permissions or free some disk -- and the
-    path is checked again afterwards, because a removal that raises nothing has
-    still failed if the directory is there.
+    Works from what the probe wrote down rather than a live handle, so it can
+    run even after a call that raised before it could hand anything back. The
+    removal is unguarded (its error is what tells a reader whether to fix
+    permissions or free disk) and the path is checked again afterwards,
+    because a removal that raises nothing has still failed if the directory
+    is there -- reporting otherwise is the exact failure this module exists
+    to catch.
     """
     locked = reported.get("locked")
     if locked and os.path.exists(locked):
@@ -125,17 +102,12 @@ def _undo_lock_and_remove(reported: dict) -> None:
 def _recover_reported_roots(result_paths) -> None:
     """Undo every recorded lock, and name every one that could not be undone.
 
-    Every record gets its turn even when an earlier one fails: the roots are
-    independent, and stopping at the first failure strands the later ones with
-    nothing coming back for them. The failures are collected and raised
-    together at the end, so a partial recovery cannot be read as a complete
-    one -- which is the same defect as a single removal that reports having
-    happened when it did not.
-
-    The per-record guard is deliberately wide. Nothing is swallowed by it:
-    whatever it catches is named in the consolidated failure, and catching
-    narrowly here would let one unexpected error decide that the remaining
-    roots are not worth attempting.
+    Every record gets its turn even when an earlier one fails, since stopping
+    at the first failure would strand the later roots with nothing coming
+    back for them; failures are collected and raised together at the end.
+    The per-record guard is deliberately wide -- whatever it catches is named
+    in the consolidated failure, rather than letting one unexpected error
+    decide the remaining roots aren't worth attempting.
     """
     failures = []
     for result_path in result_paths:
@@ -161,21 +133,14 @@ def _recover_reported_roots(result_paths) -> None:
 def probe(tmp_path):
     """Run one probe pytest and hand back what it reported from inside.
 
-    The probe file lives in a dot-directory under ``tests/`` so that the real
-    conftest applies to it (conftest discovery walks up the filesystem, so a
-    file in ``/tmp`` would collect nothing) while pytest's default
-    ``norecursedirs`` keeps an ordinary suite run from picking it up. Passing
-    the file path explicitly collects it anyway.
-
-    A probe that deliberately makes its own root unremovable writes the paths
-    down before it locks anything, so every root a call could leave behind is
-    named by a file this fixture already knows the location of. Reading those
-    back at teardown is what clears up after a call that never returned -- a
-    timeout, or a result that would not parse -- where the test itself never
-    learns which directory to go and unlock.
-
-    The list of records is hung off the returned callable, so a test can drive
-    the same recovery this teardown runs and read what it reports.
+    The probe file lives in a dot-directory under tests/ so real conftest
+    discovery applies to it (a file under /tmp would collect nothing) while
+    pytest's default norecursedirs keeps an ordinary suite run from picking
+    it up -- passing the file path explicitly collects it anyway. Recorded
+    paths are read back at teardown to clean up after a call that never
+    returned (timeout, unparseable result), and are also hung off the
+    returned callable so a test can drive the same recovery and read what it
+    reports.
     """
 
     reported_paths: list[Path] = []
@@ -282,11 +247,10 @@ def test_lionagi_test_home_is_the_deliberate_way_through(probe, tmp_path):
 def test_a_root_that_cannot_be_removed_is_reported(probe, tmp_path):
     """A cleanup that fails must say which directory it left behind, and why.
 
-    The suite deletes its temporary root from ``atexit``, which is past the
-    point where a failure can be a test result -- so the only thing that can
-    observe one is another process watching this one exit. The probe makes the
-    removal fail through ordinary permissions and this reads the exiting
-    process's stderr.
+    atexit cleanup runs past the point where a failure can be a test result,
+    so only another process watching this one exit can observe it. The probe
+    forces the removal to fail via ordinary permissions; this reads the
+    exiting process's stderr.
     """
     caller_home = tmp_path / "caller-store"
     caller_home.mkdir()
@@ -333,15 +297,11 @@ def test_one_failed_recovery_neither_hides_itself_nor_strands_the_next_root(
 ):
     """Recovering two locked roots, where the first recovery cannot be done.
 
-    Two calls leave two roots that only the recorded paths can find again, and
-    the first is made irrecoverable: its unlocking is turned into a no-op, so
-    the recovery goes on to a removal that cannot succeed. That is the failure
-    worth forcing, because it is the one a removal asked to ignore its errors
-    would carry out and then report as done.
-
-    What has to hold is that the failure reaches the caller naming the root and
-    the reason, and that the second root is recovered anyway -- a loop that
-    stops at the first failure leaves it locked on disk with nothing coming
+    The first root's unlocking is turned into a no-op so its removal cannot
+    succeed -- the failure a removal that ignored its own errors would carry
+    out and report as done. Asserts the failure reaches the caller naming the
+    root and the reason, and that the second root is recovered anyway; a loop
+    that stops at the first failure would leave it locked with nothing coming
     back for it.
     """
     caller_home = tmp_path / "caller-store"
@@ -400,11 +360,10 @@ def test_one_failed_recovery_neither_hides_itself_nor_strands_the_next_root(
 def test_a_removal_that_exhausts_the_stack_is_reported_too(monkeypatch, capsys):
     """Not every way a removal fails comes from the filesystem.
 
-    ``rmtree`` descends recursively, so a tree deep enough exhausts the stack
-    and raises ``RecursionError`` while every directory in it is perfectly
-    removable. The root is still left behind, so it has to reach the same
-    message -- not escape and become an ``atexit`` traceback, which is the one
-    outcome the reporting exists to prevent.
+    rmtree descends recursively, so a tree deep enough exhausts the stack and
+    raises RecursionError while every directory in it is perfectly removable.
+    The root is still left behind, so this must reach the same stderr
+    message rather than escape as an atexit traceback.
     """
     from tests.conftest import _remove_test_home
 
@@ -427,9 +386,9 @@ def test_a_removal_that_exhausts_the_stack_is_reported_too(monkeypatch, capsys):
 def test_a_bug_in_the_removal_is_not_dressed_up_as_a_cleanup_failure(monkeypatch, capsys):
     """Only the filesystem's refusals are turned into a message.
 
-    Calling ``rmtree`` wrongly is a defect in this suite, not a directory the
-    machine would not delete, and reporting it as the latter would send a
-    reader hunting for a root that is not there.
+    Calling rmtree wrongly is a defect in this suite, not a directory the
+    machine would not delete; reporting it as the latter would send a reader
+    hunting for a root that isn't there.
     """
     from tests.conftest import _remove_test_home
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,9 +9,7 @@ import pytest
 
 from lionagi.utils import copy, create_path, is_same_dtype, union_members
 
-# ---------------------------------------------------------------------------
 # create_path rejects backslash and existing file without overwrite
-# ---------------------------------------------------------------------------
 
 
 def test_create_path_rejects_backslash_and_existing_file_without_overwrite(tmp_path):
@@ -55,9 +53,7 @@ def test_create_path_with_extension_arg(tmp_path):
     assert p.stem == "report"
 
 
-# ---------------------------------------------------------------------------
 # copy utility
-# ---------------------------------------------------------------------------
 
 
 def test_copy_deep_returns_independent_copy():
@@ -98,9 +94,7 @@ def test_copy_rejects_non_positive_copy_count():
         copy({"x": []}, num=-1)
 
 
-# ---------------------------------------------------------------------------
 # is_same_dtype — Mapping branch (lines 92-97)
-# ---------------------------------------------------------------------------
 
 
 def test_is_same_dtype_with_mapping_same_types():
@@ -121,9 +115,7 @@ def test_is_same_dtype_list_infers_dtype():
     assert is_same_dtype([1, "two", 3]) is False
 
 
-# ---------------------------------------------------------------------------
 # union_members — lines 131-140 (_unwrap_annotated at 122-124 is exercised too)
-# ---------------------------------------------------------------------------
 
 
 def test_union_members_basic():
@@ -156,9 +148,7 @@ def test_union_members_unwrap_annotated_false():
     assert str in members
 
 
-# ---------------------------------------------------------------------------
 # create_path — time_prefix and random_hash_digits (lines 195-202)
-# ---------------------------------------------------------------------------
 
 
 def test_create_path_timestamp_prefix(tmp_path):

--- a/tests/testing/test_helpers_audit.py
+++ b/tests/testing/test_helpers_audit.py
@@ -7,9 +7,7 @@ import asyncio
 
 import pytest
 
-# ---------------------------------------------------------------------------
 # AsyncTestHelpers Python 3.10 compatibility (no asyncio.timeout)
-# ---------------------------------------------------------------------------
 
 
 class TestAsyncTestHelpersPy310:
@@ -93,9 +91,7 @@ class TestAsyncTestHelpersPy310:
         assert tasks[0].cancelled() or tasks[0].done()
 
 
-# ---------------------------------------------------------------------------
 # TestDataLoader path traversal boundary
-# ---------------------------------------------------------------------------
 
 
 class TestDataLoaderPathBoundary:


### PR DESCRIPTION
Cut docstring/comment narration that restated test bodies or names, collapsed banner-style section dividers, and removed internal issue-number references from tests/scripts/test_ci_hygiene.py comments. Kept regression rationale, invariants, and design-decision history intact. Extracted the run-directory-isolation harness design (conftest.py + test_run_directory _isolation.py) into docs/internals/ci.md rather than leaving it duplicated across test docstrings.

No executable code changed; verified per-file with the AST-equality guardrail before and after ruff format.