### PR TITLE
fix(studio): preserve canonical playbook fields

### DIFF
--- a/lionagi/_flow_spec.py
+++ b/lionagi/_flow_spec.py
@@ -52,6 +52,13 @@ def normalize_flow_spec_keys(data: dict[Any, Any]) -> dict[str, Any]:
     return normalized
 
 
+def flow_spec_yaml_key(key: str) -> str:
+    """Return the preferred YAML spelling for one canonical spec field."""
+    if key in _PRESERVE_DASHED:
+        return key
+    return key.replace("_", "-")
+
+
 def load_flow_spec(path: str | Path) -> dict[str, Any]:
     """Load and normalize one YAML or JSON flow spec."""
     spec_path = Path(path).expanduser()

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -11,6 +11,10 @@ import yaml
 from fastapi import Body, HTTPException
 
 from lionagi._flow_spec import (
+    FLOW_SPEC_FIELDS,
+    flow_spec_yaml_key,
+)
+from lionagi._flow_spec import (
     normalize_flow_spec_keys as _normalize_spec_keys,
 )
 from lionagi._flow_spec import (
@@ -167,19 +171,10 @@ def install_builtin_playbook(name: str) -> dict[str, Any]:
     return {"installed": installed_now, "playbook": get_playbook(stem)}
 
 
-# Declarative-format keys we will write through from the editor. Anything not
-# in this list is preserved as-is from the existing YAML so handcrafted keys
-# (or future additions) don't get clobbered.
-_DECLARATIVE_KEYS: tuple[str, ...] = (
-    "agent",
-    "effort",
-    "max-ops",
-    "prompt",
-    "args",
-    "yolo",
-    "show-graph",
-    "argument-hint",
-)
+_SPECIAL_PLAYBOOK_KEYS = frozenset({"description", "links", "name", "steps", "use"})
+_DECLARATIVE_KEYS: dict[str, str] = {
+    field: flow_spec_yaml_key(field) for field in sorted(FLOW_SPEC_FIELDS - _SPECIAL_PLAYBOOK_KEYS)
+}
 
 
 def create_playbook(name: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -191,14 +186,15 @@ def create_playbook(name: str, data: dict[str, Any] | None = None) -> dict[str, 
         raise FileExistsError(f"Playbook '{stem}' already exists")
 
     data = data or {}
-    spec_err = _check_spec_fields(_normalize_spec_keys(data))
+    normalized_data = _normalize_spec_keys(data)
+    spec_err = _check_spec_fields(normalized_data)
     if spec_err:
         raise ValueError(spec_err)
 
     content: dict[str, Any] = {"description": data.get("description") or ""}
 
-    for key in _DECLARATIVE_KEYS:
-        value = data.get(key)
+    for field, key in _DECLARATIVE_KEYS.items():
+        value = normalized_data.get(field)
         if value not in (None, ""):
             content[key] = value
 
@@ -249,9 +245,9 @@ def update_playbook(name: str, data: dict[str, Any]) -> dict[str, Any] | None:
     if not path.exists():
         return None
 
-    # Validate before the merge: the merge silently drops unknown keys (e.g. 'workers'),
-    # so validating the raw payload catches bad values that would otherwise pass through.
-    spec_err = _check_spec_fields(_normalize_spec_keys(data))
+    # Validate before the merge so invalid values never reach the on-disk spec.
+    normalized_data = _normalize_spec_keys(data)
+    spec_err = _check_spec_fields(normalized_data)
     if spec_err:
         raise ValueError(spec_err)
 
@@ -280,10 +276,12 @@ def update_playbook(name: str, data: dict[str, Any]) -> dict[str, Any] | None:
     if isinstance(links, list) and len(links) > 0:
         merged["links"] = links
 
-    for key in _DECLARATIVE_KEYS:
-        if key not in data:
+    for field, key in _DECLARATIVE_KEYS.items():
+        if field not in normalized_data:
             continue
-        value = data[key]
+        value = normalized_data[field]
+        if key != field:
+            merged.pop(field, None)
         if value is None or value == "":
             merged.pop(key, None)
         else:

--- a/tests/apps_studio_server/test_batch3_logic.py
+++ b/tests/apps_studio_server/test_batch3_logic.py
@@ -430,6 +430,24 @@ class TestUpdatePlaybookSpecFieldValidation:
 
         result = svc.update_playbook("pb-workers3", {"workers": 4})
         assert result is not None
+        assert result["data"]["workers"] == 4
+
+    def test_editor_write_through_covers_every_canonical_playbook_field(self):
+        import lionagi.studio.services.playbooks as svc
+        from lionagi._flow_spec import FLOW_SPEC_FIELDS, normalize_flow_spec_keys
+
+        expected_fields = FLOW_SPEC_FIELDS - {
+            "description",
+            "links",
+            "name",
+            "steps",
+            "use",
+        }
+        assert set(svc._DECLARATIVE_KEYS) == expected_fields
+        assert {
+            next(iter(normalize_flow_spec_keys({key: None})))
+            for key in svc._DECLARATIVE_KEYS.values()
+        } == expected_fields
 
     def test_max_ops_out_of_range_raises(self, tmp_path, monkeypatch):
         """max-ops: 999 (YAML hyphenated form) must be rejected after key normalization."""


### PR DESCRIPTION
## Summary

- derive Studio's writable playbook field map from canonical `FLOW_SPEC_FIELDS` instead of maintaining a drifting hand-written whitelist
- map canonical names to one preferred YAML spelling on both create and update
- preserve valid fields such as `workers`, `bypass`, and `team_mode` instead of validating and then silently dropping them
- remove stale underscore aliases when writing the preferred key so a document cannot retain two spellings of one field

## Verification

- strict RED→GREEN: `workers: 4` originally disappeared and raised `KeyError` on readback
- workers round-trip and complete canonical-field coverage now pass
- repository-entry focused suite: 224 passed
- Ruff, Pyright (0 errors), commit hooks, and diff checks passed

Closes #2975