### PR TITLE
fix(studio): use canonical engine runs list route

### DIFF
--- a/apps/studio/frontend/src/lib/api.test.ts
+++ b/apps/studio/frontend/src/lib/api.test.ts
@@ -558,6 +558,39 @@ describe("engine defs API", () => {
   });
 });
 
+describe("engine runs API", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.stubGlobal("window", {
+      ...window,
+      __STUDIO_API_BASE__: undefined,
+      location: { ...window.location, port: "8765", hostname: "localhost", protocol: "http:" },
+    });
+  });
+
+  it("listEngineRuns calls the canonical slash route directly", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        calls.push(url);
+        return Promise.resolve(
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }),
+    );
+
+    const { listEngineRuns } = await import("./api");
+    await listEngineRuns();
+
+    expect(calls).toEqual(["/api/engine-runs/"]);
+  });
+});
+
 // ─── Runs/sessions query construction (Fleet filters, cursor pagination) ─────
 
 describe("runs/sessions query construction", () => {

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -2302,7 +2302,7 @@ export async function listEngineRuns(params?: EngineRunListParams): Promise<Engi
   if (params?.limit != null) query.set("limit", String(params.limit));
   if (params?.offset != null) query.set("offset", String(params.offset));
   const qs = query.toString();
-  return fetchJson<EngineRunSummary[]>(`/api/engine-runs${qs ? `?${qs}` : ""}`);
+  return fetchJson<EngineRunSummary[]>(`/api/engine-runs/${qs ? `?${qs}` : ""}`);
 }
 
 export async function getEngineRun(runId: string): Promise<EngineRunSummary> {

--- a/tests/apps_studio_server/test_engine_runs_api.py
+++ b/tests/apps_studio_server/test_engine_runs_api.py
@@ -195,6 +195,19 @@ async def test_list_endpoint_returns_empty(patched_app):
     assert resp.json() == []
 
 
+async def test_canonical_list_endpoint_does_not_redirect(patched_app):
+    """Hosted clients reach the canonical list route without a redirect hop."""
+    _, _, client = patched_app
+    async with client as ac:
+        resp = await ac.get(
+            "/api/engine-runs/",
+            headers={"Origin": "https://studio.example.com"},
+            follow_redirects=False,
+        )
+    assert resp.status_code == 200
+    assert "location" not in resp.headers
+
+
 async def test_list_endpoint_returns_seeded_rows(patched_app):
     _, db_path, client = patched_app
     rid1 = await _seed_engine_run(db_path, kind="research", started_at=1000.0)


### PR DESCRIPTION
## Summary

- request the canonical `/api/engine-runs/` list route directly from the Studio client
- add an exact client URL regression test
- add a hosted-origin backend guard proving the canonical route returns 200 without a redirect
- leave CORS, authentication, and navigation unchanged

Fixes #3110

## Validation

- observed RED: client requested `/api/engine-runs` instead of `/api/engine-runs/`
- frontend API tests: 47 passed
- backend engine-run API tests: 21 passed
- TypeScript typecheck passed
- ESLint and Prettier passed on changed frontend files
- Ruff check/format passed on the backend test
- pre-commit hooks passed
