### PR TITLE
fix(codex): preserve approval modes via config

### DIFF
--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -496,6 +496,23 @@ class CodexCodeRequest(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def _reject_ambiguous_approval_policy(self):
+        if (
+            self.ask_for_approval
+            and not self.bypass_approvals
+            and not self.full_auto
+            and any(
+                key == "approval_policy" or key.startswith("approval_policy.")
+                for key in self.config_overrides
+            )
+        ):
+            raise ValueError(
+                "ask_for_approval cannot be combined with config_overrides entries "
+                "for approval_policy; choose one approval policy source"
+            )
+        return self
+
     # ── workspace path ────────────────────────────────────────────
 
     def cwd(self) -> Path:
@@ -521,7 +538,14 @@ class CodexCodeRequest(BaseModel):
             args.append("--full-auto")
         else:
             if self.ask_for_approval:
-                args.extend(["-a", self.ask_for_approval])
+                # The config key has the same mode vocabulary as the former CLI
+                # flag and remains available in builds that no longer expose it.
+                args.extend(
+                    [
+                        "-c",
+                        f"approval_policy={toml_override_value(self.ask_for_approval)}",
+                    ]
+                )
             if self.sandbox:
                 args.extend(["-s", self.sandbox])
 

--- a/tests/providers/openai/codex/test_approval_policy.py
+++ b/tests/providers/openai/codex/test_approval_policy.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import toml
+
+from lionagi.providers.openai.codex import CodexCodeRequest
+
+
+def _config_values(args: list[str], key: str) -> list[object]:
+    end = args.index("--") if "--" in args else len(args)
+    values: list[object] = []
+    for index, token in enumerate(args[:end]):
+        if token != "-c" or index + 1 >= end:
+            continue
+        pair = args[index + 1]
+        pair_key, separator, raw = pair.partition("=")
+        if separator and pair_key == key:
+            values.append(toml.loads(f"value = {raw}")["value"])
+    return values
+
+
+@pytest.mark.parametrize("mode", ["untrusted", "on-request", "never"])
+def test_approval_mode_uses_the_equivalent_config_key(mode: str) -> None:
+    args = CodexCodeRequest(prompt="review this", ask_for_approval=mode).as_cmd_args()
+
+    assert _config_values(args, "approval_policy") == [mode]
+    assert "-a" not in args
+    assert "--ask-for-approval" not in args
+
+
+def test_approval_mode_keeps_the_requested_sandbox() -> None:
+    args = CodexCodeRequest(
+        prompt="review this",
+        ask_for_approval="on-request",
+        sandbox="read-only",
+    ).as_cmd_args()
+
+    sandbox_index = args.index("-s")
+    assert args[sandbox_index + 1] == "read-only"
+    assert _config_values(args, "approval_policy") == ["on-request"]
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"approval_policy": "never"},
+        {"approval_policy.granular.rules": False},
+    ],
+)
+def test_approval_mode_rejects_a_second_config_source(override: dict[str, object]) -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "ask_for_approval cannot be combined with config_overrides entries for approval_policy"
+        ),
+    ):
+        CodexCodeRequest(
+            prompt="review this",
+            ask_for_approval="on-request",
+            config_overrides=override,
+        )
+
+
+def test_bypass_still_takes_precedence_over_approval_mode() -> None:
+    with pytest.warns(UserWarning, match="skips ALL approval prompts"):
+        args = CodexCodeRequest(
+            prompt="review this",
+            ask_for_approval="on-request",
+            sandbox="read-only",
+            bypass_approvals=True,
+        ).as_cmd_args()
+
+    assert "--dangerously-bypass-approvals-and-sandbox" in args
+    assert _config_values(args, "approval_policy") == []
+    assert "-s" not in args
+
+
+def test_full_auto_still_takes_precedence_over_approval_mode() -> None:
+    args = CodexCodeRequest(
+        prompt="review this",
+        ask_for_approval="on-request",
+        sandbox="read-only",
+        full_auto=True,
+    ).as_cmd_args()
+
+    assert _config_values(args, "approval_policy") == []
+    assert "-s" not in args
+    assert "--dangerously-bypass-approvals-and-sandbox" not in args


### PR DESCRIPTION
## Why

Codex CLI builds can remove the `-a/--ask-for-approval` convenience flag before LionAGI's provider adapter changes. The existing adapter emitted that flag directly, so affected builds rejected the argv before a provider call.

## What changed

- emit `ask_for_approval` through the documented `approval_policy` config key
- preserve the requested `untrusted`, `on-request`, or `never` mode exactly
- do not map to the semantically different `--approve-for-me` auto-review behavior
- fail fast when callers provide both `ask_for_approval` and a direct or nested `approval_policy` override
- keep bypass, full-auto, and explicit sandbox precedence unchanged

The [official Codex config reference](https://developers.openai.com/codex/config-reference) documents `approval_policy` with the same three values.

Closes #3101

## Validation

- strict RED→GREEN coverage: 8 focused approval-policy tests
- 175 Codex provider, CLI robustness, and path-safety tests passed
- all three config values parsed under local Codex CLI 0.147.0
- Ruff, formatting, pre-commit passed
- Pyright: 0 errors
- merge-tree with #3102 is clean

## Compatibility

Normal callers are unchanged. Callers that supplied two competing approval-policy sources now receive an explicit construction-time error instead of an ambiguous permissions configuration.