### PR TITLE
fix(studio): bound process liveness fallback

### DIFF
--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sqlite3
 import subprocess
+import threading
 import time
 import uuid
 from collections.abc import Callable
@@ -247,6 +248,13 @@ _PS_SNAPSHOT_CACHE: _PsSnapshotCache | None = None
 # and is shared by every caller.
 _PS_SNAPSHOT_INFLIGHT: dict[asyncio.AbstractEventLoop, asyncio.Task[str]] = {}
 _PS_SNAPSHOT_METRICS: dict[str, int | float | None] | None = None
+# Guards publishing the cache and bumping the counters above. Those are
+# read-modify-write sequences, and the loops that run them live on different
+# OS threads, so comparing timestamps is not enough on its own: two captures
+# can both read the cache before either writes, and then the older one wins by
+# writing last. An asyncio lock would only order coroutines within one loop.
+# Held for a few statements with no I/O and no await inside.
+_PS_SNAPSHOT_PUBLISH_LOCK = threading.Lock()
 
 
 def _ps_snapshot_metrics_state() -> dict[str, int | float | None]:
@@ -285,21 +293,28 @@ async def _capture_ps_snapshot() -> str:
     value = await anyio.to_thread.run_sync(_ps_snapshot)
     duration_ms = (time.perf_counter() - started) * 1000
 
-    metrics = _ps_snapshot_metrics_state()
-    metrics["captures"] = int(metrics["captures"] or 0) + 1
-    metrics["last_scan_duration_ms"] = round(duration_ms, 3)
+    # Compare and publish under the lock as one step. Reading the cache,
+    # deciding, and then writing is three steps, and captures run on different
+    # OS threads: without the lock two of them can both read the old value
+    # before either writes, at which point the one that started earlier
+    # publishes last and its older evidence replaces the newer.
+    with _PS_SNAPSHOT_PUBLISH_LOCK:
+        metrics = _ps_snapshot_metrics_state()
+        metrics["captures"] = int(metrics["captures"] or 0) + 1
+        metrics["last_scan_duration_ms"] = round(duration_ms, 3)
 
-    current = _PS_SNAPSHOT_CACHE
-    if current is not None and current.stored_at > taken_at:
-        # A scan that started later has already published. It is the better
-        # evidence, so it stays in the cache and is what this caller gets too.
-        return current.value
+        current = _PS_SNAPSHOT_CACHE
+        if current is not None and current.stored_at > taken_at:
+            # A scan that started later has already published. It is the
+            # better evidence, so it stays in the cache and is what this
+            # caller gets too.
+            return current.value
 
-    _PS_SNAPSHOT_CACHE = _PsSnapshotCache(
-        value=value,
-        stored_at=taken_at,
-        duration_ms=duration_ms,
-    )
+        _PS_SNAPSHOT_CACHE = _PsSnapshotCache(
+            value=value,
+            stored_at=taken_at,
+            duration_ms=duration_ms,
+        )
     return value
 
 

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -238,7 +238,11 @@ class _PsSnapshotCache(NamedTuple):
 
 
 _PS_SNAPSHOT_CACHE: _PsSnapshotCache | None = None
-_PS_SNAPSHOT_INFLIGHT: asyncio.Task[str] | None = None
+# The in-flight capture is stored with the loop that owns it. A Task belongs to
+# the loop that created it, so a caller on a different loop cannot await this
+# one -- see cached_ps_snapshot. The cached value above carries no such
+# affinity and is shared by every caller.
+_PS_SNAPSHOT_INFLIGHT: tuple[asyncio.AbstractEventLoop, asyncio.Task[str]] | None = None
 _PS_SNAPSHOT_METRICS: dict[str, int | float | None] | None = None
 
 
@@ -284,20 +288,35 @@ async def cached_ps_snapshot() -> str:
         metrics["cache_hits"] = int(metrics["cache_hits"] or 0) + 1
         return cached.value
 
-    task = _PS_SNAPSHOT_INFLIGHT
-    if task is None or task.done():
+    loop = asyncio.get_running_loop()
+    inflight = _PS_SNAPSHOT_INFLIGHT
+    task: asyncio.Task[str] | None = None
+    if inflight is not None:
+        owner, pending = inflight
+        # Singleflight is per event loop, deliberately. Awaiting a Task owned by
+        # another loop raises rather than sharing its result, so a caller on a
+        # second loop starts its own capture instead of failing. Two loops in
+        # one process is the exception (a legacy caller running its own loop
+        # beside the serving one), and one extra `ps` there beats a
+        # RuntimeError; within a loop this still collapses to a single capture.
+        if owner is loop and not pending.done():
+            task = pending
+            metrics = _ps_snapshot_metrics_state()
+            metrics["singleflight_hits"] = int(metrics["singleflight_hits"] or 0) + 1
+
+    if task is None:
         task = asyncio.create_task(_capture_ps_snapshot())
-        _PS_SNAPSHOT_INFLIGHT = task
-    else:
-        metrics = _ps_snapshot_metrics_state()
-        metrics["singleflight_hits"] = int(metrics["singleflight_hits"] or 0) + 1
+        _PS_SNAPSHOT_INFLIGHT = (loop, task)
 
     try:
         # One cancelled request must not cancel the shared capture underneath
         # other viewers that are already awaiting it.
         return await asyncio.shield(task)
     finally:
-        if task.done() and _PS_SNAPSHOT_INFLIGHT is task:
+        current = _PS_SNAPSHOT_INFLIGHT
+        # Clear only our own entry: a capture started by another loop after
+        # ours must not be dropped by this one's cleanup.
+        if current is not None and current[1] is task and task.done():
             _PS_SNAPSHOT_INFLIGHT = None
 
 

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -242,9 +242,10 @@ class _PsSnapshotCache(NamedTuple):
     # here, and roughly 15% of back-to-back reads return the same value. Two
     # captures starting inside one tick would compare equal, the `>` test would
     # not hold, and the earlier one would publish over the later one's evidence.
-    # A counter handed out under the publish lock is strictly increasing by
+    # A counter handed out under its own lock is strictly increasing by
     # construction and carries no clock dependency at all. `stored_at` is kept
-    # because the TTL is a real duration; it just no longer decides ordering.
+    # because the TTL is a real duration; it just no longer decides ordering,
+    # which is why it is read at publication rather than at scan start.
     sequence: int
 
 
@@ -293,19 +294,22 @@ async def _capture_ps_snapshot() -> str:
     Captures on different loops overlap, and they do not finish in the order
     they started: a scan that began earlier can return later. Publishing by
     arrival would let that older scan replace newer evidence, so a process
-    that appears only in the newer snapshot resolves as absent. Stamping at
-    completion would compound it, since the older data would then carry the
-    later timestamp and outlive the newer snapshot in the TTL.
+    that appears only in the newer snapshot resolves as absent. So a capture
+    claims a start-order number up front, and publishes only if nothing that
+    started later has published already.
 
-    So a snapshot is stamped with when its own scan began, and it is
-    published only if nothing newer has been published already. Stamping at
-    the start also shortens the effective TTL by the scan's duration, which
-    is the safe direction for a cache that answers liveness questions.
+    The TTL clock is read at publication instead, because that is the only
+    thing ``stored_at`` decides now. Reading it at the start would charge the
+    scan's own duration against a one-second lifetime: a scan slower than
+    that would publish an entry already expired, every later caller would
+    miss, and each would launch a scan of its own. That happens exactly under
+    the load that makes scans slow, which is when the cache has to work.
+    Nothing is lost by moving it, because the start-order number, not this
+    timestamp, is what keeps an older scan from replacing a newer one.
     """
     global _PS_SNAPSHOT_CACHE
 
     started = time.perf_counter()
-    taken_at = time.monotonic()
     # Claimed before the scan, so it orders captures by when they STARTED,
     # which is the ordering this cache publishes by. Taking it at publish time
     # instead would order by arrival and reintroduce exactly the staleness the
@@ -336,7 +340,10 @@ async def _capture_ps_snapshot() -> str:
 
         _PS_SNAPSHOT_CACHE = _PsSnapshotCache(
             value=value,
-            stored_at=taken_at,
+            # Read here, past the ordering guard above, so the TTL measures how
+            # long this value has been available rather than how long ago its
+            # scan set off. See the docstring.
+            stored_at=time.monotonic(),
             duration_ms=duration_ms,
             sequence=sequence,
         )

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -236,6 +236,16 @@ class _PsSnapshotCache(NamedTuple):
     value: str
     stored_at: float
     duration_ms: float
+    # Start order as a counter rather than as a clock reading. Publication has
+    # to know which of two captures STARTED later, and a timestamp cannot
+    # answer that at this granularity: time.monotonic() resolves to about 42ns
+    # here, and roughly 15% of back-to-back reads return the same value. Two
+    # captures starting inside one tick would compare equal, the `>` test would
+    # not hold, and the earlier one would publish over the later one's evidence.
+    # A counter handed out under the publish lock is strictly increasing by
+    # construction and carries no clock dependency at all. `stored_at` is kept
+    # because the TTL is a real duration; it just no longer decides ordering.
+    sequence: int
 
 
 _PS_SNAPSHOT_CACHE: _PsSnapshotCache | None = None
@@ -255,6 +265,12 @@ _PS_SNAPSHOT_METRICS: dict[str, int | float | None] | None = None
 # writing last. An asyncio lock would only order coroutines within one loop.
 # Held for a few statements with no I/O and no await inside.
 _PS_SNAPSHOT_PUBLISH_LOCK = threading.Lock()
+# Start order for captures, handed out at scan start. See _PsSnapshotCache.sequence.
+# Its own lock rather than the publish lock: the two guard different things, and
+# sharing one would make a capture that is mid-publish block unrelated captures
+# from even starting.
+_PS_SNAPSHOT_SEQUENCE_LOCK = threading.Lock()
+_PS_SNAPSHOT_SEQUENCE = 0
 
 
 def _ps_snapshot_metrics_state() -> dict[str, int | float | None]:
@@ -290,6 +306,14 @@ async def _capture_ps_snapshot() -> str:
 
     started = time.perf_counter()
     taken_at = time.monotonic()
+    # Claimed before the scan, so it orders captures by when they STARTED,
+    # which is the ordering this cache publishes by. Taking it at publish time
+    # instead would order by arrival and reintroduce exactly the staleness the
+    # comparison below exists to prevent.
+    with _PS_SNAPSHOT_SEQUENCE_LOCK:
+        global _PS_SNAPSHOT_SEQUENCE
+        _PS_SNAPSHOT_SEQUENCE += 1
+        sequence = _PS_SNAPSHOT_SEQUENCE
     value = await anyio.to_thread.run_sync(_ps_snapshot)
     duration_ms = (time.perf_counter() - started) * 1000
 
@@ -304,7 +328,7 @@ async def _capture_ps_snapshot() -> str:
         metrics["last_scan_duration_ms"] = round(duration_ms, 3)
 
         current = _PS_SNAPSHOT_CACHE
-        if current is not None and current.stored_at > taken_at:
+        if current is not None and current.sequence > sequence:
             # A scan that started later has already published. It is the
             # better evidence, so it stays in the cache and is what this
             # caller gets too.
@@ -314,6 +338,7 @@ async def _capture_ps_snapshot() -> str:
             value=value,
             stored_at=taken_at,
             duration_ms=duration_ms,
+            sequence=sequence,
         )
     return value
 

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -238,11 +238,14 @@ class _PsSnapshotCache(NamedTuple):
 
 
 _PS_SNAPSHOT_CACHE: _PsSnapshotCache | None = None
-# The in-flight capture is stored with the loop that owns it. A Task belongs to
+# In-flight captures, keyed by the loop that owns each one. A Task belongs to
 # the loop that created it, so a caller on a different loop cannot await this
-# one -- see cached_ps_snapshot. The cached value above carries no such
-# affinity and is shared by every caller.
-_PS_SNAPSHOT_INFLIGHT: tuple[asyncio.AbstractEventLoop, asyncio.Task[str]] | None = None
+# one -- see cached_ps_snapshot. One slot per loop rather than one slot in
+# total: with a single slot, a third loop's entry evicted the second's, and the
+# evicted loop's next caller started a duplicate capture instead of joining the
+# one already running for it. The cached value above carries no such affinity
+# and is shared by every caller.
+_PS_SNAPSHOT_INFLIGHT: dict[asyncio.AbstractEventLoop, asyncio.Task[str]] = {}
 _PS_SNAPSHOT_METRICS: dict[str, int | float | None] | None = None
 
 
@@ -261,27 +264,47 @@ def _ps_snapshot_metrics_state() -> dict[str, int | float | None]:
 
 
 async def _capture_ps_snapshot() -> str:
-    """Capture once off-loop and publish the cache before waking waiters."""
+    """Capture once off-loop and publish the cache before waking waiters.
+
+    Captures on different loops overlap, and they do not finish in the order
+    they started: a scan that began earlier can return later. Publishing by
+    arrival would let that older scan replace newer evidence, so a process
+    that appears only in the newer snapshot resolves as absent. Stamping at
+    completion would compound it, since the older data would then carry the
+    later timestamp and outlive the newer snapshot in the TTL.
+
+    So a snapshot is stamped with when its own scan began, and it is
+    published only if nothing newer has been published already. Stamping at
+    the start also shortens the effective TTL by the scan's duration, which
+    is the safe direction for a cache that answers liveness questions.
+    """
     global _PS_SNAPSHOT_CACHE
 
     started = time.perf_counter()
+    taken_at = time.monotonic()
     value = await anyio.to_thread.run_sync(_ps_snapshot)
     duration_ms = (time.perf_counter() - started) * 1000
-    _PS_SNAPSHOT_CACHE = _PsSnapshotCache(
-        value=value,
-        stored_at=time.monotonic(),
-        duration_ms=duration_ms,
-    )
+
     metrics = _ps_snapshot_metrics_state()
     metrics["captures"] = int(metrics["captures"] or 0) + 1
     metrics["last_scan_duration_ms"] = round(duration_ms, 3)
+
+    current = _PS_SNAPSHOT_CACHE
+    if current is not None and current.stored_at > taken_at:
+        # A scan that started later has already published. It is the better
+        # evidence, so it stays in the cache and is what this caller gets too.
+        return current.value
+
+    _PS_SNAPSHOT_CACHE = _PsSnapshotCache(
+        value=value,
+        stored_at=taken_at,
+        duration_ms=duration_ms,
+    )
     return value
 
 
 async def cached_ps_snapshot() -> str:
     """Return a short-TTL process snapshot with async singleflight refresh."""
-    global _PS_SNAPSHOT_INFLIGHT
-
     cached = _PS_SNAPSHOT_CACHE
     if cached is not None and time.monotonic() - cached.stored_at < PS_SNAPSHOT_TTL_SECONDS:
         metrics = _ps_snapshot_metrics_state()
@@ -289,35 +312,30 @@ async def cached_ps_snapshot() -> str:
         return cached.value
 
     loop = asyncio.get_running_loop()
-    inflight = _PS_SNAPSHOT_INFLIGHT
-    task: asyncio.Task[str] | None = None
-    if inflight is not None:
-        owner, pending = inflight
-        # Singleflight is per event loop, deliberately. Awaiting a Task owned by
-        # another loop raises rather than sharing its result, so a caller on a
-        # second loop starts its own capture instead of failing. Two loops in
-        # one process is the exception (a legacy caller running its own loop
-        # beside the serving one), and one extra `ps` there beats a
-        # RuntimeError; within a loop this still collapses to a single capture.
-        if owner is loop and not pending.done():
-            task = pending
-            metrics = _ps_snapshot_metrics_state()
-            metrics["singleflight_hits"] = int(metrics["singleflight_hits"] or 0) + 1
-
-    if task is None:
+    # Singleflight is per event loop, deliberately. Awaiting a Task owned by
+    # another loop raises rather than sharing its result, so a caller on a
+    # second loop starts its own capture instead of failing. Two loops in one
+    # process is the exception (a legacy caller running its own loop beside
+    # the serving one), and one extra `ps` there beats a RuntimeError; within
+    # a loop this collapses to a single capture however many loops are live.
+    pending = _PS_SNAPSHOT_INFLIGHT.get(loop)
+    if pending is not None and not pending.done():
+        task = pending
+        metrics = _ps_snapshot_metrics_state()
+        metrics["singleflight_hits"] = int(metrics["singleflight_hits"] or 0) + 1
+    else:
         task = asyncio.create_task(_capture_ps_snapshot())
-        _PS_SNAPSHOT_INFLIGHT = (loop, task)
+        _PS_SNAPSHOT_INFLIGHT[loop] = task
 
     try:
         # One cancelled request must not cancel the shared capture underneath
         # other viewers that are already awaiting it.
         return await asyncio.shield(task)
     finally:
-        current = _PS_SNAPSHOT_INFLIGHT
-        # Clear only our own entry: a capture started by another loop after
-        # ours must not be dropped by this one's cleanup.
-        if current is not None and current[1] is task and task.done():
-            _PS_SNAPSHOT_INFLIGHT = None
+        # Clear only our own entry: a capture started on this loop after ours
+        # must not be dropped by this one's cleanup.
+        if _PS_SNAPSHOT_INFLIGHT.get(loop) is task and task.done():
+            del _PS_SNAPSHOT_INFLIGHT[loop]
 
 
 # Process start-time comparison tolerance (clock-tick rounding).

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -10,6 +11,7 @@ import sqlite3
 import subprocess
 import time
 import uuid
+from collections.abc import Callable
 from functools import partial
 from pathlib import Path
 from typing import Any, Literal, NamedTuple
@@ -221,6 +223,84 @@ def _ps_snapshot() -> str:
         return ""
 
 
+# The command-table fallback exists for imported and legacy sessions that do
+# not carry a targeted process identity.  It is host-wide work, so nearby
+# requests share a very short-lived answer.  The value is deliberately short:
+# this cache is a display/diagnostic optimization, never evidence used to send
+# a signal to a process.
+PS_SNAPSHOT_TTL_SECONDS = 1.0
+
+
+class _PsSnapshotCache(NamedTuple):
+    value: str
+    stored_at: float
+    duration_ms: float
+
+
+_PS_SNAPSHOT_CACHE: _PsSnapshotCache | None = None
+_PS_SNAPSHOT_INFLIGHT: asyncio.Task[str] | None = None
+_PS_SNAPSHOT_METRICS: dict[str, int | float | None] | None = None
+
+
+def _ps_snapshot_metrics_state() -> dict[str, int | float | None]:
+    global _PS_SNAPSHOT_METRICS
+    if _PS_SNAPSHOT_METRICS is None:
+        _PS_SNAPSHOT_METRICS = {
+            "captures": 0,
+            "cache_hits": 0,
+            "singleflight_hits": 0,
+            "identity_resolved": 0,
+            "fallback_checks": 0,
+            "last_scan_duration_ms": None,
+        }
+    return _PS_SNAPSHOT_METRICS
+
+
+async def _capture_ps_snapshot() -> str:
+    """Capture once off-loop and publish the cache before waking waiters."""
+    global _PS_SNAPSHOT_CACHE
+
+    started = time.perf_counter()
+    value = await anyio.to_thread.run_sync(_ps_snapshot)
+    duration_ms = (time.perf_counter() - started) * 1000
+    _PS_SNAPSHOT_CACHE = _PsSnapshotCache(
+        value=value,
+        stored_at=time.monotonic(),
+        duration_ms=duration_ms,
+    )
+    metrics = _ps_snapshot_metrics_state()
+    metrics["captures"] = int(metrics["captures"] or 0) + 1
+    metrics["last_scan_duration_ms"] = round(duration_ms, 3)
+    return value
+
+
+async def cached_ps_snapshot() -> str:
+    """Return a short-TTL process snapshot with async singleflight refresh."""
+    global _PS_SNAPSHOT_INFLIGHT
+
+    cached = _PS_SNAPSHOT_CACHE
+    if cached is not None and time.monotonic() - cached.stored_at < PS_SNAPSHOT_TTL_SECONDS:
+        metrics = _ps_snapshot_metrics_state()
+        metrics["cache_hits"] = int(metrics["cache_hits"] or 0) + 1
+        return cached.value
+
+    task = _PS_SNAPSHOT_INFLIGHT
+    if task is None or task.done():
+        task = asyncio.create_task(_capture_ps_snapshot())
+        _PS_SNAPSHOT_INFLIGHT = task
+    else:
+        metrics = _ps_snapshot_metrics_state()
+        metrics["singleflight_hits"] = int(metrics["singleflight_hits"] or 0) + 1
+
+    try:
+        # One cancelled request must not cancel the shared capture underneath
+        # other viewers that are already awaiting it.
+        return await asyncio.shield(task)
+    finally:
+        if task.done() and _PS_SNAPSHOT_INFLIGHT is task:
+            _PS_SNAPSHOT_INFLIGHT = None
+
+
 # Process start-time comparison tolerance (clock-tick rounding).
 _PID_CREATE_TIME_TOLERANCE = 1.0
 
@@ -288,6 +368,57 @@ def process_liveness(
     if session_id and session_id in snapshot:
         return True
     return None
+
+
+async def _resolve_process_liveness_probe_with_snapshot(
+    probe: Callable[[str], bool | None],
+) -> tuple[bool | None, str]:
+    """Resolve liveness and return the fallback evidence used for sync classifiers."""
+    targeted = probe("")
+    metrics = _ps_snapshot_metrics_state()
+    if targeted is not None:
+        metrics["identity_resolved"] = int(metrics["identity_resolved"] or 0) + 1
+        return targeted, ""
+
+    metrics["fallback_checks"] = int(metrics["fallback_checks"] or 0) + 1
+    snapshot = await cached_ps_snapshot()
+    return probe(snapshot), snapshot
+
+
+async def resolve_process_liveness_probe(
+    probe: Callable[[str], bool | None],
+) -> bool | None:
+    """Apply targeted-first fallback semantics through a caller-owned probe."""
+    resolved, _snapshot = await _resolve_process_liveness_probe_with_snapshot(probe)
+    return resolved
+
+
+async def _resolve_process_liveness_with_snapshot(
+    session: dict[str, Any],
+    artifacts_path: Path | None,
+) -> tuple[bool | None, str]:
+    return await _resolve_process_liveness_probe_with_snapshot(
+        lambda snapshot: process_liveness(session, artifacts_path, ps_snapshot=snapshot)
+    )
+
+
+async def resolve_process_liveness(
+    session: dict[str, Any],
+    artifacts_path: Path | None,
+) -> bool | None:
+    """Prefer targeted identity; share an off-loop host scan only for legacy rows."""
+    resolved, _snapshot = await _resolve_process_liveness_with_snapshot(session, artifacts_path)
+    return resolved
+
+
+def process_snapshot_diagnostics() -> dict[str, int | float | None]:
+    """Observable coverage and capture cost for the legacy liveness fallback."""
+    metrics = dict(_ps_snapshot_metrics_state())
+    cached = _PS_SNAPSHOT_CACHE
+    metrics["cache_age_ms"] = (
+        round((time.monotonic() - cached.stored_at) * 1000, 3) if cached is not None else None
+    )
+    return metrics
 
 
 def _artifacts_path(row: Any) -> Path | None:
@@ -521,14 +652,14 @@ async def list_phantom_sessions(*, stale_hours: float = 1.0) -> list[dict[str, A
             """
         )
         rows = await cur.fetchall()
-    snapshot: str | None = None
     # One scan, one answer per artifact root: sessions repeat their roots
     # heavily, and the walk is the expensive part.
     lock_cache: dict[tuple[str, float], _ScanResult] = {}
     lock_budget = _ScanBudget()
     for row in rows:
-        if snapshot is None:
-            snapshot = _ps_snapshot()
+        artifacts = _artifacts_path(row)
+        session = {"id": row["id"], "node_metadata": row["node_metadata"]}
+        _process_alive, snapshot = await _resolve_process_liveness_with_snapshot(session, artifacts)
         # Classification stats an artifact tree and may walk it. Both are
         # synchronous filesystem work, and this coroutine is the one serving
         # every other request while it runs.
@@ -612,6 +743,7 @@ async def health_report() -> dict[str, Any]:
         return {
             "sessions": {"total": 0, "by_status": {}, "by_health": {}, "unhealthy": []},
             "db": db_health(),
+            "process_snapshot": process_snapshot_diagnostics(),
             "scheduler_timezone": scheduler_timezone_report(),
             "code_identity": await _code_identity_report(),
             "diagnostic_run_at": now_utc().isoformat(),
@@ -658,7 +790,6 @@ async def health_report() -> dict[str, Any]:
     by_status: Counter[str] = Counter()
     by_health: Counter[str] = Counter()
     unhealthy: list[dict[str, Any]] = []
-    snapshot: str | None = None
     # One scan, one answer per artifact root: sessions repeat their roots
     # heavily, and the walk is the expensive part.
     lock_cache: dict[tuple[str, float], _ScanResult] = {}
@@ -698,9 +829,7 @@ async def health_report() -> dict[str, Any]:
                 lock_scan_truncated += 1
 
         if status == "running":
-            if snapshot is None:
-                snapshot = _ps_snapshot()
-            process_alive = process_liveness(sess, artifacts, snapshot)
+            process_alive = await resolve_process_liveness(sess, artifacts)
         else:
             process_alive = False
 
@@ -769,6 +898,7 @@ async def health_report() -> dict[str, Any]:
             "unhealthy": unhealthy,
         },
         "db": db_health(),
+        "process_snapshot": process_snapshot_diagnostics(),
         # The zone this daemon interprets cron expressions in, as resolved at
         # its own start. Reported alongside the other daemon state because the
         # value is frozen per process: nothing in the source tree or the host's
@@ -841,7 +971,6 @@ async def transition_sessions(
     transitioned: list[str] = []
     skipped: list[dict[str, str]] = []
     now = time.time()
-    txn_snapshot: str | None = None
     # One scan, one answer per artifact root: sessions repeat their roots
     # heavily, and the walk is the expensive part.
     lock_cache: dict[tuple[str, float], _ScanResult] = {}
@@ -879,9 +1008,9 @@ async def transition_sessions(
                     )
                 )
                 has_stale_locks = scan.lock is not None
-            if txn_snapshot is None:
-                txn_snapshot = _ps_snapshot()
-            process_alive = process_liveness(current, artifacts, txn_snapshot)
+            process_alive, liveness_snapshot = await _resolve_process_liveness_with_snapshot(
+                current, artifacts
+            )
             health = classify_session_health(
                 current,
                 now=now,
@@ -906,7 +1035,7 @@ async def transition_sessions(
                     current,
                     now=now,
                     stale_seconds=3600,
-                    ps_snapshot=txn_snapshot,
+                    ps_snapshot=liveness_snapshot,
                     lock_cache=lock_cache,
                     lock_budget=lock_budget,
                 )

--- a/lionagi/studio/services/invocations.py
+++ b/lionagi/studio/services/invocations.py
@@ -18,11 +18,10 @@ from ..registry import studio_route
 from ._io import parse_json_col as _parse_json_col
 
 
-def _invocation_health(
+async def _invocation_health(
     sessions: list[dict[str, Any]],
     *,
     now: float,
-    ps_snapshot: str | None,
 ) -> tuple[str, float | None]:
     """Worst-of health verdict + latest activity timestamp across an
     invocation's child sessions, reusing the session health classifier
@@ -32,13 +31,15 @@ def _invocation_health(
     if not sessions:
         return "unknown", None
 
-    from .admin import _artifacts_path, process_liveness
+    from .admin import _artifacts_path, resolve_process_liveness
 
     healths: list[SessionHealth] = []
     last_activity: float | None = None
     for s in sessions:
         artifacts = _artifacts_path(s)
-        process_alive = process_liveness(s, artifacts, ps_snapshot)
+        process_alive = (
+            await resolve_process_liveness(s, artifacts) if s.get("status") == "running" else False
+        )
         healths.append(
             classify_session_health(
                 s,
@@ -70,17 +71,10 @@ async def list_invocations(
             skill=skill, plugin=plugin, status=status, limit=limit, offset=offset
         )
         now = time.time()
-        ps_snapshot: str | None = None
         out: list[dict[str, Any]] = []
         for r in rows:
             child_sessions = await db.list_sessions_for_invocation(r["id"])
-            if child_sessions and ps_snapshot is None:
-                from .admin import _ps_snapshot
-
-                ps_snapshot = _ps_snapshot()
-            health, last_activity_at = _invocation_health(
-                child_sessions, now=now, ps_snapshot=ps_snapshot
-            )
+            health, last_activity_at = await _invocation_health(child_sessions, now=now)
             node_meta = r.get("node_metadata")
             if isinstance(node_meta, str):
                 try:
@@ -162,14 +156,7 @@ async def get_invocation(invocation_id: str, *, readonly: bool = False) -> dict[
         # The schedule_run that fired this invocation, when scheduled, so the
         # detail page can show exit_code/error_detail without correlating IDs.
         schedule_run = await db.get_schedule_run_by_invocation(invocation_id)
-        ps_snapshot: str | None = None
-        if sessions:
-            from .admin import _ps_snapshot
-
-            ps_snapshot = _ps_snapshot()
-        health, last_activity_at = _invocation_health(
-            sessions, now=time.time(), ps_snapshot=ps_snapshot
-        )
+        health, last_activity_at = await _invocation_health(sessions, now=time.time())
     return {
         "id": row["id"],
         "skill": row["skill"],

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -13,11 +13,19 @@ from lionagi.state.db import StateDB, state_db_known_absent
 from lionagi.state.reasons import RunReasons, SessionReasons, ShowReasons
 
 from . import admin as admin_svc
-from .admin import _artifacts_path, _ps_snapshot, process_liveness
+from .admin import _artifacts_path, process_liveness, resolve_process_liveness_probe
 from .shows import _SHOW_TERMINAL_STATUSES, _play_dirs
 from .shows import _read_json as _read_show_json
 
 _log = logging.getLogger(__name__)
+
+
+async def _resolve_liveness(session: dict, artifacts: Path | None) -> bool | None:
+    """Preserve the module's liveness seam while sharing the host-wide fallback."""
+    return await resolve_process_liveness_probe(
+        lambda snapshot: process_liveness(session, artifacts, snapshot)
+    )
+
 
 # Phantom PhantomReason → SessionReasons code (mirrors admin._PHANTOM_REASON_CODES).
 _PHANTOM_REASON_CODES: dict[str, str] = {
@@ -217,14 +225,11 @@ async def reap_null_status_sessions(*, stale_hours: float | None = None) -> int:
                 "FROM sessions WHERE status IS NULL"
             )
 
-        ps_snapshot: str | None = None
         for row in rows:
             sid = row["id"]
             artifacts = _artifacts_path(row)
             session = {"id": sid, "node_metadata": row.get("node_metadata")}
-            if ps_snapshot is None:
-                ps_snapshot = _ps_snapshot()
-            if process_liveness(session, artifacts, ps_snapshot) is True:
+            if await _resolve_liveness(session, artifacts) is True:
                 # Process still alive — skip, it may write its own status.
                 continue
 
@@ -408,7 +413,6 @@ async def reap_stale_plays(*, stale_hours: float | None = None) -> int:
                 tuple(sorted(_REAPABLE_PLAY_STATUSES)),
             )
 
-        ps_snapshot: str | None = None
         for cand in candidates:
             play_id = cand["id"]
             try:
@@ -436,13 +440,8 @@ async def reap_stale_plays(*, stale_hours: float | None = None) -> int:
                             (session_id,),
                         )
                         if srow is not None:
-                            if ps_snapshot is None:
-                                ps_snapshot = _ps_snapshot()
                             session = {"id": srow["id"], "node_metadata": srow.get("node_metadata")}
-                            if (
-                                process_liveness(session, _artifacts_path(srow), ps_snapshot)
-                                is True
-                            ):
+                            if await _resolve_liveness(session, _artifacts_path(srow)) is True:
                                 continue
 
                     updated_at_raw = row.get("updated_at")
@@ -654,7 +653,6 @@ async def reap_stale_shows(*, stale_hours: float | None = None) -> int:
                 tuple(sorted(_SHOW_TERMINAL_STATUSES)),
             )
 
-        ps_snapshot: str | None = None
         for cand in candidates:
             show_id = cand["id"]
             try:
@@ -689,10 +687,8 @@ async def reap_stale_shows(*, stale_hours: float | None = None) -> int:
                         )
                         if srow is None:
                             continue
-                        if ps_snapshot is None:
-                            ps_snapshot = _ps_snapshot()
                         session = {"id": srow["id"], "node_metadata": srow.get("node_metadata")}
-                        if process_liveness(session, _artifacts_path(srow), ps_snapshot) is True:
+                        if await _resolve_liveness(session, _artifacts_path(srow)) is True:
                             live = True
                             break
                     if live:
@@ -712,7 +708,7 @@ async def reap_stale_shows(*, stale_hours: float | None = None) -> int:
                         if play_pid <= 1:
                             continue
                         session = {"id": "", "node_metadata": {"pid": play_pid}}
-                        if process_liveness(session, None, ps_snapshot) is True:
+                        if await _resolve_liveness(session, None) is True:
                             live = True
                             break
                     if live:

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -535,15 +535,14 @@ async def list_runs(
     sessions = await _sessions_svc.list_sessions(limit=limit, offset=offset, where=where, sort=sort)
     now = time.time()
     out = []
-    snapshot: str | None = None
     for s in sessions:
         alive: bool | None = None
         if s.get("status") == "running":
-            if snapshot is None:
-                from .admin import _ps_snapshot
+            from .admin import resolve_process_liveness_probe
 
-                snapshot = _ps_snapshot()
-            alive = _session_liveness(s, snapshot)
+            alive = await resolve_process_liveness_probe(
+                lambda snapshot, row=s: _session_liveness(row, snapshot)
+            )
         out.append(_run_row(s, now, process_alive=alive))
 
     tagmap = await run_tags.tags_for_sessions([r["id"] for r in out])
@@ -646,7 +645,14 @@ async def get_run(
         "message_count": message_count,
         "last_message_at": last_message_at,
     }
-    alive = _session_liveness(detail_session) if detail_session.get("status") == "running" else None
+    if detail_session.get("status") == "running":
+        from .admin import resolve_process_liveness_probe
+
+        alive = await resolve_process_liveness_probe(
+            lambda snapshot: _session_liveness(detail_session, snapshot)
+        )
+    else:
+        alive = None
     row = _run_row(detail_session, time.time(), process_alive=alive)
 
     from . import run_tags

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -465,6 +465,7 @@ def test_admin_health_response_shape(tmp_path, monkeypatch):
         "code_identity",
         "db",
         "diagnostic_run_at",
+        "process_snapshot",
         "scheduler_timezone",
         "sessions",
     ]

--- a/tests/apps_studio_server/test_process_snapshot_cache.py
+++ b/tests/apps_studio_server/test_process_snapshot_cache.py
@@ -1,4 +1,4 @@
-"""Scale contracts for run-list process-liveness fallback (issue #3108)."""
+"""Scale contracts for the run list's process-liveness fallback."""
 
 from __future__ import annotations
 
@@ -33,6 +33,7 @@ def _isolate_snapshot_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_CACHE", None, raising=False)
     monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_INFLIGHT", {}, raising=False)
     monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_METRICS", None, raising=False)
+    monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_SEQUENCE", 0, raising=False)
 
 
 async def _stub_run_dependencies(
@@ -314,14 +315,85 @@ async def test_an_older_capture_does_not_overwrite_newer_liveness_evidence(
     # Starts strictly later, so its data is the newer evidence.
     assert await admin_svc._capture_ps_snapshot() == "NEW"
     assert admin_svc._PS_SNAPSHOT_CACHE.value == "NEW"
-    newer_stored_at = admin_svc._PS_SNAPSHOT_CACHE.stored_at
+    newer_sequence = admin_svc._PS_SNAPSHOT_CACHE.sequence
 
     release_old.set()
     # The older scan returns last. It must neither publish nor hand its own
-    # stale value back to its caller.
+    # stale value back to its caller. Asserting on the sequence rather than on
+    # the timestamp: the sequence is what publication compares, so an untouched
+    # sequence is the direct evidence that the older scan did not publish.
     assert await old_task == "NEW"
     assert admin_svc._PS_SNAPSHOT_CACHE.value == "NEW"
-    assert admin_svc._PS_SNAPSHOT_CACHE.stored_at == newer_stored_at
+    assert admin_svc._PS_SNAPSHOT_CACHE.sequence == newer_sequence
+
+
+async def test_captures_that_start_inside_one_clock_tick_still_publish_in_start_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Publication order must not depend on the clock separating two captures.
+
+    The monotonic clock ties often enough here to matter: it advertises about
+    42ns of resolution, and roughly one back-to-back read in seven returns the
+    same value as the read before it. Two captures that start inside one tick
+    carry the same start time, a greater-than test on those times does not
+    hold, and the capture that started earlier publishes over the later one's
+    evidence. The clock is frozen below so the tie is certain rather than
+    hoped for.
+    """
+    import threading
+
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+
+    frozen_reading = 1000.0
+
+    class _FrozenMonotonic:
+        """Delegates to the real time module, except that monotonic() stands still."""
+
+        @staticmethod
+        def monotonic() -> float:
+            return frozen_reading
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(time, name)
+
+    monkeypatch.setattr(admin_svc, "time", _FrozenMonotonic())
+    # Both captures below read this clock for their start time, so asserting it
+    # here is what makes the tie a fact of the test rather than an assumption.
+    assert admin_svc.time.monotonic() == frozen_reading
+
+    entered_old = threading.Event()
+    release_old = threading.Event()
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def capture() -> str:
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            mine = calls
+        if mine == 1:
+            entered_old.set()
+            release_old.wait(timeout=10)
+            return "OLD"
+        return "NEW"
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", capture)
+
+    old_task = asyncio.create_task(admin_svc._capture_ps_snapshot())
+    assert await asyncio.to_thread(entered_old.wait, 5), "the first capture never started"
+
+    assert await admin_svc._capture_ps_snapshot() == "NEW"
+    published = admin_svc._PS_SNAPSHOT_CACHE
+    assert published.value == "NEW"
+    # Both captures stamped the same instant, which is the condition under test.
+    assert published.stored_at == frozen_reading
+
+    release_old.set()
+    assert await old_task == "NEW"
+    assert admin_svc._PS_SNAPSHOT_CACHE.value == "NEW"
+    assert admin_svc._PS_SNAPSHOT_CACHE.sequence == published.sequence
 
 
 def test_cross_loop_captures_leave_the_newest_snapshot_cached(
@@ -472,6 +544,12 @@ def test_cache_publish_is_mutually_exclusive_across_loops(monkeypatch):
     Asserting on overlap rather than on a lost write: the lost write needs a
     specific interleaving to show up, while overlap is the condition that
     makes the lost write possible at all, and it is observable directly.
+
+    The two captures are coordinated by event, not by elapsed time. Whichever
+    one reaches the critical section first holds it open until the other is
+    demonstrably blocked on the lock, and only then checks that it is alone.
+    Holding it open for a fixed sleep instead would prove nothing on the run
+    where the second capture arrives after the sleep ends.
     """
     import threading
 
@@ -479,24 +557,48 @@ def test_cache_publish_is_mutually_exclusive_across_loops(monkeypatch):
 
     _isolate_snapshot_cache(monkeypatch)
 
+    second_at_gate = threading.Event()
+
+    class _GatedLock:
+        """The publish lock, reporting when a capture has to wait its turn."""
+
+        def __init__(self, inner: threading.Lock) -> None:
+            self._inner = inner
+
+        def __enter__(self) -> Any:
+            if not self._inner.acquire(blocking=False):
+                second_at_gate.set()
+                self._inner.acquire()
+            return self
+
+        def __exit__(self, *_exc: Any) -> bool:
+            self._inner.release()
+            return False
+
     real_cache_cls = admin_svc._PsSnapshotCache
     inside = 0
+    entries = 0
     observed = {"max_inside": 0}
     bookkeeping = threading.Lock()
 
     def _instrumented(*args: Any, **kwargs: Any) -> Any:
-        nonlocal inside
+        nonlocal inside, entries
         with bookkeeping:
+            entries += 1
+            mine = entries
             inside += 1
             observed["max_inside"] = max(observed["max_inside"], inside)
-        # Hold the critical section open long enough that a second thread
-        # reaching it would be seen. Without the publish lock this window is
-        # wide enough to make the overlap essentially certain.
-        time.sleep(0.05)
+        if mine == 1:
+            # Without exclusion the other capture never has to wait, so it
+            # never reaches the gate and this times out.
+            assert second_at_gate.wait(timeout=10), (
+                "the second capture never had to wait for the publish lock"
+            )
         with bookkeeping:
             inside -= 1
         return real_cache_cls(*args, **kwargs)
 
+    monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_PUBLISH_LOCK", _GatedLock(threading.Lock()))
     monkeypatch.setattr(admin_svc, "_PsSnapshotCache", _instrumented)
     monkeypatch.setattr(admin_svc, "_ps_snapshot", lambda: "PID COMMAND\n1 init\n")
 

--- a/tests/apps_studio_server/test_process_snapshot_cache.py
+++ b/tests/apps_studio_server/test_process_snapshot_cache.py
@@ -622,3 +622,159 @@ def test_cache_publish_is_mutually_exclusive_across_loops(monkeypatch):
         f"{observed['max_inside']} captures were publishing at once; "
         "the compare-and-publish step is not mutually exclusive"
     )
+
+
+async def test_a_scan_slower_than_the_ttl_still_produces_a_cache_that_hits(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The published entry must not already be expired when it lands.
+
+    The TTL clock reading and the scan are two different moments, and taking
+    the reading first charges the scan's duration against the entry's whole
+    lifetime. A scan slower than the TTL then publishes something dead on
+    arrival: the next caller misses, starts its own scan, and so does the one
+    after it. Slow scans are what the cache exists for, so this is the load
+    under which it would quietly stop being a cache at all.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+
+    scan_seconds = admin_svc.PS_SNAPSHOT_TTL_SECONDS * 2
+    assert scan_seconds > admin_svc.PS_SNAPSHOT_TTL_SECONDS, (
+        "the scan has to outlast the TTL or this test asserts nothing"
+    )
+    reading = 1000.0
+
+    class _ScanAdvancesTheClock:
+        """Real time module, except monotonic() advances only while a scan runs."""
+
+        @staticmethod
+        def monotonic() -> float:
+            return reading
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(time, name)
+
+    monkeypatch.setattr(admin_svc, "time", _ScanAdvancesTheClock())
+
+    captures = 0
+
+    def capture() -> str:
+        nonlocal captures, reading
+        captures += 1
+        # The scan itself is what consumes wall-clock here; nothing else in
+        # this test moves the clock, so any expiry is the scan's duration.
+        reading += scan_seconds
+        return f"SNAPSHOT-{captures}"
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", capture)
+
+    first = await admin_svc.cached_ps_snapshot()
+    assert first == "SNAPSHOT-1"
+    assert captures == 1
+
+    second = await admin_svc.cached_ps_snapshot()
+    assert second == "SNAPSHOT-1", (
+        "the second caller got a fresh scan, so the entry published by the "
+        "first was already past its TTL when it landed"
+    )
+    assert captures == 1, f"expected the cached entry to be reused, but {captures} scans ran"
+
+
+async def test_the_cache_still_expires_once_the_ttl_actually_elapses(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Control for the test above.
+
+    An entry that never expired would satisfy that one too, so without this
+    the suite would read a broken TTL as a working cache.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+
+    reading = 1000.0
+
+    class _ManualMonotonic:
+        @staticmethod
+        def monotonic() -> float:
+            return reading
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(time, name)
+
+    monkeypatch.setattr(admin_svc, "time", _ManualMonotonic())
+
+    captures = 0
+
+    def capture() -> str:
+        nonlocal captures
+        captures += 1
+        return f"SNAPSHOT-{captures}"
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", capture)
+
+    assert await admin_svc.cached_ps_snapshot() == "SNAPSHOT-1"
+    assert await admin_svc.cached_ps_snapshot() == "SNAPSHOT-1"
+    assert captures == 1
+
+    reading += admin_svc.PS_SNAPSHOT_TTL_SECONDS + 0.001
+
+    assert await admin_svc.cached_ps_snapshot() == "SNAPSHOT-2"
+    assert captures == 2
+
+
+async def test_a_page_of_legacy_rows_launches_one_scan_even_when_the_scan_is_slow(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The consequence the TTL reading actually governs, asserted at the consumer.
+
+    Legacy rows carry no targeted process identity, so each one falls back to
+    the shared host scan. That is precisely the population the cache exists
+    for. With the TTL clock read before the scan, a scan slower than the TTL
+    made every row in a page pay for its own, so the health and phantom loops
+    got slower the slower scanning already was.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+
+    reading = 1000.0
+    scan_seconds = admin_svc.PS_SNAPSHOT_TTL_SECONDS * 3
+
+    class _ScanAdvancesTheClock:
+        @staticmethod
+        def monotonic() -> float:
+            return reading
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(time, name)
+
+    monkeypatch.setattr(admin_svc, "time", _ScanAdvancesTheClock())
+
+    scans = 0
+
+    def capture() -> str:
+        nonlocal scans, reading
+        scans += 1
+        reading += scan_seconds
+        return "host-process-table"
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", capture)
+
+    rows = 8
+    # No recorded pid, so every row misses the targeted path and falls through
+    # to the shared scan — the legacy shape this cache serves.
+    for _ in range(rows):
+        await admin_svc.resolve_process_liveness({"id": "legacy-row"}, None)
+
+    assert scans == 1, (
+        f"{rows} legacy rows launched {scans} host scans; the cached entry was "
+        "expiring on arrival because its age was charged from before the scan"
+    )
+    metrics = admin_svc.process_snapshot_diagnostics()
+    assert metrics["fallback_checks"] == rows, (
+        "the rows have to have taken the fallback path, or this counts scans "
+        "that were never going to happen"
+    )

--- a/tests/apps_studio_server/test_process_snapshot_cache.py
+++ b/tests/apps_studio_server/test_process_snapshot_cache.py
@@ -1,0 +1,172 @@
+"""Scale contracts for run-list process-liveness fallback (issue #3108)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any
+
+import psutil
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+
+def _running_row(*, session_id: str, node_metadata: dict[str, Any] | None) -> dict[str, Any]:
+    now = time.time()
+    return {
+        "id": session_id,
+        "name": "process snapshot contract",
+        "status": "running",
+        "started_at": now,
+        "updated_at": now,
+        "last_message_at": now,
+        "node_metadata": node_metadata,
+    }
+
+
+def _isolate_snapshot_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep module-global cache state from coupling otherwise independent tests."""
+    import lionagi.studio.services.admin as admin_svc
+
+    monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_CACHE", None, raising=False)
+    monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_INFLIGHT", None, raising=False)
+    monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_METRICS", None, raising=False)
+
+
+async def _stub_run_dependencies(
+    monkeypatch: pytest.MonkeyPatch, rows: list[dict[str, Any]]
+) -> None:
+    import lionagi.studio.services.run_tags as run_tags
+    import lionagi.studio.services.runs as runs_svc
+
+    async def list_sessions(**_kwargs: Any) -> list[dict[str, Any]]:
+        return [dict(row) for row in rows]
+
+    async def tags_for_sessions(_ids: list[str]) -> dict[str, list[str]]:
+        return {}
+
+    monkeypatch.setattr(runs_svc._sessions_svc, "list_sessions", list_sessions)
+    monkeypatch.setattr(run_tags, "tags_for_sessions", tags_for_sessions)
+
+
+def test_identity_complete_run_page_does_not_capture_process_table(monkeypatch):
+    """Targeted PID identity must be evaluated before the host-wide fallback."""
+    import lionagi.studio.services.admin as admin_svc
+    import lionagi.studio.services.runs as runs_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+    create_time = psutil.Process(os.getpid()).create_time()
+    rows = [
+        _running_row(
+            session_id=f"identity-{idx}",
+            node_metadata={"pid": os.getpid(), "pid_create_time": create_time},
+        )
+        for idx in range(20)
+    ]
+
+    def forbidden_capture() -> str:
+        raise AssertionError("identity-complete pages must not enumerate every OS process")
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", forbidden_capture)
+
+    async def exercise() -> list[dict[str, Any]]:
+        await _stub_run_dependencies(monkeypatch, rows)
+        return await runs_svc.list_runs(limit=20)
+
+    result = asyncio.run(exercise())
+    assert len(result) == 20
+
+
+def test_concurrent_legacy_run_pages_share_one_process_capture(monkeypatch):
+    """Concurrent viewers inside the TTL share one off-loop fallback capture."""
+    import lionagi.studio.services.admin as admin_svc
+    import lionagi.studio.services.runs as runs_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+    session_id = "legacy-session-without-pid"
+    rows = [_running_row(session_id=session_id, node_metadata=None)]
+    captures = 0
+
+    def slow_capture() -> str:
+        nonlocal captures
+        captures += 1
+        time.sleep(0.08)
+        return f"1234 li agent --resume {session_id}"
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", slow_capture)
+
+    async def exercise() -> list[list[dict[str, Any]]]:
+        await _stub_run_dependencies(monkeypatch, rows)
+        tasks = [asyncio.create_task(runs_svc.list_runs(limit=1)) for _ in range(12)]
+        # The fallback runs off-loop: this timer must fire while the capture is
+        # still sleeping, rather than only after the listing already finished.
+        await asyncio.sleep(0.02)
+        assert any(not task.done() for task in tasks)
+        return await asyncio.gather(*tasks)
+
+    pages = asyncio.run(exercise())
+    assert captures == 1
+    assert all(page[0]["effective_health"] == "healthy" for page in pages)
+
+
+def test_admin_health_exposes_process_fallback_coverage(monkeypatch):
+    """Operators can see identity coverage, fallback volume, cache age and scan cost."""
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+    monkeypatch.setattr(admin_svc, "require_file_store", lambda: None)
+    monkeypatch.setattr(admin_svc, "store_exists", lambda: False)
+    monkeypatch.setattr(admin_svc, "db_health", lambda: {})
+
+    async def code_identity() -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr(admin_svc, "_code_identity_report", code_identity)
+
+    report = asyncio.run(admin_svc.health_report())
+    diagnostics = report["process_snapshot"]
+    assert diagnostics == {
+        "captures": 0,
+        "cache_hits": 0,
+        "singleflight_hits": 0,
+        "identity_resolved": 0,
+        "fallback_checks": 0,
+        "last_scan_duration_ms": None,
+        "cache_age_ms": None,
+    }
+
+
+def test_invocation_health_avoids_host_scan_for_terminal_and_identity_rows(monkeypatch):
+    """Invocation listings inherit the same targeted-first process contract."""
+    import lionagi.studio.services.admin as admin_svc
+    import lionagi.studio.services.invocations as invocations_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+    now = time.time()
+    create_time = psutil.Process(os.getpid()).create_time()
+    sessions = [
+        {
+            **_running_row(
+                session_id="identity-child",
+                node_metadata={"pid": os.getpid(), "pid_create_time": create_time},
+            ),
+            "last_message_at": now,
+        },
+        {
+            "id": "completed-child",
+            "status": "completed",
+            "updated_at": now - 10,
+            "last_message_at": now - 10,
+            "node_metadata": None,
+        },
+    ]
+
+    def forbidden_capture() -> str:
+        raise AssertionError("resolved and terminal invocation children need no process table")
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", forbidden_capture)
+    health, last_activity = asyncio.run(invocations_svc._invocation_health(sessions, now=now))
+    assert health == "healthy"
+    assert last_activity == now

--- a/tests/apps_studio_server/test_process_snapshot_cache.py
+++ b/tests/apps_studio_server/test_process_snapshot_cache.py
@@ -31,7 +31,7 @@ def _isolate_snapshot_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     import lionagi.studio.services.admin as admin_svc
 
     monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_CACHE", None, raising=False)
-    monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_INFLIGHT", None, raising=False)
+    monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_INFLIGHT", {}, raising=False)
     monkeypatch.setattr(admin_svc, "_PS_SNAPSHOT_METRICS", None, raising=False)
 
 
@@ -275,3 +275,185 @@ async def test_concurrent_callers_on_one_loop_still_share_a_single_capture(
     assert captures == 1
     metrics = admin_svc._ps_snapshot_metrics_state()
     assert int(metrics["singleflight_hits"] or 0) >= 1
+
+
+async def test_an_older_capture_does_not_overwrite_newer_liveness_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Captures overlap and do not finish in the order they started. A scan that
+    began earlier and returned later must not replace newer evidence, or a
+    process visible only in the newer snapshot resolves as absent.
+    """
+    import threading
+
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+
+    entered_old = threading.Event()
+    release_old = threading.Event()
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def capture() -> str:
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            mine = calls
+        if mine == 1:
+            entered_old.set()
+            release_old.wait(timeout=10)
+            return "OLD"
+        return "NEW"
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", capture)
+
+    old_task = asyncio.create_task(admin_svc._capture_ps_snapshot())
+    assert await asyncio.to_thread(entered_old.wait, 5), "the first capture never started"
+
+    # Starts strictly later, so its data is the newer evidence.
+    assert await admin_svc._capture_ps_snapshot() == "NEW"
+    assert admin_svc._PS_SNAPSHOT_CACHE.value == "NEW"
+    newer_stored_at = admin_svc._PS_SNAPSHOT_CACHE.stored_at
+
+    release_old.set()
+    # The older scan returns last. It must neither publish nor hand its own
+    # stale value back to its caller.
+    assert await old_task == "NEW"
+    assert admin_svc._PS_SNAPSHOT_CACHE.value == "NEW"
+    assert admin_svc._PS_SNAPSHOT_CACHE.stored_at == newer_stored_at
+
+
+def test_cross_loop_captures_leave_the_newest_snapshot_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same race across two event loops, which is how it arises in the
+    daemon: a legacy caller running its own loop beside the serving one.
+    """
+    import threading
+
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+
+    entered_slow = threading.Event()
+    release_slow = threading.Event()
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def capture() -> str:
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            mine = calls
+        if mine == 1:
+            entered_slow.set()
+            release_slow.wait(timeout=10)
+            return "OLD"
+        return "NEW"
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", capture)
+
+    results: dict[str, object] = {}
+
+    def slow_loop() -> None:
+        results["slow"] = asyncio.run(admin_svc.cached_ps_snapshot())
+
+    def fast_loop() -> None:
+        assert entered_slow.wait(timeout=5), "the slow capture never started"
+        results["fast"] = asyncio.run(admin_svc.cached_ps_snapshot())
+        release_slow.set()
+
+    threads = [
+        threading.Thread(target=slow_loop, daemon=True),
+        threading.Thread(target=fast_loop, daemon=True),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=20)
+        assert not t.is_alive(), "a caller never returned"
+
+    assert results["fast"] == "NEW"
+    assert admin_svc._PS_SNAPSHOT_CACHE.value == "NEW"
+
+
+def test_a_second_loop_does_not_evict_the_first_loops_singleflight_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One in-flight slot per loop, not one in total. With a single slot the
+    later loop's entry replaced the earlier one, and the earlier loop's next
+    caller then started a duplicate host-wide scan instead of joining the one
+    already running for it.
+    """
+    import threading
+
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+
+    captures = 0
+    captures_lock = threading.Lock()
+    first_registered = threading.Event()
+    second_registered = threading.Event()
+    observed_by_first = threading.Event()
+    release = threading.Event()
+
+    def capture() -> str:
+        nonlocal captures
+        with captures_lock:
+            captures += 1
+            mine = captures
+        if mine == 1:
+            first_registered.set()
+        elif mine == 2:
+            second_registered.set()
+        # Every capture stays in flight until the assertions have been made,
+        # so no caller can reach a warm cache and skip the slot lookup.
+        release.wait(timeout=10)
+        return "PID COMMAND\n1 init\n"
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", capture)
+
+    observed: dict[str, Any] = {}
+    errors: list[BaseException] = []
+
+    async def first_loop() -> None:
+        loop = asyncio.get_running_loop()
+        one = asyncio.create_task(admin_svc.cached_ps_snapshot())
+        assert await asyncio.to_thread(second_registered.wait, 10)
+        # The other loop registered after this one. This loop's slot has to
+        # still be here; that is what its next caller joins.
+        observed["slot_survived"] = admin_svc._PS_SNAPSHOT_INFLIGHT.get(loop) is not None
+        two = asyncio.create_task(admin_svc.cached_ps_snapshot())
+        observed_by_first.set()
+        await asyncio.gather(one, two)
+
+    async def second_loop() -> None:
+        assert await asyncio.to_thread(first_registered.wait, 10)
+        await admin_svc.cached_ps_snapshot()
+
+    def run(coro_factory: Any) -> None:
+        try:
+            asyncio.run(coro_factory())
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=run, args=(first_loop,), daemon=True),
+        threading.Thread(target=run, args=(second_loop,), daemon=True),
+    ]
+    for t in threads:
+        t.start()
+    assert observed_by_first.wait(timeout=20), "the first loop never made its observation"
+    release.set()
+    for t in threads:
+        t.join(timeout=20)
+        assert not t.is_alive(), "a loop never returned"
+
+    assert errors == []
+    assert observed["slot_survived"] is True
+    # Two loops, two scans. A third would mean the first loop's second caller
+    # started its own instead of joining.
+    assert captures == 2
+    assert admin_svc._PS_SNAPSHOT_INFLIGHT == {}

--- a/tests/apps_studio_server/test_process_snapshot_cache.py
+++ b/tests/apps_studio_server/test_process_snapshot_cache.py
@@ -457,3 +457,66 @@ def test_a_second_loop_does_not_evict_the_first_loops_singleflight_slot(
     # started its own instead of joining.
     assert captures == 2
     assert admin_svc._PS_SNAPSHOT_INFLIGHT == {}
+
+
+def test_cache_publish_is_mutually_exclusive_across_loops(monkeypatch):
+    """Two captures must not be inside the compare-and-publish step at once.
+
+    Publishing reads the cache, decides whether its own scan is newer, and
+    writes. Those are separate steps, and captures run on different OS
+    threads, so without mutual exclusion both can read the old value before
+    either writes. The one that started earlier then publishes last and its
+    older process table replaces the newer one, which is how a process that
+    exists only in the newer snapshot comes back as absent.
+
+    Asserting on overlap rather than on a lost write: the lost write needs a
+    specific interleaving to show up, while overlap is the condition that
+    makes the lost write possible at all, and it is observable directly.
+    """
+    import threading
+
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+
+    real_cache_cls = admin_svc._PsSnapshotCache
+    inside = 0
+    observed = {"max_inside": 0}
+    bookkeeping = threading.Lock()
+
+    def _instrumented(*args: Any, **kwargs: Any) -> Any:
+        nonlocal inside
+        with bookkeeping:
+            inside += 1
+            observed["max_inside"] = max(observed["max_inside"], inside)
+        # Hold the critical section open long enough that a second thread
+        # reaching it would be seen. Without the publish lock this window is
+        # wide enough to make the overlap essentially certain.
+        time.sleep(0.05)
+        with bookkeeping:
+            inside -= 1
+        return real_cache_cls(*args, **kwargs)
+
+    monkeypatch.setattr(admin_svc, "_PsSnapshotCache", _instrumented)
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", lambda: "PID COMMAND\n1 init\n")
+
+    errors: list[BaseException] = []
+
+    def _run() -> None:
+        try:
+            asyncio.run(admin_svc._capture_ps_snapshot())
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_run, daemon=True) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=20)
+        assert not t.is_alive(), "a capture never returned"
+
+    assert errors == []
+    assert observed["max_inside"] == 1, (
+        f"{observed['max_inside']} captures were publishing at once; "
+        "the compare-and-publish step is not mutually exclusive"
+    )

--- a/tests/apps_studio_server/test_process_snapshot_cache.py
+++ b/tests/apps_studio_server/test_process_snapshot_cache.py
@@ -170,3 +170,108 @@ def test_invocation_health_avoids_host_scan_for_terminal_and_identity_rows(monke
     health, last_activity = asyncio.run(invocations_svc._invocation_health(sessions, now=now))
     assert health == "healthy"
     assert last_activity == now
+
+
+def test_a_second_event_loop_gets_its_own_capture_instead_of_a_cross_loop_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The in-flight capture is a Task, and a Task belongs to one event loop.
+
+    Sharing it through a process-global meant a caller running its own loop
+    reached `asyncio.shield` on a Task owned by the serving loop and got a
+    cross-loop RuntimeError instead of the snapshot. Two real loops are driven
+    here, in separate threads, with the capture held open until both callers
+    are inside it -- a sequential test cannot reach the state at all, because
+    the in-flight slot is empty by the time the second call runs.
+    """
+    import threading
+
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+
+    both_arrived = threading.Barrier(2, timeout=10)
+    captures = 0
+    captures_lock = threading.Lock()
+
+    def slow_capture() -> str:
+        nonlocal captures
+        with captures_lock:
+            captures += 1
+        # Hold the capture open until the other loop has also entered
+        # cached_ps_snapshot, so the second caller meets a PENDING in-flight
+        # entry rather than a finished one.
+        try:
+            both_arrived.wait()
+        except threading.BrokenBarrierError:  # pragma: no cover - timeout path
+            pass
+        return "PID COMMAND\n1 init\n"
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", slow_capture)
+
+    results: dict[str, object] = {}
+
+    def run_on_its_own_loop(name: str) -> None:
+        try:
+            results[name] = asyncio.run(admin_svc.cached_ps_snapshot())
+        except BaseException as exc:  # noqa: BLE001 - the defect raised RuntimeError
+            results[name] = exc
+
+    threads = [
+        threading.Thread(target=run_on_its_own_loop, args=(name,), daemon=True)
+        for name in ("first", "second")
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+        assert not t.is_alive(), "a caller never returned"
+
+    for name in ("first", "second"):
+        assert not isinstance(results[name], BaseException), (
+            f"{name} loop raised instead of receiving a snapshot: {results[name]!r}"
+        )
+        assert results[name] == "PID COMMAND\n1 init\n"
+
+    # Both loops really did run concurrently and each captured for itself:
+    # the barrier only releases when two captures are in flight at once, so
+    # this also proves the two calls overlapped rather than ran back to back.
+    assert captures == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callers_on_one_loop_still_share_a_single_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The positive arm: per-loop scoping must not disable singleflight.
+
+    Without this, the fix above is equally satisfied by removing the shared
+    capture entirely and letting every caller run its own `ps`.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    _isolate_snapshot_cache(monkeypatch)
+
+    captures = 0
+    release = asyncio.Event()
+
+    def counted_capture() -> str:
+        nonlocal captures
+        captures += 1
+        return "PID COMMAND\n1 init\n"
+
+    monkeypatch.setattr(admin_svc, "_ps_snapshot", counted_capture)
+
+    async def gated() -> str:
+        await release.wait()
+        return await admin_svc.cached_ps_snapshot()
+
+    waiters = [asyncio.create_task(gated()) for _ in range(4)]
+    await asyncio.sleep(0)
+    release.set()
+    values = await asyncio.gather(*waiters)
+
+    assert values == ["PID COMMAND\n1 init\n"] * 4
+    assert captures == 1
+    metrics = admin_svc._ps_snapshot_metrics_state()
+    assert int(metrics["singleflight_hits"] or 0) >= 1


### PR DESCRIPTION
## Summary

- resolve PID/create-time identities before considering the legacy command-snapshot fallback
- move fallback capture off the event loop and share it through a one-second TTL plus async singleflight
- use the same liveness service across run lists/detail, invocations, lifecycle, and admin paths
- expose capture, cache-hit, singleflight, identity-resolution, fallback, cache-age, and scan-duration metrics
- preserve tri-state liveness and existing monkeypatch seams for legacy/imported rows

## Verification

- strict RED→GREEN: an identity-complete 20-row page now performs zero `ps` captures
- 12 concurrent legacy pages share one capture instead of blocking the loop and launching 12
- new metrics and invocation bypass contracts passed
- 165 focused run/detail/admin/invocation/lifecycle tests passed
- Ruff, Pyright (0 errors), lint, commit hooks, and diff checks passed

Closes #3108