### PR TITLE
fix(fanout): reject assignment-shaped synthesis

### DIFF
--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
+import json
 import os
+import re
 import time
 
 from lionagi._errors import EmptyOutgoingContentError, LionError
@@ -34,6 +36,7 @@ from ._orchestration import (
     build_worker_branch,
     finalize_orchestration,
     parse_orchestrator_provider,
+    register_branch_hook,
     role_roster,
     setup_orchestration,
     start_live_persist,
@@ -53,6 +56,51 @@ class FanoutPlanError(LionError):
 # exclude it rather than synthesize over a placeholder as if it were content.
 FAILED_WORKER_MARKER = "(worker failed: no output)"
 FAILED_SYNTHESIS_MARKER = "(synthesis failed: no output)"
+
+
+def _is_assignment_shaped_synthesis(value: object) -> bool:
+    """True when the entire response is a planner-style assignment payload."""
+    text = str(value).strip()
+    fenced = re.fullmatch(r"```(?:json)?\s*(.*?)\s*```", text, flags=re.DOTALL)
+    if fenced is not None:
+        text = fenced.group(1)
+    try:
+        payload = json.loads(text)
+    except (TypeError, ValueError):
+        return False
+
+    if isinstance(payload, dict) and isinstance(payload.get("assignments"), list):
+        assignments = payload["assignments"]
+    elif isinstance(payload, list):
+        assignments = payload
+    elif isinstance(payload, dict):
+        assignments = [payload]
+    else:
+        return False
+    return bool(assignments) and all(
+        isinstance(item, dict) and "task" in item and "assignee" in item for item in assignments
+    )
+
+
+async def _fresh_synthesis_branch(env: OrchestrationEnv):
+    """Build a clean synthesizer branch without the planner conversation."""
+    from lionagi.agent import AgentSpec, create_agent
+
+    spec = AgentSpec.compose(
+        "synthesizer",
+        pack=env.pack if env.pack is not None else "default",
+        grant_emissions=False,
+    )
+    branch = await create_agent(
+        spec,
+        load_settings=False,
+        chat_model=env.orc_branch.chat_model.copy(),
+    )
+    branch.name = "synthesis"
+    env.session.include_branches(branch)
+    if env._live_persist:
+        register_branch_hook(env._live_persist, branch)
+    return branch
 
 
 def _parse_worker_pool(workers_str: str | None, *, num_workers: int) -> list[str]:
@@ -478,7 +526,7 @@ async def _run_fanout_inner(
         else:
             warn("No workers ran; there is no output to synthesize.")
     if with_synthesis and contexts:
-        synth_spec = synthesis_model or model_spec
+        synth_spec = synthesis_model or env.default_model_spec
         synth_label = str(parse_model_spec(synth_spec))
 
         progress(f"Phase 3: Synthesis [{synth_label}]...")
@@ -487,9 +535,10 @@ async def _run_fanout_inner(
             synthesis_prompt or f"{SYNTHESIS_INSTRUCTION}\n\nOriginal task: {prompt}"
         )
 
+        synth_branch = await _fresh_synthesis_branch(env)
         synth_node = env.builder.add_operation(
             "operate",
-            branch=env.orc_branch,
+            branch=synth_branch,
             depends_on=fanned_nodes,
             instruction=synth_instruction,
             context=contexts,
@@ -516,6 +565,15 @@ async def _run_fanout_inner(
             synth_text = FAILED_SYNTHESIS_MARKER
         else:
             synth_text = str(synth_res) if synth_res is not None else "(no response)"
+            if _is_assignment_shaped_synthesis(synth_text):
+                failed_ops.add(str(synth_node))
+                if _shared is not None:
+                    _shared["op_failures"] = sorted(failed_ops)
+                warn(
+                    "Synthesis returned a planner assignment instead of an integrated "
+                    "result; marking the synthesis leg failed."
+                )
+                synth_text = FAILED_SYNTHESIS_MARKER
         synthesis_result = {
             "model": synth_label,
             "response": synth_text,

--- a/tests/cli/orchestrate/test_fanout_failure_visibility.py
+++ b/tests/cli/orchestrate/test_fanout_failure_visibility.py
@@ -135,6 +135,33 @@ def _one_fails_one_completes(session):
     return run_dag
 
 
+def _workers_then_synthesis(session, synthesis_response: str):
+    """Complete every worker on pass one and return *synthesis_response* on pass two."""
+    passes: list = []
+
+    async def run_dag(graph, **kwargs):
+        passes.append(graph)
+        nodes = list(graph.internal_nodes.values())
+        if len(passes) == 1:
+            operation_results = {}
+            emits = []
+            for number, node in enumerate(nodes, start=1):
+                response = f"worker {number} result"
+                operation_results[node.id] = response
+                emits.append(_completed(session, node, response))
+            await asyncio.gather(*emits, return_exceptions=True)
+            return {"operation_results": operation_results}
+        synth = nodes[-1]
+        await asyncio.gather(
+            _completed(session, synth, synthesis_response, name="synthesis"),
+            return_exceptions=True,
+        )
+        return {"operation_results": {synth.id: synthesis_response}}
+
+    run_dag.passes = passes
+    return run_dag
+
+
 async def test_a_failed_worker_flips_terminal_status_and_renders_its_marker(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -272,3 +299,83 @@ async def test_a_failed_synthesis_is_marked_as_failed_not_as_empty(
     # And it got there through the engine, whose signal bridge is the only thing
     # that can carry a synthesis failure to the observer above.
     assert len(passes) == 2
+
+
+async def test_assignment_shaped_synthesis_fails_the_run_and_artifact(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    env, run, session = _fanout_env(tmp_path)
+    assignments = [TaskAssignment(task="first", assignee="worker")]
+    assignment_json = (
+        '```json\n{"assignments":[{"task":"write the answer",'
+        '"assignee":"synthesizer","depends_on":[]}]}\n```'
+    )
+    warnings: list[str] = []
+    _wire_fanout(
+        monkeypatch,
+        env,
+        assignments,
+        _workers_then_synthesis(session, assignment_json),
+        warnings=warnings,
+    )
+
+    output, terminal_status = await fanout_module._run_fanout(
+        "codex/model", "work", num_workers=1, with_synthesis=True
+    )
+
+    assert terminal_status == "failed"
+    assert FAILED_SYNTHESIS_MARKER in output
+    assert run.synthesis_path.read_text() == FAILED_SYNTHESIS_MARKER
+    assert any("assignment" in message.lower() for message in warnings)
+
+
+async def test_synthesis_uses_a_fresh_branch_not_the_planner_branch(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    env, _, session = _fanout_env(tmp_path)
+    assignments = [TaskAssignment(task="first", assignee="worker")]
+    _wire_fanout(
+        monkeypatch,
+        env,
+        assignments,
+        _workers_then_synthesis(session, "integrated result"),
+    )
+    synthesis_branches: list[Branch] = []
+    original_add = env.builder.add_operation
+
+    def capture_add(operation, **kwargs):
+        if kwargs.get("instruction") == "integrate these results":
+            synthesis_branches.append(kwargs["branch"])
+        return original_add(operation, **kwargs)
+
+    monkeypatch.setattr(env.builder, "add_operation", capture_add)
+
+    await fanout_module._run_fanout(
+        "codex/model",
+        "work",
+        num_workers=1,
+        with_synthesis=True,
+        synthesis_prompt="integrate these results",
+    )
+
+    assert len(synthesis_branches) == 1
+    assert synthesis_branches[0] is not env.orc_branch
+
+
+async def test_profile_routed_synthesis_label_uses_the_resolved_default_model(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    env, _, session = _fanout_env(tmp_path)
+    assignments = [TaskAssignment(task="first", assignee="worker")]
+    progress_messages: list[str] = []
+    _wire_fanout(
+        monkeypatch,
+        env,
+        assignments,
+        _workers_then_synthesis(session, "integrated result"),
+        progress=progress_messages,
+    )
+
+    await fanout_module._run_fanout("", "work", num_workers=1, with_synthesis=True)
+
+    assert any(message == "Phase 3: Synthesis [codex/model]..." for message in progress_messages)


### PR DESCRIPTION
## Summary

- run Phase 3 synthesis on a fresh synthesizer branch instead of reusing the planner's structured-assignment conversation
- reject pure assignment-shaped JSON as failed synthesis, write the existing failure marker, record an operation failure, and finish the run as failed
- preserve normal prose synthesis behavior
- resolve profile-routed progress labels from the effective default model instead of rendering `Synthesis []`

## Verification

- strict RED→GREEN coverage for assignment JSON reporting completed, planner-branch reuse, and empty profile-routed labels
- focused synthesis module: 7/7 passed
- fanout artifact, fan shape, and live-persistence suites: 94/94 passed
- Ruff, pre-commit, commit hooks, and diff checks passed

Closes #3043