### PR TITLE
fix(studio): measure branch duration from lifecycle timestamps

### DIFF
--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -701,6 +701,38 @@ describe("history/RunDetail.tsx — persisted branch totals survive message pagi
     expect(runStep.result?.duration_sec).toBe(600);
     expect(runStep.result?.message_count).toBe(30_525);
   });
+
+  it("uses branch lifecycle bounds when a cancelled branch has only one message", async () => {
+    const { branchToRunStep } = await import("./RunDetail");
+    const runStep = branchToRunStep(
+      {
+        id: "branch-cancelled",
+        name: "architect",
+        created_at: 100,
+        started_at: null,
+        ended_at: 178.1,
+        first_message_at: 101,
+        last_message_at: 101,
+        message_total: 1,
+        messages: [
+          {
+            id: "prompt-only",
+            role: "user",
+            content: { instruction: "Investigate" },
+            sender: "user",
+            timestamp: 101,
+            lion_class: "Instruction",
+          },
+        ],
+      },
+      "cancelled",
+    );
+
+    expect(runStep.result?.duration_sec).toBe(78);
+    const { container } = renderRunStepCards([runStep]);
+    expect(container.textContent).toContain("1m 18s");
+    expect(container.textContent).not.toContain("0s");
+  });
 });
 
 describe("history/RunDetail.tsx — live branch aggregates", () => {

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -535,8 +535,8 @@ export function branchToRunStep(
     rolesCounts[rm.role] = (rolesCounts[rm.role] ?? 0) + 1;
   }
 
-  const firstMessageAt = branch.first_message_at ?? branch.started_at ?? null;
-  const lastMessageAt = branch.last_message_at ?? branch.ended_at ?? null;
+  const firstMessageAt = branch.started_at ?? branch.created_at ?? branch.first_message_at ?? null;
+  const lastMessageAt = branch.ended_at ?? branch.last_message_at ?? null;
   const durationSec =
     firstMessageAt != null && lastMessageAt != null
       ? Math.max(0, Math.round(lastMessageAt - firstMessageAt))

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -788,7 +788,11 @@ async def get_session(
                     "provider": br["provider"],
                     "agent_name": br["agent_name"],
                     "status": br["status"] if "status" in br_keys else None,
-                    "started_at": br["started_at"] if "started_at" in br_keys else None,
+                    "started_at": (
+                        br["started_at"]
+                        if "started_at" in br_keys and br["started_at"] is not None
+                        else br["created_at"]
+                    ),
                     "ended_at": br["ended_at"] if "ended_at" in br_keys else None,
                 }
             )

--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -161,6 +161,24 @@ async def test_get_run_returns_all_required_keys(patched_runs_svc):
     assert not missing, f"Missing keys in get_run response: {missing}"
 
 
+async def test_get_run_populates_missing_branch_start_from_creation_time(patched_runs_svc):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    branch_id = f"{sid}-br"
+    await seed_session(db_path, session_id=sid, status="cancelled")
+    await seed_branch(db_path, branch_id=branch_id, session_id=sid)
+    async with StateDB(db_path) as db:
+        await db.update_branch(branch_id, status="cancelled", ended_at=278.1)
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    branch = result["branches"][0]
+    assert branch["created_at"] == 200.0
+    assert branch["started_at"] == 200.0
+    assert branch["ended_at"] == 278.1
+
+
 # Test 4 — get_run maps session fields to correct response keys
 
 


### PR DESCRIPTION
## Summary

- fill missing branch `started_at` values from the branch's persisted `created_at` lifecycle timestamp
- make Run Detail prefer lifecycle start/end timestamps for branch duration
- retain message timestamps as the fallback for legacy payloads
- correctly show long single-message cancelled branches instead of collapsing them to `0s`

## Verification

- strict RED→GREEN: API fallback changed from `None` to the lifecycle start
- the 78.1-second single-message cancellation fixture now renders `1m 18s`
- affected backend suites passed
- Run Detail suite: 151 passed
- Ruff, ESLint, Prettier, TypeScript, production build, and diff checks passed

Closes #3025