### PR TITLE
fix(run): bound idle gaps in early-streaming CLI workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@
 # endpoints (e.g. gemini_code, pi) are unaffected unless liveness_timeout is
 # passed explicitly. 0 disables the watchdog. Default: 120.
 # LIONAGI_WORKER_LIVENESS_TIMEOUT=120
+
+# Seconds an early-streaming CLI worker may stay silent between chunks. The
+# window resets after every chunk; a miss fails with worker.stream_idle and is
+# never retried because partial output may already have been consumed. Buffered
+# endpoints are unaffected unless idle_timeout is passed explicitly. 0 disables
+# the idle watchdog. Default: 300.
+# LIONAGI_WORKER_IDLE_TIMEOUT=300

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1001,7 +1001,7 @@ li agent -c "continue most recent"
 | `LIONAGI_RUN_ID` | When explicitly set for a task-producing child process, reuse the supplied run ID | `cli/_runs.py` |
 | `LIONAGI_HOME` | Override `~/.lionagi/` base dir | `lionagi/utils.py` |
 | `LIONAGI_WORKER_LIVENESS_TIMEOUT` | Seconds `run()` waits for a CLI worker's first stream chunk before retrying once, then raising `WorkerLivenessError`; default `120`, `0` disables. Applied by default only to endpoints that stream output early (`claude_code`, `codex`) — buffered endpoints (`gemini-cli`, `pi`) are unaffected unless `liveness_timeout` is passed explicitly to `run()` | `lionagi/operations/run/run.py` |
-| `LIONAGI_WORKER_IDLE_TIMEOUT` | Maximum silence between chunks from an early-streaming CLI worker; resets per chunk, defaults to `300`, and `0` disables. A miss after partial output raises `WorkerLivenessError` (`worker.stream_idle`) without retry. Buffered endpoints are unaffected unless `idle_timeout` is passed explicitly to `run()` | `lionagi/operations/run/run.py` |
+| `LIONAGI_WORKER_IDLE_TIMEOUT` | Maximum silence between chunks from an early-streaming CLI worker; resets per chunk, defaults to `600`, and `0` disables. A miss after partial output raises `WorkerLivenessError` (`worker.stream_idle`) without retry. Buffered endpoints are unaffected unless `idle_timeout` is passed explicitly to `run()` | `lionagi/operations/run/run.py` |
 | `OPENAI_API_KEY` | OpenAI REST API key (for `iModel`, not for `codex` CLI alias) | `lionagi/config.py` |
 | `ANTHROPIC_API_KEY` | Anthropic REST API key (for `iModel`; `claude` alias uses `claude login` instead) | `lionagi/config.py` |
 | `GEMINI_API_KEY` | Gemini API key (`gemini` provider, not `gemini-code` CLI auth) | `lionagi/config.py` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1001,6 +1001,7 @@ li agent -c "continue most recent"
 | `LIONAGI_RUN_ID` | When explicitly set for a task-producing child process, reuse the supplied run ID | `cli/_runs.py` |
 | `LIONAGI_HOME` | Override `~/.lionagi/` base dir | `lionagi/utils.py` |
 | `LIONAGI_WORKER_LIVENESS_TIMEOUT` | Seconds `run()` waits for a CLI worker's first stream chunk before retrying once, then raising `WorkerLivenessError`; default `120`, `0` disables. Applied by default only to endpoints that stream output early (`claude_code`, `codex`) — buffered endpoints (`gemini-cli`, `pi`) are unaffected unless `liveness_timeout` is passed explicitly to `run()` | `lionagi/operations/run/run.py` |
+| `LIONAGI_WORKER_IDLE_TIMEOUT` | Maximum silence between chunks from an early-streaming CLI worker; resets per chunk, defaults to `300`, and `0` disables. A miss after partial output raises `WorkerLivenessError` (`worker.stream_idle`) without retry. Buffered endpoints are unaffected unless `idle_timeout` is passed explicitly to `run()` | `lionagi/operations/run/run.py` |
 | `OPENAI_API_KEY` | OpenAI REST API key (for `iModel`, not for `codex` CLI alias) | `lionagi/config.py` |
 | `ANTHROPIC_API_KEY` | Anthropic REST API key (for `iModel`; `claude` alias uses `claude login` instead) | `lionagi/config.py` |
 | `GEMINI_API_KEY` | Gemini API key (`gemini` provider, not `gemini-code` CLI auth) | `lionagi/config.py` |

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -100,24 +100,28 @@ the primary error or a secondary one to log and swallow.
 A worker whose subprocess dies at/near spawn (or otherwise produces
 nothing) leaves an operation awaiting a stream chunk that never arrives —
 the leg stays "running" forever and every dependent operation in a flow
-deadlocks behind it. `_stream_with_liveness()` guards the *first* chunk
-only: once any chunk has arrived, the subprocess is alive and the rest of
-the stream is governed solely by `stream_deadline`.
+deadlocks behind it. `_stream_with_liveness()` guards both the *first* chunk
+and the gap between later chunks. The idle window resets after every chunk.
 
 On a first-output miss, the subprocess is retried once with an identical
 invocation. A second miss raises `WorkerLivenessError` so the operation
 transitions to FAILED and releases its dependents, instead of hanging as a
 zombie "running" leg.
 
-`liveness_timeout` of `None`/`<=0` disables the watchdog entirely
-(deterministic/test runs). When the caller's own `stream_deadline` is
-tighter than `liveness_timeout`, the deadline wins and its `TimeoutError` is
-propagated unchanged — not treated as a liveness miss, not retried — since
-the caller asked for that total-stream budget deliberately. The default
-liveness timeout only applies to endpoints declaring
+Once any chunk has escaped the stream, a watchdog miss is not retried: the
+consumer may already have acted on that partial output. Instead it raises
+`WorkerLivenessError` with reason `worker.stream_idle`. The first-output and
+idle windows are configured independently by `liveness_timeout` and
+`idle_timeout`; non-positive values disable their respective window.
+
+When the caller's own `stream_deadline` is tighter than either watchdog
+window, the deadline wins and its `TimeoutError` is propagated unchanged —
+not treated as a liveness miss, not retried — since the caller asked for that
+total-stream budget deliberately. The default watchdogs only apply to endpoints declaring
 `streams_first_output_early`; a buffered transport (e.g. `gemini_code`,
 whose first chunk arrives only once the whole result is in) would otherwise
-have a healthy long call misdiagnosed as a dead worker.
+have a healthy long call misdiagnosed as a dead worker. Explicit per-run
+values remain opt-in overrides for any endpoint.
 
 ## Review engine partial export on deadline
 

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -1261,8 +1261,9 @@ only while its declared target remains trusted, removing it on
 shortly after the subprocess spawns (e.g. an ndjson "system"/"init" event), making a stalled
 first chunk a reliable dead-worker signal. False for transports that buffer all output until
 the run completes, where a slow-but-healthy call is indistinguishable from a dead one until
-the whole result arrives. This flag gates `run.py`'s default liveness watchdog
-(`LIONAGI_WORKER_LIVENESS_TIMEOUT`).
+the whole result arrives. This flag gates `run.py`'s default first-output and
+between-chunk watchdogs (`LIONAGI_WORKER_LIVENESS_TIMEOUT` and
+`LIONAGI_WORKER_IDLE_TIMEOUT`).
 
 ### `connections/endpoint_config.py`
 

--- a/docs/internals/support-libs.md
+++ b/docs/internals/support-libs.md
@@ -73,7 +73,9 @@ then fails loud with `WorkerLivenessError` instead of hanging as a zombie
 "running" leg. `0` disables the watchdog (deterministic / test runs).
 
 `LIONAGI_WORKER_IDLE_TIMEOUT` is the between-chunk idle window for
-early-streaming CLI turns (default 300 seconds). It resets after every chunk.
+early-streaming CLI turns (default 600 seconds). It resets after every chunk.
+The window has to clear the worker's slowest single tool call, not its slowest
+chunk, because a worker emits nothing for the duration of any tool it runs.
 A miss after partial output raises `WorkerLivenessError` with reason
 `worker.stream_idle` without retrying the subprocess. `0` disables this window.
 Buffered transports receive neither default watchdog because silence is their

--- a/docs/internals/support-libs.md
+++ b/docs/internals/support-libs.md
@@ -72,6 +72,13 @@ no first stream chunk within this window is retried once (fresh subprocess),
 then fails loud with `WorkerLivenessError` instead of hanging as a zombie
 "running" leg. `0` disables the watchdog (deterministic / test runs).
 
+`LIONAGI_WORKER_IDLE_TIMEOUT` is the between-chunk idle window for
+early-streaming CLI turns (default 300 seconds). It resets after every chunk.
+A miss after partial output raises `WorkerLivenessError` with reason
+`worker.stream_idle` without retrying the subprocess. `0` disables this window.
+Buffered transports receive neither default watchdog because silence is their
+normal behavior; callers may still opt in with per-run `idle_timeout`.
+
 `LIONAGI_ANTIGRAVITY_PRINT_TIMEOUT` is the Antigravity print-mode subprocess
 cap (seconds). One hour is comfortably above expected caller deadlines while
 retaining a finite subprocess bound; deployments that need another ceiling

--- a/lionagi/config.py
+++ b/lionagi/config.py
@@ -80,8 +80,15 @@ class AppSettings(BaseSettings, frozen=True):
     LIONAGI_WORKER_LIVENESS_TIMEOUT: float = 120.0
 
     # Maximum silence between chunks for early-streaming CLI run() turns;
-    # 0 disables. Longer than first-output because tool calls may be quiet.
-    LIONAGI_WORKER_IDLE_TIMEOUT: float = 300.0
+    # 0 disables. Longer than first-output because a worker is silent for the
+    # whole of any tool call it makes, so this bounds the worker's slowest
+    # single tool call rather than its slowest chunk. Measured against real
+    # transcripts, 96 distinct tool calls exceeded 300s (max 362s) and none
+    # exceeded 600s, so a 300s window would kill live work. The asymmetry
+    # favours generosity: too wide only delays noticing a genuinely hung
+    # worker, while too narrow kills a healthy one mid-tool-call and reports
+    # it as a liveness failure.
+    LIONAGI_WORKER_IDLE_TIMEOUT: float = 600.0
 
     # Antigravity print-mode subprocess cap.
     # See docs/internals/support-libs.md#config-liveness-timeouts

--- a/lionagi/config.py
+++ b/lionagi/config.py
@@ -79,6 +79,10 @@ class AppSettings(BaseSettings, frozen=True):
     # the watchdog. See docs/internals/support-libs.md#config-liveness-timeouts
     LIONAGI_WORKER_LIVENESS_TIMEOUT: float = 120.0
 
+    # Maximum silence between chunks for early-streaming CLI run() turns;
+    # 0 disables. Longer than first-output because tool calls may be quiet.
+    LIONAGI_WORKER_IDLE_TIMEOUT: float = 300.0
+
     # Antigravity print-mode subprocess cap.
     # See docs/internals/support-libs.md#config-liveness-timeouts
     LIONAGI_ANTIGRAVITY_PRINT_TIMEOUT: float = 3600.0

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -122,14 +122,19 @@ async def _stream_with_liveness(
     liveness_timeout: float | None,
     api_call_holder: list,
     max_attempts: int = 2,
+    *,
+    idle_timeout: float | None = None,
 ) -> AsyncGenerator:
-    """Spawn the worker subprocess and enforce a first-output liveness window, retrying once on miss.
+    """Enforce first-output and between-chunk worker liveness windows.
 
     See docs/internals/providers.md#run-worker-liveness-watchdog for the retry
     and deadline-interaction contract. ``api_call_holder`` is a caller-owned
     list; the winning attempt's ``api_call`` is recorded at index 0.
     """
-    if not liveness_timeout or liveness_timeout <= 0:
+    liveness_timeout = liveness_timeout if liveness_timeout and liveness_timeout > 0 else None
+    idle_timeout = idle_timeout if idle_timeout and idle_timeout > 0 else None
+
+    if liveness_timeout is None and idle_timeout is None:
         api_call = await model.create_event(**kw)
         api_call_holder.append(api_call)
         await model.executor.append(api_call)
@@ -158,7 +163,10 @@ async def _stream_with_liveness(
                 )
         return
 
-    for attempt in range(max_attempts):
+    # A first-output miss is safe to retry because nothing escaped the stream.
+    # Once any chunk is yielded, the idle path below always fails immediately.
+    attempts = max_attempts if liveness_timeout is not None else 1
+    for attempt in range(attempts):
         api_call = await model.create_event(**kw)
         await model.executor.append(api_call)
         if api_call_holder:
@@ -169,23 +177,26 @@ async def _stream_with_liveness(
         agen = _stream_with_deadline(model, api_call, stream_deadline)
         stream_iter = agen.__aiter__()
 
-        remaining_to_deadline = (
-            stream_deadline - anyio.current_time() if stream_deadline is not None else None
-        )
-        # Liveness "owns" the timeout only when it's the tighter bound; otherwise
-        # a timeout here is the caller's own stream_deadline, not a liveness miss.
-        is_liveness_boundary = (
-            remaining_to_deadline is None or liveness_timeout < remaining_to_deadline
-        )
-        wait_for = (
-            liveness_timeout
-            if remaining_to_deadline is None
-            else max(0.0, min(liveness_timeout, remaining_to_deadline))
-        )
-
+        is_liveness_boundary = False
         try:
-            with anyio.fail_after(wait_for):
+            if liveness_timeout is None:
                 first_chunk = await stream_iter.__anext__()
+            else:
+                remaining_to_deadline = (
+                    stream_deadline - anyio.current_time() if stream_deadline is not None else None
+                )
+                # Liveness "owns" the timeout only when it's the tighter bound;
+                # otherwise this is the caller's total-stream deadline.
+                is_liveness_boundary = (
+                    remaining_to_deadline is None or liveness_timeout < remaining_to_deadline
+                )
+                wait_for = (
+                    liveness_timeout
+                    if remaining_to_deadline is None
+                    else max(0.0, min(liveness_timeout, remaining_to_deadline))
+                )
+                with anyio.fail_after(wait_for):
+                    first_chunk = await stream_iter.__anext__()
         except StopAsyncIteration:
             # Zero chunks is a legitimate empty completion, not a hang.
             return
@@ -197,12 +208,12 @@ async def _stream_with_liveness(
                     "run: liveness watchdog agen.aclose() raised during cleanup: %r",
                     close_exc,
                 )
-            if not is_liveness_boundary:
+            if liveness_timeout is None or not is_liveness_boundary:
                 raise
-            if attempt == max_attempts - 1:
+            if attempt == attempts - 1:
                 raise WorkerLivenessError(
                     f"worker produced no first stream output within "
-                    f"{liveness_timeout:.0f}s across {max_attempts} attempt(s)",
+                    f"{liveness_timeout:.0f}s across {attempts} attempt(s)",
                     reason="worker.no_first_output",
                 ) from exc
             logger.warning(
@@ -210,7 +221,7 @@ async def _stream_with_liveness(
                 "retrying worker subprocess",
                 liveness_timeout,
                 attempt + 1,
-                max_attempts,
+                attempts,
             )
             continue
         except BaseException:
@@ -237,8 +248,40 @@ async def _stream_with_liveness(
         else:
             try:
                 yield first_chunk
-                async for chunk in agen:
-                    yield chunk
+                if idle_timeout is None:
+                    async for chunk in agen:
+                        yield chunk
+                else:
+                    while True:
+                        remaining_to_deadline = (
+                            stream_deadline - anyio.current_time()
+                            if stream_deadline is not None
+                            else None
+                        )
+                        # As for first output, the tighter bound owns the
+                        # failure. Equality belongs to the overall deadline.
+                        is_idle_boundary = (
+                            remaining_to_deadline is None or idle_timeout < remaining_to_deadline
+                        )
+                        wait_for = (
+                            idle_timeout
+                            if remaining_to_deadline is None
+                            else max(0.0, min(idle_timeout, remaining_to_deadline))
+                        )
+                        try:
+                            with anyio.fail_after(wait_for):
+                                chunk = await stream_iter.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        except TimeoutError as exc:
+                            if not is_idle_boundary:
+                                raise
+                            raise WorkerLivenessError(
+                                f"worker produced no stream output for "
+                                f"{idle_timeout:.0f}s after partial output",
+                                reason="worker.stream_idle",
+                            ) from exc
+                        yield chunk
             finally:
                 # Same explicit-close reasoning as the passthrough branch above.
                 _unwinding = sys.exc_info()[1] is not None
@@ -483,26 +526,40 @@ async def run(
                     default_cap = _app_settings.LIONAGI_ANTIGRAVITY_PRINT_TIMEOUT
                     kw["print_timeout"] = format_print_timeout(default_cap)
 
-        # Explicit values always honored; absent falls back to the configured
-        # default only for endpoints declaring streams_first_output_early — a
-        # buffered transport (e.g. gemini_code) would misdiagnose a healthy long
-        # call as a dead worker under the default watchdog otherwise.
+        # Explicit values always honored; absent values fall back to configured
+        # defaults only for endpoints declaring streams_first_output_early. A
+        # buffered transport would otherwise misdiagnose a healthy long call.
         _liveness_timeout_explicit = "liveness_timeout" in kw
         _liveness_timeout = kw.pop("liveness_timeout", None)
-        if _liveness_timeout is None and not _liveness_timeout_explicit:
-            if getattr(endpoint, "streams_first_output_early", False):
-                from lionagi.config import settings as _app_settings  # noqa: PLC0415
+        _idle_timeout_explicit = "idle_timeout" in kw
+        _idle_timeout = kw.pop("idle_timeout", None)
+        _streams_output_early = getattr(endpoint, "streams_first_output_early", False)
+        if _streams_output_early and (
+            (_liveness_timeout is None and not _liveness_timeout_explicit)
+            or (_idle_timeout is None and not _idle_timeout_explicit)
+        ):
+            from lionagi.config import settings as _app_settings  # noqa: PLC0415
 
+            if _liveness_timeout is None and not _liveness_timeout_explicit:
                 _liveness_timeout = _app_settings.LIONAGI_WORKER_LIVENESS_TIMEOUT
+            if _idle_timeout is None and not _idle_timeout_explicit:
+                _idle_timeout = _app_settings.LIONAGI_WORKER_IDLE_TIMEOUT
         if not isinstance(_liveness_timeout, int | float) or _liveness_timeout <= 0:
             _liveness_timeout = None
+        if not isinstance(_idle_timeout, int | float) or _idle_timeout <= 0:
+            _idle_timeout = None
 
         kw["stream"] = True
         _api_call_holder: list = []
         await emit_api_pre_call(branch, model)
         _api_call_started = True
         stream_gen = _stream_with_liveness(
-            model, kw, _stream_deadline, _liveness_timeout, _api_call_holder
+            model,
+            kw,
+            _stream_deadline,
+            _liveness_timeout,
+            _api_call_holder,
+            idle_timeout=_idle_timeout,
         )
         try:
             try:

--- a/lionagi/providers/_provider_errors.py
+++ b/lionagi/providers/_provider_errors.py
@@ -95,7 +95,7 @@ class ProviderAdapterError(ProviderError):
 
 
 class WorkerLivenessError(ProviderError):
-    """Spawn/hang failure: no first-stream output within the liveness window across every retry, distinct from a classified content error."""
+    """Worker missed a first-output or between-chunk liveness window."""
 
     def __init__(
         self,

--- a/lionagi/service/connections/agentic_endpoint.py
+++ b/lionagi/service/connections/agentic_endpoint.py
@@ -14,7 +14,8 @@ class AgenticEndpoint(Endpoint):
 
     is_cli: ClassVar[bool] = True
 
-    # Early-first-chunk transports gate run.py's liveness watchdog (LIONAGI_WORKER_LIVENESS_TIMEOUT).
+    # Early-streaming transports gate run.py's default first-output and
+    # between-chunk liveness watchdogs.
     # See docs/internals/runtime.md.
     streams_first_output_early: ClassVar[bool] = False
 

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -1131,6 +1131,44 @@ def _make_buffered_delay_cli_model(create_event_calls: list, delay: float):
     return m
 
 
+def _make_scheduled_cli_model(
+    create_event_calls: list,
+    schedule: list[tuple[float, StreamChunk]],
+    *,
+    hang_after: bool = False,
+    streams_first_output_early: bool = True,
+):
+    """A CLI iModel that emits chunks after controlled per-chunk delays."""
+    import anyio
+
+    m = iModel(provider="openai", model="gpt-4.1-mini", api_key="test_key")
+    endpoint_ns = types.SimpleNamespace(
+        is_cli=True,
+        session_id=None,
+        streams_first_output_early=streams_first_output_early,
+        to_dict=lambda: {"type": "fake_cli", "session_id": None},
+    )
+    m.endpoint = endpoint_ns
+    m.streaming_process_func = None
+
+    async def create_event(**kw):
+        create_event_calls.append(kw)
+        return object()
+
+    m.create_event = create_event
+    m.executor = types.SimpleNamespace(append=AsyncMock(), config={})
+
+    async def stream(api_call=None):
+        for delay, chunk in schedule:
+            await anyio.sleep(delay)
+            yield chunk
+        if hang_after:
+            await anyio.sleep(999)
+
+    m.stream = stream
+    return m
+
+
 async def test_run_liveness_watchdog_raises_after_exhausting_retries():
     """A worker that never produces a first chunk is retried once, then
     fails loud with WorkerLivenessError — the operation must be able to
@@ -1342,3 +1380,153 @@ async def test_run_liveness_watchdog_explicit_timeout_enforced_on_buffered_endpo
             pass
 
     assert len(create_event_calls) == 2
+
+
+async def test_run_idle_watchdog_fails_after_partial_output_without_retry(monkeypatch):
+    """A worker that emits once then stalls fails distinctly and is not rerun."""
+    import lionagi.config as config_module
+    from lionagi.providers._provider_errors import WorkerLivenessError
+
+    create_event_calls: list[dict] = []
+    model = _make_scheduled_cli_model(
+        create_event_calls,
+        [(0, StreamChunk(type="text", content="partial"))],
+        hang_after=True,
+    )
+    branch = Branch()
+    branch.chat_model = model
+    fast_settings = config_module.AppSettings(LIONAGI_WORKER_IDLE_TIMEOUT=0.03)
+    monkeypatch.setattr(config_module, "settings", fast_settings)
+
+    with pytest.raises(WorkerLivenessError) as exc_info:
+        await _collect(
+            run(
+                branch,
+                "go",
+                RunParam(
+                    imodel_kw={
+                        "timeout": 0.2,
+                        "liveness_timeout": 0.1,
+                    }
+                ),
+            )
+        )
+
+    assert exc_info.value.reason == "worker.stream_idle"
+    assert len(create_event_calls) == 1
+    assert "idle_timeout" not in create_event_calls[0]
+
+
+async def test_run_idle_watchdog_resets_after_every_chunk():
+    """Total stream time may exceed the idle window when each gap stays below it."""
+    create_event_calls: list[dict] = []
+    model = _make_scheduled_cli_model(
+        create_event_calls,
+        [
+            (0, StreamChunk(type="text", content="a")),
+            (0.03, StreamChunk(type="text", content="b")),
+            (0.03, StreamChunk(type="text", content="c")),
+            (0.03, StreamChunk(type="text", content="d")),
+        ],
+    )
+    branch = Branch()
+    branch.chat_model = model
+
+    results = await _collect(
+        run(
+            branch,
+            "go",
+            RunParam(
+                imodel_kw={
+                    "timeout": 0.5,
+                    "liveness_timeout": 0.1,
+                    "idle_timeout": 0.08,
+                }
+            ),
+        )
+    )
+
+    text_msgs = [r for r in results if isinstance(r, AssistantResponse)]
+    assert [msg.response for msg in text_msgs] == ["abcd"]
+    assert len(create_event_calls) == 1
+    assert "idle_timeout" not in create_event_calls[0]
+
+
+async def test_run_idle_watchdog_yields_to_tighter_overall_deadline():
+    """The caller's total-stream budget retains ownership when it expires first."""
+    from lionagi.providers._provider_errors import WorkerLivenessError
+
+    create_event_calls: list[dict] = []
+    model = _make_scheduled_cli_model(
+        create_event_calls,
+        [(0, StreamChunk(type="text", content="partial"))],
+        hang_after=True,
+    )
+    branch = Branch()
+    branch.chat_model = model
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await _collect(
+            run(
+                branch,
+                "go",
+                RunParam(
+                    imodel_kw={
+                        "timeout": 0.04,
+                        "liveness_timeout": 0.1,
+                        "idle_timeout": 0.2,
+                    }
+                ),
+            )
+        )
+
+    assert not isinstance(exc_info.value, WorkerLivenessError)
+    assert len(create_event_calls) == 1
+    assert "idle_timeout" not in create_event_calls[0]
+
+
+async def test_run_idle_watchdog_allows_normal_completion():
+    """The run-only idle setting is stripped and a healthy stream completes."""
+    create_event_calls: list[dict] = []
+    model = _make_scheduled_cli_model(
+        create_event_calls,
+        [
+            (0, StreamChunk(type="text", content="hello")),
+            (0.01, StreamChunk(type="text", content=" world")),
+        ],
+    )
+    branch = Branch()
+    branch.chat_model = model
+
+    results = await _collect(run(branch, "go", RunParam(imodel_kw={"idle_timeout": 0.1})))
+
+    text_msgs = [r for r in results if isinstance(r, AssistantResponse)]
+    assert [msg.response for msg in text_msgs] == ["hello world"]
+    assert len(create_event_calls) == 1
+    assert "idle_timeout" not in create_event_calls[0]
+
+
+async def test_run_idle_watchdog_default_skips_buffered_endpoint(monkeypatch):
+    """Buffered transports remain exempt from the default mid-stream bound."""
+    import lionagi.config as config_module
+
+    create_event_calls: list[dict] = []
+    model = _make_scheduled_cli_model(
+        create_event_calls,
+        [
+            (0, StreamChunk(type="text", content="buffered")),
+            (0.08, StreamChunk(type="text", content=" result")),
+        ],
+        streams_first_output_early=False,
+    )
+    branch = Branch()
+    branch.chat_model = model
+
+    fast_settings = config_module.AppSettings(LIONAGI_WORKER_IDLE_TIMEOUT=0.02)
+    monkeypatch.setattr(config_module, "settings", fast_settings)
+
+    results = await _collect(run(branch, "go", RunParam()))
+
+    text_msgs = [r for r in results if isinstance(r, AssistantResponse)]
+    assert [msg.response for msg in text_msgs] == ["buffered result"]
+    assert len(create_event_calls) == 1


### PR DESCRIPTION
## Why

The existing liveness watchdog bounded only the first stream chunk. Once a CLI worker emitted anything, it could go silent and retain its slot until the caller's full run deadline.

## What changed

- add a configurable between-chunk idle watchdog for early-streaming CLI workers
- reset the idle window after every emitted chunk
- fail with `worker.stream_idle` without retrying once partial output has escaped
- preserve ownership of a tighter caller-provided overall deadline
- keep buffered transports outside the default watchdog policy
- document `LIONAGI_WORKER_IDLE_TIMEOUT` (300 seconds by default) and per-run `idle_timeout`
- allow non-positive values to disable the idle bound for intentionally long silent work

Closes #3100

## Validation

- strict RED: 4 expected failures / 1 control pass
- GREEN: 112 run, flow-liveness, config, and documentation-contract tests passed
- Ruff check/format passed
- Markdown lint passed
- targeted Pyright: 0 errors
- commit hooks and `git diff --check` passed

## Compatibility

Buffered providers remain exempt. Workloads with legitimate silent tool calls longer than five minutes can raise the environment/per-run value or explicitly disable it. Existing partial-response buffering is unchanged.