### PR TITLE
fix(schedule): distinguish slow request timeouts from unreachable Studio

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -96,6 +96,11 @@ through the scheduler's own resolver, since an echoed cron expression only prove
 survived the trip. Reaching the schedule store is itself a fact that can fail — most of these
 commands are HTTP calls to a running Studio, so an unreachable Studio answers with an explicit
 `unavailable` naming the URL, never an empty list that reads as "there are no schedules".
+A request that exceeds the client deadline remains `unavailable` in the version 1 envelope but
+is qualified as a request timeout, including its elapsed time and configured limit. A timed-out
+mutation has an unknown outcome: the daemon may still commit it, so neither the human nor machine
+client suggests restarting Studio or retries the write automatically; callers should inspect the
+schedule before deciding whether to retry.
 
 ## `orchestrate/` (`li o fanout` / `li o flow`)
 
@@ -360,6 +365,7 @@ has to hold on both routes into teardown — cancellation landing mid-`run_dag()
 landing after `run_dag()` has already returned, inside the `finally` block's
 own drain `gather()` (where that except never runs, so `_dag_cancelled` stays
 `False`) — since only one of those two routes exercises the flag.
+
 ### `_round_records.py` / `_quiescence.py` — proving a manifest round is idle
 
 A manifest round dispatches independent legs as subprocesses, each in its own

--- a/lionagi/cli/machine_schedule.py
+++ b/lionagi/cli/machine_schedule.py
@@ -59,6 +59,7 @@ def _studio(path: str, method: str = "GET", body: dict[str, Any] | None = None) 
         method=method,
         headers={"Content-Type": "application/json"} if data else {},
     )
+    started_at = time.monotonic()
     try:
         with urllib.request.urlopen(request, timeout=STUDIO_TIMEOUT_SECONDS) as response:  # noqa: S310
             raw = response.read()
@@ -66,6 +67,30 @@ def _studio(path: str, method: str = "GET", body: dict[str, Any] | None = None) 
         detail = exc.read().decode(errors="replace")[:2000]
         raise MachineError(_error_kind(exc.code), _http_message(exc.code, detail)) from exc
     except OSError as exc:
+        from lionagi.studio.cli import (
+            _is_schedule_request_timeout,
+            _schedule_request_timeout_message,
+        )
+
+        if _is_schedule_request_timeout(exc):
+            elapsed_seconds = max(0.0, time.monotonic() - started_at)
+            raise MachineError(
+                "unavailable",
+                _schedule_request_timeout_message(
+                    method=method,
+                    url=url,
+                    elapsed_seconds=elapsed_seconds,
+                    limit_seconds=STUDIO_TIMEOUT_SECONDS,
+                ),
+                detail={
+                    "reason": "request_timeout",
+                    "method": method,
+                    "path": f"/api/schedules{path}",
+                    "elapsed_seconds": round(elapsed_seconds, 3),
+                    "limit_seconds": STUDIO_TIMEOUT_SECONDS,
+                    "completion": "unknown",
+                },
+            ) from exc
         raise MachineError(
             "unavailable",
             f"could not reach Studio at {_studio_url()}: {exc}. The schedule store is "

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -741,6 +741,7 @@ def _launch_vite_dev(
 
 
 _warned_api_suffix = False
+_SCHEDULE_API_TIMEOUT_SECONDS = 10.0
 
 
 def _base_url() -> str:
@@ -765,6 +766,22 @@ def _base_url() -> str:
     return f"http://{host}:{port}"
 
 
+def _is_schedule_request_timeout(exc: OSError) -> bool:
+    """Return whether urllib stopped because the request exceeded its deadline."""
+    return isinstance(exc, TimeoutError) or isinstance(getattr(exc, "reason", None), TimeoutError)
+
+
+def _schedule_request_timeout_message(
+    *, method: str, url: str, elapsed_seconds: float, limit_seconds: float
+) -> str:
+    """Describe a timeout without claiming the mutation did not land."""
+    return (
+        f"Studio request {method} {url} timed out "
+        f"(elapsed {elapsed_seconds:.1f}s; limit {limit_seconds:g}s). "
+        "The request may still have completed; verify schedule state before retrying."
+    )
+
+
 def _api(path: str, method: str = "GET", body: dict | None = None) -> Any:
     """Minimal HTTP helper — no extra deps beyond stdlib urllib."""
     import urllib.error
@@ -778,14 +795,27 @@ def _api(path: str, method: str = "GET", body: dict | None = None) -> Any:
         method=method,
         headers={"Content-Type": "application/json"} if data else {},
     )
+    started_at = time.monotonic()
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+        with urllib.request.urlopen(req, timeout=_SCHEDULE_API_TIMEOUT_SECONDS) as resp:  # noqa: S310
             return json.loads(resp.read())
     except urllib.error.HTTPError as exc:
         msg = exc.read().decode(errors="replace")
         print(f"Error {exc.code}: {msg}", file=sys.stderr)
         return None
     except OSError as exc:
+        if _is_schedule_request_timeout(exc):
+            elapsed_seconds = max(0.0, time.monotonic() - started_at)
+            print(
+                _schedule_request_timeout_message(
+                    method=method,
+                    url=url,
+                    elapsed_seconds=elapsed_seconds,
+                    limit_seconds=_SCHEDULE_API_TIMEOUT_SECONDS,
+                ),
+                file=sys.stderr,
+            )
+            return None
         print(
             f"Cannot reach Studio at {_base_url()} — is `li studio` running? ({exc})",
             file=sys.stderr,

--- a/tests/cli/test_schedule_transport_errors.py
+++ b/tests/cli/test_schedule_transport_errors.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Schedule HTTP transport failures preserve the operator-safe distinction."""
+
+from __future__ import annotations
+
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
+
+import pytest
+
+from lionagi.cli.machine import MachineError
+
+
+class _FailingUrlopen:
+    def __init__(self, error: OSError) -> None:
+        self.error = error
+        self.calls: list[tuple[str, str, float]] = []
+
+    def __call__(self, request: urllib.request.Request, *, timeout: float):
+        self.calls.append((request.get_method(), request.full_url, timeout))
+        raise self.error
+
+
+class _SlowStudio(BaseHTTPRequestHandler):
+    requests: list[tuple[str, str]] = []
+
+    def do_DELETE(self) -> None:  # noqa: N802 — stdlib handler API
+        self.requests.append(("DELETE", self.path))
+        time.sleep(0.25)
+
+    def log_message(self, *args: object) -> None:
+        pass
+
+
+def test_human_schedule_transport_keeps_connection_refused_restart_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import lionagi.studio.cli as schedule_cli
+
+    monkeypatch.setenv("LIONAGI_STUDIO_URL", "http://127.0.0.1:8765")
+    urlopen = _FailingUrlopen(urllib.error.URLError(ConnectionRefusedError("connection refused")))
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+
+    assert schedule_cli._api("/") is None
+
+    assert urlopen.calls == [
+        ("GET", "http://127.0.0.1:8765/api/schedules/", 10),
+    ]
+    message = capsys.readouterr().err
+    assert "Cannot reach Studio at http://127.0.0.1:8765" in message
+    assert "is `li studio` running?" in message
+
+
+def test_human_schedule_mutation_timeout_reports_uncertain_completion_once(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import lionagi.studio.cli as schedule_cli
+
+    monkeypatch.setenv("LIONAGI_STUDIO_URL", "http://127.0.0.1:8765")
+    monkeypatch.setattr(
+        schedule_cli,
+        "time",
+        SimpleNamespace(monotonic=iter((100.0, 110.25)).__next__),
+    )
+    urlopen = _FailingUrlopen(TimeoutError("timed out"))
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+
+    assert schedule_cli._api("/sched-1", method="DELETE") is None
+
+    assert urlopen.calls == [
+        ("DELETE", "http://127.0.0.1:8765/api/schedules/sched-1", 10),
+    ]
+    message = capsys.readouterr().err
+    assert "timed out (elapsed 10.2s; limit 10s)" in message
+    assert "may still have completed" in message
+    assert "Cannot reach" not in message
+    assert "`li studio`" not in message
+    assert "restart" not in message.lower()
+
+
+def test_live_but_slow_studio_is_a_timeout_not_an_unreachable_daemon(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import lionagi.studio.cli as schedule_cli
+
+    _SlowStudio.requests = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _SlowStudio)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("LIONAGI_STUDIO_URL", f"http://127.0.0.1:{server.server_port}")
+    monkeypatch.setattr(schedule_cli, "_SCHEDULE_API_TIMEOUT_SECONDS", 0.05)
+
+    try:
+        assert schedule_cli._api("/sched-1", method="DELETE") is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert _SlowStudio.requests == [("DELETE", "/api/schedules/sched-1")]
+    message = capsys.readouterr().err
+    assert "timed out (elapsed " in message
+    assert "; limit 0.05s)" in message
+    assert "may still have completed" in message
+    assert "Cannot reach" not in message
+    assert "`li studio`" not in message
+
+
+def test_machine_schedule_transport_keeps_connection_refused_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import lionagi.cli.machine_schedule as machine_schedule
+
+    monkeypatch.setenv("LIONAGI_STUDIO_URL", "http://127.0.0.1:8765")
+    urlopen = _FailingUrlopen(urllib.error.URLError(ConnectionRefusedError("connection refused")))
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+
+    with pytest.raises(MachineError) as raised:
+        machine_schedule._studio("/")
+
+    assert raised.value.kind == "unavailable"
+    assert "could not reach Studio at http://127.0.0.1:8765" in str(raised.value)
+    assert "nothing was read or written" in str(raised.value)
+    assert raised.value.detail is None
+
+
+def test_machine_schedule_mutation_timeout_is_structured_and_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import lionagi.cli.machine_schedule as machine_schedule
+
+    monkeypatch.setenv("LIONAGI_STUDIO_URL", "http://127.0.0.1:8765")
+    monkeypatch.setattr(
+        machine_schedule,
+        "time",
+        SimpleNamespace(monotonic=iter((200.0, 215.5)).__next__),
+    )
+    urlopen = _FailingUrlopen(urllib.error.URLError(TimeoutError("timed out")))
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+
+    with pytest.raises(MachineError) as raised:
+        machine_schedule._studio("/sched-1/disable", method="POST")
+
+    assert urlopen.calls == [
+        ("POST", "http://127.0.0.1:8765/api/schedules/sched-1/disable", 15.0),
+    ]
+    assert raised.value.kind == "unavailable"
+    message = str(raised.value)
+    assert "timed out (elapsed 15.5s; limit 15s)" in message
+    assert "may still have completed" in message
+    assert "could not reach" not in message
+    assert "nothing was read or written" not in message
+    assert "`li studio`" not in message
+    assert "restart" not in message.lower()
+    assert raised.value.detail == {
+        "reason": "request_timeout",
+        "method": "POST",
+        "path": "/api/schedules/sched-1/disable",
+        "elapsed_seconds": 15.5,
+        "limit_seconds": 15.0,
+        "completion": "unknown",
+    }


### PR DESCRIPTION
## Why

The human and machine schedule transports caught every `OSError` as an unreachable daemon. A request accepted by a healthy Studio that exceeded the client deadline therefore printed the closed-port restart hint, even though a timed-out mutation could still complete.

## What changed

- distinguish direct and `URLError`-wrapped request timeouts from connection-refused/unreachable failures
- report method, URL/path, monotonic elapsed time, and the configured client limit
- remove the restart hint from timeout errors while preserving it for genuinely unreachable Studio
- send timed-out mutations exactly once and state that completion is unknown and may still have landed
- preserve the machine contract-v1 `unavailable` kind while adding structured timeout detail
- document the timeout ambiguity and no-auto-retry safety contract

Closes #3132

## Validation

- strict RED: both closed-port controls passed while both timeout arms failed with the old message
- GREEN: 200 transport, human schedule CLI, route-drift, machine-envelope, and MCP schedule tests passed
- includes a real live-but-slow loopback daemon regression
- Ruff, formatting, changed-file pre-commit hooks, Markdown lint, and `git diff --check` passed
- targeted Pyright: 0 errors

## Scope

This intentionally does not hide or retry the server-side latency in #3131. Urllib cannot reliably distinguish every connect-phase timeout from a response-phase timeout, so the new machine reason is truthfully `request_timeout`; explicit refused/reset errors remain unreachable.