### PR TITLE
fix(flow): honor zero reactive spawn capacity

### DIFF
--- a/docs/guides/orchestration.md
+++ b/docs/guides/orchestration.md
@@ -134,8 +134,10 @@ For a positive `max_ops` ceiling, the fresh-run arithmetic is:
 spawn capacity = max(0, max_ops - initial planned assignments)
 ```
 
-A four-assignment plan under `max_ops: 4` therefore advertises itself as
-reactive but has zero capacity to accept a spawn. Size the ceiling as:
+A four-assignment plan under `max_ops: 4` therefore has zero spawn capacity,
+so its workers are not granted the spawn tool. The reactive state and effective
+`max_spawn` are recorded in the flow checkpoint and Studio run metadata. Size
+the ceiling as:
 
 ```text
 max_ops = intended initial plan + intended reactive spawns

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -47,6 +47,7 @@ class CheckpointWriter:
     prompt: str
     plan: list[dict]
     config: dict[str, Any]
+    max_spawn: int | None = None
     flow_context: dict[str, Any] = field(default_factory=dict)
     ops: dict[str, dict[str, Any]] = field(default_factory=dict)
     spawned: list[dict] = field(default_factory=list)
@@ -54,7 +55,7 @@ class CheckpointWriter:
     _seq: int = field(default=0, repr=False, compare=False)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        checkpoint = {
             "version": CHECKPOINT_VERSION,
             "session_id": self.session_id,
             "prompt": self.prompt,
@@ -64,6 +65,9 @@ class CheckpointWriter:
             "spawned": self.spawned,
             "config": self.config,
         }
+        if self.max_spawn is not None:
+            checkpoint["max_spawn"] = self.max_spawn
+        return checkpoint
 
     async def record(
         self,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -710,6 +710,14 @@ def _parse_reactive(spec: str | None) -> tuple[bool, set[str] | None]:
     return (True, roles) if roles else (True, None)
 
 
+def _remaining_spawn_capacity(
+    max_ops: int, planned_count: int, restored_spawn_count: int = 0
+) -> int:
+    """Return the remaining reactive-spawn budget for this execution attempt."""
+    initial_capacity = max_ops - planned_count if max_ops > 0 else 20
+    return max(0, initial_capacity - restored_spawn_count)
+
+
 def _flow_header_fn(w: dict, i: int, n: int) -> list[str]:
     deps = w.get("depends_on") or []
     dep_str = f"  deps: {', '.join(deps)}" if deps else ""
@@ -742,6 +750,7 @@ class _DagState:
     spawn_roles: set[str] | None
     role_base: dict[str, object]
     worker_models: list[str]
+    max_spawn: int | None = None
     op_segments: list[dict] = field(default_factory=list)
     # role → its resolved artifact_defaults (profile first, else casts Role),
     # cached once per role in _build_dag so _execute_dag can register the same
@@ -809,6 +818,7 @@ async def _build_dag(
     plan_result: _PlanResult,
     *,
     reactive_spec: str,
+    max_spawn: int,
 ) -> _DagState:
     """Wire worker branches into the operation graph builder and snapshot to Studio."""
     assignments = plan_result.assignments
@@ -820,7 +830,7 @@ async def _build_dag(
     reactive, spawn_roles = _parse_reactive(reactive_spec)
 
     def _may_spawn(role: str) -> bool:
-        return reactive and (spawn_roles is None or role in spawn_roles)
+        return max_spawn > 0 and reactive and (spawn_roles is None or role in spawn_roles)
 
     worker_models: list[str] = []
     node_ids: list[str] = []
@@ -930,6 +940,8 @@ async def _build_dag(
 
     # Early DAG snapshot for Studio.
     early_graph = {
+        "reactive": reactive,
+        "max_spawn": max_spawn,
         "agents": [
             {"id": agent_ids[i], "name": agent_ids[i], "model": worker_models[i]}
             for i in range(len(assignments))
@@ -978,6 +990,7 @@ async def _build_dag(
         spawn_roles=spawn_roles,
         role_base=role_base,
         worker_models=worker_models,
+        max_spawn=max_spawn,
         role_artifact_defaults=role_artifact_defaults,
         worker_branches=worker_branches,
         messenger_bound=worker_messenger_bound,
@@ -1198,6 +1211,13 @@ async def _execute_dag(
     _segment_tasks: list = []
     _control_log_tasks: list = []
 
+    # Restored spawns already consumed spawn budget and exist as completed/
+    # failed work; both the budget below and spawn accounting must count them.
+    restored_spawn_count = len(checkpoint_spawned_seed or [])
+    max_spawn = dag_state.max_spawn
+    if max_spawn is None:
+        max_spawn = _remaining_spawn_capacity(max_ops, len(assignments), restored_spawn_count)
+
     _checkpoint_writer: CheckpointWriter | None = None
     if checkpoint_config is not None:
         _ctx_lp = getattr(env, "_live_persist", None)
@@ -1207,6 +1227,7 @@ async def _execute_dag(
             prompt=checkpoint_prompt,
             plan=checkpoint_plan or [],
             config=checkpoint_config,
+            max_spawn=max_spawn,
             # Seed with prior-checkpoint state (empty on a fresh run) so a
             # resume-of-a-resume can't silently lose context before the next flush.
             flow_context=dict(checkpoint_flow_context or {}),
@@ -1223,12 +1244,6 @@ async def _execute_dag(
     else:
         progress(f"Executing DAG (reactive off): {len(assignments)} assignments...")
     conc = max_concurrent if max_concurrent > 0 else max(len(assignments), 1)
-    # Restored spawns already consumed spawn budget and exist as completed/
-    # failed work; both the budget below and spawn accounting must count them.
-    restored_spawn_count = len(checkpoint_spawned_seed or [])
-    # --max-ops shares budget between initial plan + spawns; default cap of
-    # 20 otherwise so an un-capped reactive run can't fan out unbounded.
-    max_spawn = max(0, (max_ops - len(assignments) if max_ops > 0 else 20) - restored_spawn_count)
     # Resume must start the spawn-id ordinal sequence past whatever restored
     # spawns already used (MAX existing + 1, not count — crashes can leave
     # gaps) or a live spawn could reissue a restored spawn_id/artifact dir.
@@ -2911,7 +2926,15 @@ async def _run_flow_inner(
         budget_preambles=budget_preambles,
     )
 
-    dag_state = await _build_dag(env, prompt, plan_result, reactive_spec=reactive_spec)
+    restored_spawn_count = len((resume_checkpoint or {}).get("spawned") or [])
+    max_spawn = _remaining_spawn_capacity(max_ops, len(assignments), restored_spawn_count)
+    dag_state = await _build_dag(
+        env,
+        prompt,
+        plan_result,
+        reactive_spec=reactive_spec,
+        max_spawn=max_spawn,
+    )
 
     if resume_checkpoint is not None:
         _apply_checkpoint_precompletion(

--- a/tests/cli/orchestrate/test_fan_shape.py
+++ b/tests/cli/orchestrate/test_fan_shape.py
@@ -64,7 +64,9 @@ async def test_flow_dag_gives_independent_assignments_no_sequential_edges(tmp_pa
         "lionagi.cli.orchestrate.flow.build_worker_branch",
         return_value=(_FakeBranch(), "codex/gpt-5.5", None, False),
     ):
-        dag_state = await _build_dag(env, "do stuff", plan_result, reactive_spec="off")
+        dag_state = await _build_dag(
+            env, "do stuff", plan_result, reactive_spec="off", max_spawn=20
+        )
 
     assert len(dag_state.node_ids) == 6
 
@@ -101,7 +103,7 @@ async def test_flow_dag_preserves_declared_dependency_chain(tmp_path):
         "lionagi.cli.orchestrate.flow.build_worker_branch",
         return_value=(_FakeBranch(), "codex/gpt-5.5", None, False),
     ):
-        dag_state = await _build_dag(env, "task", plan_result, reactive_spec="off")
+        dag_state = await _build_dag(env, "task", plan_result, reactive_spec="off", max_spawn=20)
 
     counts = _label_counts(env.builder)
     assert counts[("depends_on",)] == 1

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -1983,7 +1983,9 @@ async def test_resume_missing_artifact_still_flips_status_to_failed(
         "lionagi.cli.orchestrate.flow.build_worker_branch",
         return_value=(Branch(name="worker"), "claude", None, False),
     ):
-        dag_state = await _build_dag(env, "write the brief", plan_result, reactive_spec="off")
+        dag_state = await _build_dag(
+            env, "write the brief", plan_result, reactive_spec="off", max_spawn=20
+        )
 
     checkpoint_ops = {
         "worker": {"agent_id": "worker", "status": "completed", "response": "done previously"}

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -263,7 +263,9 @@ async def test_build_dag_populates_node_ids(tmp_path):
         "lionagi.cli.orchestrate.flow.build_worker_branch",
         return_value=(_FakeBranch("researcher"), "codex/gpt-5.5", None, False),
     ):
-        dag_state = await _build_dag(env, "do stuff", plan_result, reactive_spec="off")
+        dag_state = await _build_dag(
+            env, "do stuff", plan_result, reactive_spec="off", max_spawn=20
+        )
 
     assert len(dag_state.node_ids) == 2
     assert len(dag_state.worker_models) == 2
@@ -303,7 +305,7 @@ async def test_build_dag_early_graph_write_preserves_unrelated_metadata(tmp_path
         "lionagi.cli.orchestrate.flow.build_worker_branch",
         return_value=(_FakeBranch("researcher"), "codex/gpt-5.5", None, False),
     ):
-        await _build_dag(env, "do stuff", plan_result, reactive_spec="off")
+        await _build_dag(env, "do stuff", plan_result, reactive_spec="off", max_spawn=20)
 
     assert db._node_metadata["unverifiable_since"] == 111.0
     assert db._node_metadata["unverifiable_count"] == 2
@@ -333,7 +335,7 @@ async def test_build_dag_deps_by_node_format(tmp_path):
         "lionagi.cli.orchestrate.flow.build_worker_branch",
         return_value=(_FakeBranch(), "codex/gpt-5.5", None, False),
     ):
-        dag_state = await _build_dag(env, "task", plan_result, reactive_spec="off")
+        dag_state = await _build_dag(env, "task", plan_result, reactive_spec="off", max_spawn=20)
 
     nid0, nid1 = dag_state.node_ids
     assert dag_state.deps_by_node[nid0] == []
@@ -390,7 +392,7 @@ async def test_build_dag_deps_follow_the_built_graph_not_the_declared_plan(tmp_p
         ),
         patch("lionagi.cli.orchestrate.flow._build_worker_operate_node", _diverging_build),
     ):
-        dag_state = await _build_dag(env, "task", plan_result, reactive_spec="off")
+        dag_state = await _build_dag(env, "task", plan_result, reactive_spec="off", max_spawn=20)
 
     nid0, nid1, nid2, nid3 = dag_state.node_ids
     assert dag_state.deps_by_node[nid0] == []
@@ -450,7 +452,7 @@ async def test_build_dag_reactive_all_grants_spawn(tmp_path):
         "lionagi.cli.orchestrate.flow.build_worker_branch",
         return_value=(_FakeBranch(), "codex/gpt-5.5", None, False),
     ):
-        dag_state = await _build_dag(env, "task", plan_result, reactive_spec="all")
+        dag_state = await _build_dag(env, "task", plan_result, reactive_spec="all", max_spawn=20)
 
     assert dag_state.reactive is True
     assert dag_state.spawn_roles is None
@@ -479,7 +481,7 @@ async def test_build_dag_pool_override_passes_to_worker(tmp_path):
         return _FakeBranch(role), model_override or "default", None, False
 
     with patch("lionagi.cli.orchestrate.flow.build_worker_branch", side_effect=fake_build):
-        await _build_dag(env, "task", plan_result, reactive_spec="off")
+        await _build_dag(env, "task", plan_result, reactive_spec="off", max_spawn=20)
 
     assert calls[0]["model_override"] == "codex/cheap"
     assert calls[1]["model_override"] == "codex/expensive"

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2404,7 +2404,7 @@ async def test_build_dag_wires_role_artifact_defaults_into_live_contract_and_fai
         "lionagi.cli.orchestrate.flow.build_worker_branch",
         return_value=(Branch(name="reviewer"), "codex/gpt-5.5", None, False),
     ):
-        await _build_dag(env, "review this PR", plan_result, reactive_spec="off")
+        await _build_dag(env, "review this PR", plan_result, reactive_spec="off", max_spawn=20)
 
     # The live in-memory contract was extended during DAG build, before any
     # worker ran.

--- a/tests/cli/orchestrate/test_run_flow_inner.py
+++ b/tests/cli/orchestrate/test_run_flow_inner.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -413,6 +414,59 @@ async def test_run_flow_inner_max_ops_caps_planning_request(
     assert "BUDGET: at most 2 ops total" in planner.calls[0]["guidance"]
     assert env.session.run_dag_calls == []
     fake_runtime.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_flow_inner_zero_spawn_capacity_withholds_spawn_tool(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, fake_runtime
+):
+    planner = _Planner([_assignments()], expected_max_tasks=2)
+    grants: list[bool] = []
+
+    async def capture_spawn_grant(env, *, agent_id, grant_spawn, **kwargs):
+        grants.append(grant_spawn)
+        branch = Branch(name=agent_id)
+        env.session.include_branches(branch)
+        return branch, "fake/model", None, False
+
+    monkeypatch.setattr(flow_module, "plan", planner)
+    monkeypatch.setattr(flow_module, "build_worker_branch", capture_spawn_grant)
+    env = _env(tmp_path, ["research output", "implementation output"])
+
+    await _run_flow_inner(
+        "codex/gpt-5.5",
+        "characterize the flow",
+        env=env,
+        max_ops=2,
+        reactive_spec="all",
+    )
+
+    assert grants == [False, False]
+    assert env.session.run_dag_calls[0][1]["max_spawn"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_flow_inner_records_effective_spawn_capacity(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, fake_runtime
+):
+    planner = _Planner([_assignments()], expected_max_tasks=2)
+    monkeypatch.setattr(flow_module, "plan", planner)
+    env = _env(tmp_path, ["research output", "implementation output"])
+    env.run.checkpoint_path = tmp_path / "checkpoint.json"
+
+    await _run_flow_inner(
+        "codex/gpt-5.5",
+        "characterize the flow",
+        env=env,
+        max_ops=2,
+        reactive_spec="all",
+        checkpoint_config={"model_spec": "codex/gpt-5.5"},
+    )
+
+    checkpoint = json.loads(env.run.checkpoint_path.read_text())
+    assert checkpoint["max_spawn"] == 0
+    assert env._finalize_extras["reactive"] is True
+    assert env._finalize_extras["max_spawn"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- make reactive spawn-tool grants consult the same remaining-capacity calculation used by execution
- with zero capacity, grant no spawn tool and advertise no capability workers cannot use
- persist `reactive` and `max_spawn` in checkpoints and Studio's early graph metadata
- restore the same spawn budget on resume so resumed workers see the original contract

## Verification

- strict RED→GREEN: zero capacity changed from `grants=[true,true]` to no grants
- checkpoint/resume contract now records and restores `max_spawn`
- full `tests/cli/orchestrate` suite passed
- pre-commit, Pyright (0 errors), and diff checks passed

Closes #3029