### PR TITLE
fix(codex): emit --sandbox workspace-write instead of the removed --full-auto

### DIFF
--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -518,7 +518,10 @@ class CodexCodeRequest(BaseModel):
         if self.bypass_approvals:
             args.append("--dangerously-bypass-approvals-and-sandbox")
         elif self.full_auto:
-            args.append("--full-auto")
+            # Codex 0.147.0 removed `--full-auto`, turning the earlier deprecation
+            # warning into a hard argv error. Its deprecation notice prescribes
+            # `--sandbox workspace-write`, which keeps the same sandbox posture.
+            args.extend(["--sandbox", "workspace-write"])
         else:
             if self.ask_for_approval:
                 args.extend(["-a", self.ask_for_approval])


### PR DESCRIPTION
Codex CLI 0.147.0 removed `--full-auto`, turning a prior deprecation warning into a hard argv error, so every leg requesting it failed before any API call with "unexpected argument '--full-auto' found". The deprecation notice prescribes `--sandbox workspace-write`, which holds the same sandbox posture, so this is a flag rename rather than a change in permissions.

Verified against 0.147.0: the built argv no longer contains `--full-auto` and does contain `--sandbox workspace-write`, and a live leg constructed with `full_auto=True` completes.
