### PR TITLE
fix(flow): give escalation retries unique references

### DIFF
--- a/lionagi/operations/builder.py
+++ b/lionagi/operations/builder.py
@@ -266,10 +266,14 @@ class OperationGraphBuilder:
         return self.graph
 
     def get_node_by_reference(self, reference_id: str):
-        for op in self._operations.values():
-            if op.metadata.get("reference_id") == reference_id:
-                return op
-        return None
+        matches = [
+            op
+            for op in self.graph.internal_nodes.values()
+            if getattr(op, "metadata", {}).get("reference_id") == reference_id
+        ]
+        if len(matches) > 1:
+            raise OperationError(f"Duplicate reference_id {reference_id!r}")
+        return matches[0] if matches else None
 
     def visualize_state(self) -> dict[str, Any]:
         expansions = {}

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -384,19 +384,22 @@ class DependencyAwareExecutor:
             from lionagi.session.signal import NodePaused  # noqa: PLC0415
 
             op_id = str(operation.id)
-            name = operation.metadata.get("reference_id", op_id[:8])
+            name, _ = self._display_name(operation)
             return NodePaused(op_id=op_id, name=name)
 
         self._emit_best_effort(_factory)
 
     def _display_name(self, operation: Operation) -> tuple[str, bool]:
         """Resolve a lifecycle-signal display name before a branch is bound:
-        the authored ``reference_id`` if the caller set one, else the op_id's
-        own 8-char prefix as a last resort. Returns ``(name, is_fallback)`` so
-        callers know whether the name is genuine without re-deriving it from
-        string equality against the op_id prefix (a real name can coincide
-        with that prefix by chance).
+        an explicit ``display_name`` or authored ``reference_id`` if the caller
+        set one, else the op_id's own 8-char prefix as a last resort. Returns
+        ``(name, is_fallback)`` so callers know whether the name is genuine
+        without re-deriving it from string equality against the op_id prefix (a
+        real name can coincide with that prefix by chance).
         """
+        display_name = operation.metadata.get("display_name")
+        if display_name is not None:
+            return display_name, False
         ref_id = operation.metadata.get("reference_id")
         if ref_id is not None:
             return ref_id, False
@@ -667,11 +670,11 @@ class DependencyAwareExecutor:
         if not isinstance(verdict, str) or verdict.strip().lower() != GATE_VERDICT_REJECT:
             return
 
-        ref_id = operation.metadata.get("reference_id", str(operation.id)[:8])
+        display_name, _ = self._display_name(operation)
         self._gate_rejections[operation.id] = {
             "reason_code": SKIP_REASON_UPSTREAM_GATE_REJECT,
             "gate_id": str(operation.id),
-            "gate_name": ref_id,
+            "gate_name": display_name,
         }
 
     async def _check_edge_conditions(self, operation: Operation) -> bool:
@@ -1142,9 +1145,10 @@ class ReactiveExecutor(DependencyAwareExecutor):
             status = "failed"
         else:
             status = "completed"
+        name, _ = self._display_name(node)
         return FlowEvent(
             operation_id=str(node.id),
-            name=node.metadata.get("reference_id", str(node.id)[:8]),
+            name=name,
             status=status,
             result=self.results.get(node.id),
             spawned=node.id in self._spawned_ids,
@@ -1177,7 +1181,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
         reason = getattr(req, "reason", "")
         emitter_id = emitter.id if emitter is not None else None
         op_id = str(emitter_id) if emitter_id is not None else ""
-        name = emitter.metadata.get("reference_id", op_id[:8]) if emitter is not None else ""
+        name = self._display_name(emitter)[0] if emitter is not None else ""
 
         self._emit_node_escalated(op_id, name, reason, route, req)
 
@@ -1195,9 +1199,11 @@ class ReactiveExecutor(DependencyAwareExecutor):
             # node it retries (e.g. mirroring a CLI engine's transcript) — cheaper to
             # carry now than to re-derive `name` from a stale emitter reference later.
             child.metadata["escalated_from_name"] = name
-            # Lifecycle signals prefer reference_id over the operation UUID,
-            # so the retry is readable before its branch has been assigned.
-            child.metadata["reference_id"] = f"{name} escalation retry"
+            # Keep the human label separate from the join key: repeated retries
+            # of the same node share a label but must remain individually
+            # addressable by their own stable operation identity.
+            child.metadata["display_name"] = f"{name} escalation retry"
+            child.metadata["reference_id"] = str(child.id)
             if self._accept_node(child, emitter_id=emitter_id, independent=True):
                 self._escalated_ids.add(emitter_id)
         elif route == "notify":

--- a/tests/operations/test_builder_extended.py
+++ b/tests/operations/test_builder_extended.py
@@ -5,6 +5,7 @@
 
 import pytest
 
+from lionagi._errors import OperationError
 from lionagi.operations.builder import ExpansionStrategy, OperationGraphBuilder
 
 
@@ -62,6 +63,14 @@ class TestOperationGraphBuilderBasics:
         # Test retrieval by reference
         retrieved = builder.get_node_by_reference("ref_1")
         assert retrieved == node
+
+    def test_duplicate_reference_lookup_fails_loudly(self):
+        builder = OperationGraphBuilder()
+        builder.add_operation(operation="chat", node_id="duplicate")
+        builder.add_operation(operation="chat", node_id="duplicate")
+
+        with pytest.raises(OperationError, match="Duplicate reference_id 'duplicate'"):
+            builder.get_node_by_reference("duplicate")
 
     def test_add_operation_with_branch(self):
         """Test adding operation with branch ID."""

--- a/tests/operations/test_escalation_routing.py
+++ b/tests/operations/test_escalation_routing.py
@@ -141,11 +141,48 @@ async def test_escalation_child_carries_readable_name_and_parent_pointer():
         if isinstance(n, Operation) and n.metadata.get("escalated_from") == str(parent_id)
     )
     assert child.metadata["escalated_from_name"] == "cheap"
-    assert child.metadata["reference_id"] == "cheap escalation retry"
+    assert child.metadata["display_name"] == "cheap escalation retry"
+    assert child.metadata["reference_id"] == str(child.id)
     assert (str(child.id), "cheap escalation retry", "queued") in progress_events
     assert len(spawned_signals) == 1
     assert spawned_signals[0].parent_id == child.metadata["escalated_from"] == str(parent_id)
     assert spawned_signals[0].independent is True
+
+
+@pytest.mark.asyncio
+async def test_repeated_escalations_have_unique_retrievable_identity():
+    """Two retries of one node must not collapse onto one join key."""
+
+    async def cheap(instruction: str = "", **kw: Any):
+        if instruction.startswith("[escalation]"):
+            return "completed after retry"
+        return [
+            EscalationRequest(reason="try specialist", context={"route": "higher_tier"}),
+            EscalationRequest(reason="try expert", context={"route": "higher_tier"}),
+        ]
+
+    session = _session(cheap=cheap)
+    builder = OperationGraphBuilder()
+    parent_id = builder.add_operation("cheap", node_id="cheap", instruction="original")
+
+    await flow(session, builder.get_graph(), reactive=True)
+
+    children = [
+        node
+        for node in builder.get_graph().internal_nodes.values()
+        if isinstance(node, Operation) and node.metadata.get("escalated_from") == str(parent_id)
+    ]
+
+    assert len(children) == 2
+    assert {child.metadata["escalated_from"] for child in children} == {str(parent_id)}
+    assert {child.metadata["display_name"] for child in children} == {"cheap escalation retry"}
+
+    reference_ids = [child.metadata["reference_id"] for child in children]
+    assert len(set(reference_ids)) == 2
+    assert all(
+        builder.get_node_by_reference(reference_id) is child
+        for reference_id, child in zip(reference_ids, children, strict=True)
+    )
 
 
 # give_up: signals without re-spawning


### PR DESCRIPTION
## Summary

- assign every escalation retry a UUID-backed join key while retaining the readable retry label separately
- preserve the structured `escalated_from` parent relationship
- make builder lookup include reactive graph nodes and fail loudly on duplicate reference ids
- leave #2924's escalation-edge rewiring out of scope

## Verification

- strict RED→GREEN coverage for repeated escalation and duplicate lookup
- full operations suite: 830 passed, 4 skipped
- Ruff, Pyright, and commit hooks passed

Closes #3137