### PR TITLE
fix(flow): route synthesis through the lifecycle bridge

### DIFF
--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -503,9 +503,18 @@ async def _run_fanout_inner(
             # bridge, so a failed synthesis reaches the observer above. Calling
             # session.flow directly emits no node signals at all, which leaves
             # the observer silent and renders the failure as an empty response.
+            # The graph still carries the workers, since synthesis depends on
+            # them, but they ran in the worker phase above and already have
+            # their terminal events; signalling them here would record the
+            # same work a second time.
+            synth_graph = env.builder.get_graph()
+            already_ran = {str(n.id) for n in synth_graph.internal_nodes.values()} - {
+                str(synth_node)
+            }
             result3 = await eng_run.run_dag(
-                env.builder.get_graph(),
+                synth_graph,
                 verbose=env.verbose,
+                skip_signal_ops=already_ran,
             )
         finally:
             env.session.observer.unobserve(_record_failed_op)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -765,6 +765,14 @@ class _ExecResult:
     t_exec_elapsed: float
     escalated_agent_ids: list[str] = field(default_factory=list)
     engine_run: Any | None = field(default=None, repr=False)
+    # Op ids the checkpoint observer must ignore. The observer is registered
+    # on the engine run, which later phases reuse, so it also sees nodes that
+    # did not exist when it was built. A phase that adds such a node declares
+    # it here before running. Named as what to SKIP rather than a set of
+    # nodes to accept: an accept-list is a closed description of the graph
+    # taken before the graph stopped changing, so anything arriving later is
+    # misclassified by default, which is the failure this carries.
+    checkpoint_skip_ids: set[str] = field(default_factory=set, repr=False)
 
 
 # ── Phase 1: build DAG ────────────────────────────────────────────────────────
@@ -1167,6 +1175,7 @@ async def _execute_dag(
     checkpoint_flow_context: dict | None = None,
     checkpoint_spawned_seed: list[dict] | None = None,
     team_max_rounds: int = 2,
+    checkpoint_skip_ids: set[str] | None = None,
 ) -> _ExecResult:
     """Drive the planning engine over the DAG and collect per-agent results.
     checkpoint_config gates the checkpoint writer (opt-in); checkpoint_spawned_seed
@@ -1193,6 +1202,14 @@ async def _execute_dag(
     # DependencyAwareExecutor.__init__; both the control poller and the
     # checkpoint writer's per-completion hook read from it.
     _executor_ref: dict[str, object] = {}
+
+    # Handed out on the result so a later phase sharing this engine run can
+    # exclude its own node from checkpointing before that node runs. Accepted
+    # as an argument so a caller can seed it, since the observer's writes are
+    # drained inside this call and a later phase's additions have to be
+    # visible to that drain.
+    if checkpoint_skip_ids is None:
+        checkpoint_skip_ids = set()
     _checkpoint_tasks: list = []
     _branch_status_tasks: list = []
     _escalation_link_tasks: list = []
@@ -1318,6 +1335,19 @@ async def _execute_dag(
         (not sig.name, which a spawned clone can share with a planned node)
         routes to record() vs record_spawned() to avoid key collisions."""
         if _checkpoint_writer is None:
+            return
+        # A node a later phase adds to the graph is neither a planned op nor a
+        # reactive spawn, and both branches below are wrong for it: record()
+        # would write the planned `ops` keyspace under a name no plan entry
+        # claims, and record_spawned() would hand resume something it rebuilds
+        # into the fresh graph as pre-completed work. The spawn soundness
+        # checks do not stop that, because they are written for role-spawned
+        # nodes and such a node passes each one vacuously -- no assignee, so
+        # the assignee/spawn_id pairing check does not apply, and no parent, so
+        # the parent-terminal check does not apply. Not recording is the honest
+        # answer: nothing about the phase needs restoring, since it is derived
+        # from results the checkpoint already holds.
+        if sig.op_id in checkpoint_skip_ids:
             return
         executor = _executor_ref.get("executor")
         response = None
@@ -2107,6 +2137,7 @@ async def _execute_dag(
         t_exec_elapsed=t_exec_elapsed,
         escalated_agent_ids=escalated_agent_ids,
         engine_run=eng_run,
+        checkpoint_skip_ids=checkpoint_skip_ids,
     )
 
 
@@ -2184,6 +2215,11 @@ async def _synthesize(
     # replayed nodes as completed.
     synth_graph = env.builder.get_graph()
     already_ran = {str(n.id) for n in synth_graph.internal_nodes.values()} - {str(synth_node)}
+    # The synthesis node's own signals stay audible, so the checkpoint
+    # observer registered during execution sees a node that did not exist
+    # when it was built and has no branch it belongs to. Exclude it before
+    # the pass rather than after: the observer fires during run_dag.
+    exec_result.checkpoint_skip_ids.add(str(synth_node))
     synth_result_raw = await exec_result.engine_run.run_dag(
         synth_graph,
         verbose=env.verbose,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -2176,9 +2176,18 @@ async def _synthesize(
     t_synth = time.monotonic()
     if exec_result.engine_run is None:
         raise RuntimeError("synthesis requires the engine run that executed the DAG")
+    # The graph still carries every worker node, because synthesis depends on
+    # them and the executor resolves those dependencies from it. They already
+    # ran in the execution phase, though, so this pass must not signal them
+    # again: that would write a second set of terminal events for work it did
+    # not do, and a checkpointed resume rebuilt from those events treats the
+    # replayed nodes as completed.
+    synth_graph = env.builder.get_graph()
+    already_ran = {str(n.id) for n in synth_graph.internal_nodes.values()} - {str(synth_node)}
     synth_result_raw = await exec_result.engine_run.run_dag(
-        env.builder.get_graph(),
+        synth_graph,
         verbose=env.verbose,
+        skip_signal_ops=already_ran,
     )
     t_synth_elapsed = time.monotonic() - t_synth
     synth_res = synth_result_raw.get("operation_results", {}).get(synth_node)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -764,6 +764,7 @@ class _ExecResult:
     n_spawned: int
     t_exec_elapsed: float
     escalated_agent_ids: list[str] = field(default_factory=list)
+    engine_run: Any | None = field(default=None, repr=False)
 
 
 # ── Phase 1: build DAG ────────────────────────────────────────────────────────
@@ -2105,6 +2106,7 @@ async def _execute_dag(
         n_spawned=n_spawned,
         t_exec_elapsed=t_exec_elapsed,
         escalated_agent_ids=escalated_agent_ids,
+        engine_run=eng_run,
     )
 
 
@@ -2172,7 +2174,12 @@ async def _synthesize(
         context=artifacts,
     )
     t_synth = time.monotonic()
-    synth_result_raw = await env.session.flow(env.builder.get_graph(), verbose=env.verbose)
+    if exec_result.engine_run is None:
+        raise RuntimeError("synthesis requires the engine run that executed the DAG")
+    synth_result_raw = await exec_result.engine_run.run_dag(
+        env.builder.get_graph(),
+        verbose=env.verbose,
+    )
     t_synth_elapsed = time.monotonic() - t_synth
     synth_res = synth_result_raw.get("operation_results", {}).get(synth_node)
     synthesis_result = {

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -630,11 +630,18 @@ class EngineRun:
         on_branch_created: Any = None,
         spawn_branch_setup: Any = None,
         on_op_complete: Any = None,
+        skip_signal_ops: set[Any] | None = None,
     ) -> dict[str, Any]:
-        """Execute a prebuilt operation DAG on the run's session and return operation results."""
+        """Execute a prebuilt operation DAG on the run's session and return operation results.
+
+        ``skip_signal_ops`` names ops that already ran in an earlier pass, so this
+        pass does not signal them a second time. Default signals every node.
+        """
         from .flow_signals import flow_progress_signals  # noqa: PLC0415
 
-        async with flow_progress_signals(self.session, graph) as on_progress:
+        async with flow_progress_signals(
+            self.session, graph, skip_ops=skip_signal_ops
+        ) as on_progress:
             result = await self.session.flow(
                 graph,
                 context=context,

--- a/lionagi/engines/flow_signals.py
+++ b/lionagi/engines/flow_signals.py
@@ -43,12 +43,26 @@ def _build_node_edge_meta(graph: Any) -> dict[str, dict]:
 
 @contextlib.asynccontextmanager
 async def flow_progress_signals(
-    session: Any, graph: Any
+    session: Any, graph: Any, *, skip_ops: set[Any] | None = None
 ) -> AsyncIterator[Callable[[str, str, str, float, bool], None]]:
     """Yield an ``on_progress`` callback that persists node-lifecycle signals; awaits
-    every emitted signal on exit so observers finish before the caller reads what they wrote."""
+    every emitted signal on exit so observers finish before the caller reads what they wrote.
+
+    ``skip_ops`` names ops that already ran in an earlier pass. A pass over a graph
+    whose nodes already ran reports those nodes again, and signalling them a second
+    time writes terminal events for work this pass did not do; a resume rebuilt from
+    those events treats the replay as completed. Naming what to *skip* rather than
+    what to signal is what keeps a node created during the pass audible: a spawn is
+    absent from the set because it did not exist when the caller named it, and its
+    first signal is emitted in the same synchronous admission call as the spawn
+    notification, so there is no moment at which a caller could have added it.
+    """
     emits: list[asyncio.Future] = []
     node_edge_meta = _build_node_edge_meta(graph)
+    # Normalised to str: node ids travel as UUID in the builder's return values and
+    # as str on the signals, so an un-normalised set matches nothing and silently
+    # replays every node it was given to suppress.
+    skipped: set[str] = set() if skip_ops is None else {str(op) for op in skip_ops}
 
     def _on_progress(
         op_id: str,
@@ -57,6 +71,8 @@ async def flow_progress_signals(
         elapsed: float,
         name_is_fallback: bool,
     ) -> None:
+        if op_id in skipped:
+            return
         meta = node_edge_meta.setdefault(op_id, {})
         parent_id = meta.get("parent_id")
         depends_on = meta.get("depends_on", [])

--- a/tests/cli/orchestrate/test_fanout_failure_visibility.py
+++ b/tests/cli/orchestrate/test_fanout_failure_visibility.py
@@ -113,10 +113,17 @@ def _one_fails_one_completes(session):
     graph with the synthesis node appended and completes that. ``passes`` records
     one entry per call, which is how a test tells the two phases apart."""
     passes: list = []
+    pass_kwargs: list = []
+    pass_node_ids: list = []
 
     async def run_dag(graph, **kwargs):
         passes.append(graph)
+        pass_kwargs.append(dict(kwargs))
         nodes = list(graph.internal_nodes.values())
+        # Snapshot the ids now: get_graph() hands back the builder's live graph,
+        # so a later read of `passes[0]` sees the synthesis node too and would
+        # describe the worker pass as having run work it had not yet been given.
+        pass_node_ids.append({str(n.id) for n in nodes})
         if len(passes) == 1:
             emits = [
                 _failed(session, nodes[0]),
@@ -132,6 +139,8 @@ def _one_fails_one_completes(session):
         return {"operation_results": {synth.id: "synthesis result"}}
 
     run_dag.passes = passes
+    run_dag.pass_kwargs = pass_kwargs
+    run_dag.pass_node_ids = pass_node_ids
     return run_dag
 
 
@@ -187,6 +196,16 @@ async def test_a_failed_worker_is_excluded_from_the_synthesis_context(
     assert synthesis_context == ["worker 2 result"]
     # Both phases execute through the engine, so synthesis is a second pass.
     assert len(run_dag.passes) == 2
+    # That second pass re-runs the worker nodes' graph, so it must name them as
+    # already-run. Signalling them again would record their work twice, and a
+    # resume rebuilt from the replayed terminal events would treat it as real.
+    worker_ids = run_dag.pass_node_ids[0]
+    assert worker_ids, "control: the worker pass must have had nodes to skip"
+    assert run_dag.pass_kwargs[1]["skip_signal_ops"] == worker_ids
+    # ...and the synthesis node itself is not skipped, or the run's own
+    # synthesis would leave no trace.
+    synth_ids = run_dag.pass_node_ids[1] - run_dag.pass_kwargs[1]["skip_signal_ops"]
+    assert len(synth_ids) == 1
 
 
 async def test_all_workers_failed_skips_synthesis_and_says_why(

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -2210,3 +2210,116 @@ def test_flow_resume_dispatch_maps_resume_error_to_failed_exit_code(caplog):
         code = run_orchestrate(args)
 
     assert code == 1
+
+
+async def test_checkpoint_observer_skips_a_declared_node_and_still_records_a_real_spawn(
+    tmp_path: Path,
+):
+    """A node a later phase adds to the graph must not reach the checkpoint.
+
+    The observer routes by membership in the execution phase's node set, which
+    is fixed before that phase runs. Synthesis adds its node afterwards and
+    reuses the same engine run, so its completion arrives at an observer that
+    has never heard of it and is recorded as a reactive spawn. Resume then
+    rebuilds it into the fresh graph as pre-completed work, and none of the
+    spawn soundness checks stop it: they are written for role-spawned nodes,
+    and this node has no assignee and no parent, so each check passes without
+    ever applying.
+
+    The second half of this test is the part that makes the first half mean
+    anything. An empty `spawned` list is also what a dead checkpoint path
+    produces, so an undeclared node is completed in the same run and must
+    still be recorded.
+    """
+    env = _make_resume_env(tmp_path)
+    env.session = Session(default_branch=Branch(name="orchestrator"))
+    env.run.checkpoint_path = tmp_path / "checkpoint.json"
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="research", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["claude"],
+    )
+
+    synth_node_id = str(uuid4())
+    real_spawn_id = str(uuid4())
+    # Seeded here because the observer's writes are drained inside
+    # _execute_dag; _synthesize adds to this same set object in production.
+    skip_ids = {synth_node_id}
+
+    fake_executor = SimpleNamespace(context=SimpleNamespace(content={}), results={})
+
+    async def _run_dag_result(*args, executor_ref=None, **_kw):
+        executor_ref["executor"] = fake_executor
+        await env.session.emit(
+            NodeCompleted(op_id="node-0", name="worker", elapsed=0.1, parent_id=None, depends_on=[])
+        )
+        # The synthesis node: declared, and shaped exactly like the case that
+        # slips every soundness check -- no assignee, no parent.
+        await env.session.emit(
+            NodeCompleted(
+                op_id=synth_node_id, name="synthesis", elapsed=0.1, parent_id=None, depends_on=[]
+            )
+        )
+        # A genuine reactive spawn in the same run: undeclared, so it must
+        # still land in `spawned`.
+        await env.session.emit(
+            NodeCompleted(
+                op_id=real_spawn_id,
+                name="spawned-child",
+                elapsed=0.1,
+                parent_id="node-0",
+                depends_on=[],
+            )
+        )
+        return {
+            "operation_results": {"node-0": "result-A"},
+            "spawned_operations": 1,
+            "escalated_operations": [],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = _run_dag_result
+
+    from lionagi.engines import PlanningEngine
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(
+            env,
+            plan_result,
+            dag_state,
+            max_concurrent=1,
+            max_ops=0,
+            checkpoint_prompt="write the brief",
+            checkpoint_plan=[{"agent_id": "worker"}],
+            checkpoint_config={"model_spec": "claude"},
+            checkpoint_skip_ids=skip_ids,
+        )
+
+    data = load_checkpoint(env.run.checkpoint_path)
+    spawned_ids = {e["node_id"] for e in data.get("spawned", [])}
+
+    assert synth_node_id not in spawned_ids, (
+        "a declared node must not be checkpointed as a reactive spawn; resume "
+        f"would rebuild it as pre-completed work. spawned={spawned_ids}"
+    )
+    assert real_spawn_id in spawned_ids, (
+        "the control failed: an undeclared spawn was not recorded either, so "
+        "this test cannot tell a working skip from a dead checkpoint path. "
+        f"spawned={spawned_ids}"
+    )
+    # The planned op is unaffected, and the skipped node did not leak into the
+    # planned keyspace by the other branch.
+    assert data["ops"]["worker"]["status"] == "completed"
+    assert "synthesis" not in data["ops"]

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -1431,10 +1431,10 @@ async def test_synthesize_returns_dict_with_model_key(tmp_path):
         ],
         n_spawned=0,
         t_exec_elapsed=1.0,
+        engine_run=SimpleNamespace(
+            run_dag=AsyncMock(return_value={"operation_results": {"node-0": "synthesized content"}})
+        ),
     )
-
-    # session.flow returns a synthesis response.
-    env.session.flow = _make_flow_returning("node-1", "synthesized content")
 
     result = await _synthesize(
         env,
@@ -1450,6 +1450,64 @@ async def test_synthesize_returns_dict_with_model_key(tmp_path):
     assert "model" in result
     assert "response" in result
     assert "time_ms" in result
+
+
+@pytest.mark.asyncio
+async def test_synthesize_reuses_execution_engine_lifecycle_bridge(tmp_path):
+    """Synthesis must use the same engine run that executed the worker DAG."""
+    env = _make_env(tmp_path)
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="x", assignee="researcher")],
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-worker"],
+        known_nodes={"node-worker"},
+        deps_by_node={"node-worker": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+    exec_result = _ExecResult(
+        agent_results=[
+            {
+                "id": "researcher",
+                "agent_id": "researcher",
+                "name": "researcher",
+                "response": "findings",
+            }
+        ],
+        n_spawned=0,
+        t_exec_elapsed=1.0,
+    )
+    engine_run = SimpleNamespace(
+        run_dag=AsyncMock(
+            return_value={"operation_results": {"node-0": "synthesized through engine"}}
+        )
+    )
+    exec_result.engine_run = engine_run
+    env.session.flow = _make_flow_returning("node-0", "direct session result")
+
+    result = await _synthesize(
+        env,
+        "task",
+        plan_result,
+        dag_state,
+        exec_result,
+        synthesis_model=None,
+        model_spec="codex/gpt-5.5",
+    )
+
+    engine_run.run_dag.assert_awaited_once_with(
+        env.builder.get_graph(),
+        verbose=env.verbose,
+    )
+    assert result is not None
+    assert result["response"] == "synthesized through engine"
 
 
 @pytest.mark.asyncio
@@ -1491,9 +1549,10 @@ async def test_synthesize_includes_spawned_artifact_dir(tmp_path):
         ],
         n_spawned=1,
         t_exec_elapsed=1.0,
+        engine_run=SimpleNamespace(
+            run_dag=AsyncMock(return_value={"operation_results": {"node-0": "synthesized content"}})
+        ),
     )
-
-    env.session.flow = _make_flow_returning("node-1", "synthesized content")
 
     await _synthesize(
         env,

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -1505,6 +1505,9 @@ async def test_synthesize_reuses_execution_engine_lifecycle_bridge(tmp_path):
     engine_run.run_dag.assert_awaited_once_with(
         env.builder.get_graph(),
         verbose=env.verbose,
+        # The synthesis node is the only node in this graph, so there is no
+        # earlier pass whose nodes have to be kept quiet.
+        skip_signal_ops=set(),
     )
     assert result is not None
     assert result["response"] == "synthesized through engine"
@@ -1997,3 +2000,64 @@ def _make_flow_returning(node_id: str, response: str):
         return {"operation_results": {node_id: response}}
 
     return _flow
+
+
+@pytest.mark.asyncio
+async def test_synthesize_keeps_already_executed_workers_out_of_the_signal_pass(tmp_path):
+    """Synthesis re-runs the whole graph, because the executor resolves the new
+    node's dependencies from it. The worker nodes already ran, so they are named
+    as skipped: signalling them here would record their work a second time and a
+    checkpointed resume rebuilt from those events would treat the replay as real.
+    """
+    env = _make_env(tmp_path)
+    # Two workers that the execution phase already ran.
+    worker_a = env.builder.add_operation("operate", branch=env.orc_branch, depends_on=[])
+    worker_b = env.builder.add_operation("operate", branch=env.orc_branch, depends_on=[worker_a])
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="x", assignee="researcher")],
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[worker_a, worker_b],
+        known_nodes={worker_a, worker_b},
+        deps_by_node={worker_a: [], worker_b: [worker_a]},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+    exec_result = _ExecResult(
+        agent_results=[
+            {"id": "researcher", "agent_id": "researcher", "name": "researcher", "response": "f"}
+        ],
+        n_spawned=0,
+        t_exec_elapsed=1.0,
+    )
+    exec_result.engine_run = SimpleNamespace(
+        run_dag=AsyncMock(return_value={"operation_results": {}})
+    )
+
+    await _synthesize(
+        env,
+        "task",
+        plan_result,
+        dag_state,
+        exec_result,
+        synthesis_model=None,
+        model_spec="codex/gpt-5.5",
+    )
+
+    kwargs = exec_result.engine_run.run_dag.await_args.kwargs
+    skipped = kwargs["skip_signal_ops"]
+    assert skipped == {worker_a, worker_b}, (
+        f"the executed workers must be kept out of the synthesis signal pass: {skipped}"
+    )
+    # The synthesis node is the work this pass actually does, so it must not be
+    # skipped -- suppressing it would make the run's own synthesis invisible.
+    graph_ids = {str(n.id) for n in env.builder.get_graph().internal_nodes.values()}
+    synth_ids = graph_ids - skipped
+    assert len(synth_ids) == 1, f"exactly one unskipped (synthesis) node expected: {synth_ids}"

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -2061,3 +2061,73 @@ async def test_synthesize_keeps_already_executed_workers_out_of_the_signal_pass(
     graph_ids = {str(n.id) for n in env.builder.get_graph().internal_nodes.values()}
     synth_ids = graph_ids - skipped
     assert len(synth_ids) == 1, f"exactly one unskipped (synthesis) node expected: {synth_ids}"
+
+
+async def test_synthesize_declares_its_node_as_uncheckpointable(tmp_path):
+    """The synthesis node must be named before the pass that runs it.
+
+    The checkpoint observer built during execution routes by a node set fixed
+    at that time, so it treats this later node as a reactive spawn. Declaring
+    it is what keeps it out of the checkpoint; ordering matters because the
+    observer fires while run_dag is running, not after it returns.
+    """
+    env = _make_env(tmp_path)
+    worker = env.builder.add_operation("operate", branch=env.orc_branch, depends_on=[])
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="x", assignee="researcher")],
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[worker],
+        known_nodes={worker},
+        deps_by_node={worker: []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+    exec_result = _ExecResult(
+        agent_results=[
+            {"id": "researcher", "agent_id": "researcher", "name": "researcher", "response": "f"}
+        ],
+        n_spawned=0,
+        t_exec_elapsed=1.0,
+    )
+
+    declared_when_called: set[str] = set()
+
+    async def _capture_run_dag(*_args, **_kw):
+        # Read the set as run_dag sees it: a declaration made after this
+        # returns would be too late for the observer.
+        declared_when_called.update(exec_result.checkpoint_skip_ids)
+        return {"operation_results": {}}
+
+    exec_result.engine_run = SimpleNamespace(run_dag=_capture_run_dag)
+
+    await _synthesize(
+        env,
+        "task",
+        plan_result,
+        dag_state,
+        exec_result,
+        synthesis_model=None,
+        model_spec="codex/gpt-5.5",
+    )
+
+    graph_ids = {str(n.id) for n in env.builder.get_graph().internal_nodes.values()}
+    synth_ids = graph_ids - {str(worker)}
+    assert len(synth_ids) == 1, f"expected exactly one synthesis node: {synth_ids}"
+    synth_id = synth_ids.pop()
+
+    assert synth_id in declared_when_called, (
+        "the synthesis node must be declared uncheckpointable BEFORE run_dag, "
+        f"since the observer fires during it. declared={declared_when_called}"
+    )
+    assert str(worker) not in declared_when_called, (
+        "only the synthesis node belongs in the skip set; skipping the planned "
+        f"worker would drop its checkpoint entry. declared={declared_when_called}"
+    )

--- a/tests/cli/orchestrate/test_run_flow_inner.py
+++ b/tests/cli/orchestrate/test_run_flow_inner.py
@@ -108,7 +108,12 @@ class _SessionBackedEngineRun:
         inspect.signature(EngineRun.run_dag).bind(self, graph, **kwargs)
         assert isinstance(graph, Graph)
         self.session.run_dag_calls.append((graph, dict(kwargs)))
-        if set(kwargs) == {"verbose"}:
+        # Route on a semantic difference between the phases rather than on the
+        # exact set of keywords: the execution phase builds worker branches and
+        # synthesis does not, so on_branch_created is what tells them apart.
+        # Keying on the whole kwargs set made this a second routing contract
+        # that had to be edited in step with every new run_dag option.
+        if "on_branch_created" not in kwargs:
             return await self.session.flow(graph, verbose=kwargs["verbose"])
         assert set(kwargs) == _RUN_DAG_KEYWORDS
         node_ids = tuple(node.id for node in graph.internal_nodes)

--- a/tests/cli/orchestrate/test_run_flow_inner.py
+++ b/tests/cli/orchestrate/test_run_flow_inner.py
@@ -107,8 +107,10 @@ class _SessionBackedEngineRun:
     async def run_dag(self, graph, **kwargs):
         inspect.signature(EngineRun.run_dag).bind(self, graph, **kwargs)
         assert isinstance(graph, Graph)
-        assert set(kwargs) == _RUN_DAG_KEYWORDS
         self.session.run_dag_calls.append((graph, dict(kwargs)))
+        if set(kwargs) == {"verbose"}:
+            return await self.session.flow(graph, verbose=kwargs["verbose"])
+        assert set(kwargs) == _RUN_DAG_KEYWORDS
         node_ids = tuple(node.id for node in graph.internal_nodes)
         assert len(node_ids) == len(self.session.execution_responses)
         return {
@@ -156,7 +158,7 @@ def _env(tmp_path, execution_responses: list[str], *, spawned_operations: int = 
 
 
 def _assert_run_dag_contract(env, *, expected_max_concurrent: int = 2) -> None:
-    assert len(env.session.run_dag_calls) == 1
+    assert env.session.run_dag_calls
     graph, kwargs = env.session.run_dag_calls[0]
     assert graph is env.builder.get_graph()
     on_branch_created = kwargs.pop("on_branch_created")
@@ -257,6 +259,7 @@ async def test_run_flow_inner_sequences_phases_and_propagates_results_to_synthes
         "[implementer via implementer]: implementation output",
     ]
     _assert_run_dag_contract(env)
+    assert len(env.session.run_dag_calls) == 2
     assert len(env.session.flow_calls) == 1
     assert "research output" in output
     assert "implementation output" in output
@@ -294,6 +297,7 @@ async def test_run_flow_inner_with_synthesis_controls_synthesis_gate(
     )
 
     _assert_run_dag_contract(env)
+    assert len(env.session.run_dag_calls) == 1 + int(expected_synthesis)
     assert len(env.session.flow_calls) == int(expected_synthesis)
     assert ("synthesized deliverable" in output) is expected_synthesis
     assert len(env.builder.get_graph().internal_nodes) == (3 if expected_synthesis else 2)

--- a/tests/operations/test_graph_entrypoint_conformance.py
+++ b/tests/operations/test_graph_entrypoint_conformance.py
@@ -3988,7 +3988,13 @@ async def test_synthesize_calls_execution_engine_with_builder_graph(tmp_path):
         model_spec="codex/gpt-5.5",
     )
 
-    run_dag_spy.assert_awaited_once_with(env.builder.get_graph(), verbose=False)
+    run_dag_spy.assert_awaited_once_with(
+        env.builder.get_graph(),
+        verbose=False,
+        # The synthesis node is the only node in this graph, so there is no
+        # earlier pass whose finished nodes have to be kept out of the signals.
+        skip_signal_ops=set(),
+    )
     passed_graph = run_dag_spy.call_args.args[0]
     assert passed_graph.nodes == env.builder._nodes
     assert len(passed_graph.nodes) == 1

--- a/tests/operations/test_graph_entrypoint_conformance.py
+++ b/tests/operations/test_graph_entrypoint_conformance.py
@@ -203,13 +203,14 @@ GRAPH_SURFACES: tuple[GraphSurface, ...] = (
         symbol="lionagi.cli.orchestrate.flow._synthesize",
         location=("lionagi/cli/orchestrate/flow.py", "_synthesize"),
         role="adapter",
-        expected_target="Session.flow",
+        expected_target="EngineRun.run_dag",
         persistence="inherited",
-        reason="CLI flow synthesis phase submits the final synthesis op directly through Session.flow "
-        "rather than the engine bridge; persistence setup is shared with cli-o-flow-exec",
+        reason="CLI flow synthesis phase; the final synthesis op is driven through the same "
+        "EngineRun.run_dag bridge as cli-o-flow-exec rather than being submitted directly to "
+        "Session.flow; persistence setup is shared with cli-o-flow-exec",
         delegation_test=(
             "tests/operations/test_graph_entrypoint_conformance.py::"
-            "test_synthesize_calls_env_session_flow_with_builder_graph"
+            "test_synthesize_calls_execution_engine_with_builder_graph"
         ),
     ),
     GraphSurface(

--- a/tests/operations/test_graph_entrypoint_conformance.py
+++ b/tests/operations/test_graph_entrypoint_conformance.py
@@ -3936,11 +3936,8 @@ async def test_execute_dag_delegates_to_planning_engine_run_dag(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_synthesize_calls_env_session_flow_with_builder_graph(tmp_path):
-    """cli-o-flow-synth: `_synthesize` submits the final synthesis op directly
-    through `env.session.flow`, a distinct call site from the run_dag bridge
-    cli-o-flow-exec uses — it needs its own identity-preserving probe rather
-    than relying on expected_target being read anywhere."""
+async def test_synthesize_calls_execution_engine_with_builder_graph(tmp_path):
+    """cli-o-flow-synth: synthesis reuses the execution engine's run_dag bridge."""
     from lionagi.casts.emission import TaskAssignment
     from lionagi.cli.orchestrate.flow import _DagState, _ExecResult, _PlanResult, _synthesize
     from tests.cli.orchestrate.test_flow_phases import _FakeBranch, _make_env
@@ -3965,6 +3962,7 @@ async def test_synthesize_calls_env_session_flow_with_builder_graph(tmp_path):
         role_base={},
         worker_models=["codex/gpt-5.5"],
     )
+    run_dag_spy = AsyncMock(return_value={"operation_results": {}, "completed_operations": []})
     exec_result = _ExecResult(
         agent_results=[
             {
@@ -3976,10 +3974,8 @@ async def test_synthesize_calls_env_session_flow_with_builder_graph(tmp_path):
         ],
         n_spawned=0,
         t_exec_elapsed=1.0,
+        engine_run=mock.MagicMock(run_dag=run_dag_spy),
     )
-
-    flow_spy = AsyncMock(return_value={"operation_results": {}, "completed_operations": []})
-    env.session.flow = flow_spy
 
     await _synthesize(
         env,
@@ -3991,8 +3987,8 @@ async def test_synthesize_calls_env_session_flow_with_builder_graph(tmp_path):
         model_spec="codex/gpt-5.5",
     )
 
-    flow_spy.assert_called_once()
-    passed_graph = flow_spy.call_args.args[0]
+    run_dag_spy.assert_awaited_once_with(env.builder.get_graph(), verbose=False)
+    passed_graph = run_dag_spy.call_args.args[0]
     assert passed_graph.nodes == env.builder._nodes
     assert len(passed_graph.nodes) == 1
 

--- a/tests/session/test_lifecycle_signals.py
+++ b/tests/session/test_lifecycle_signals.py
@@ -599,3 +599,95 @@ def test_lane_for_skipped_resets_on_a_genuine_retry():
     assert (
         lane_for([NodeSkipped(op_id="a", name="a"), NodeStarted(op_id="a", name="a")]) == "running"
     )
+
+
+# A second pass over an already-run graph must not replay its terminal events
+
+
+@pytest.mark.asyncio
+async def test_second_pass_does_not_replay_terminal_signals_for_finished_nodes():
+    """Synthesis adds a node to the executed graph and runs the graph again, because
+    the executor resolves the new node's dependencies from it. The finished nodes are
+    reported again by that pass, and signalling them a second time records work this
+    pass never did -- a resume rebuilt from those events treats the replay as completed.
+    """
+    from lionagi.engines import Engine
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+
+    async def work(**kw):
+        return "ok"
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("work", work)
+
+    completed: list[str] = []
+    session.observe(NodeCompleted, handler=lambda s, _: completed.append(s.op_id))
+
+    builder = OperationGraphBuilder()
+    worker = builder.add_operation("work")
+
+    run = Engine().new_run(session=session)
+    await run.run_dag(builder.get_graph())
+
+    assert completed == [str(worker)], "worker completes exactly once in the first pass"
+
+    # Second pass: a new node depending on the finished one, over the same graph.
+    synth = builder.add_operation("work", depends_on=[worker])
+    await run.run_dag(builder.get_graph(), skip_signal_ops={worker})
+
+    assert completed.count(str(worker)) == 1, (
+        f"the finished worker was signalled again by the second pass: {completed}"
+    )
+    assert str(synth) in completed, "the node this pass actually ran must still be signalled"
+
+
+@pytest.mark.asyncio
+async def test_skip_signal_ops_does_not_suppress_nodes_spawned_during_the_pass():
+    """A restricted pass names the work that already ran, which cannot name a node
+    that does not exist yet. A spawn is new work, not a replay, so it still signals."""
+    from lionagi.casts.emission import SpawnRequest
+    from lionagi.engines import Engine
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.operations.node import create_operation
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+
+    async def spawner(**kw):
+        return SpawnRequest(instruction="follow-up", independent=True)
+
+    async def follow_up(**kw):
+        return "child done"
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    session.register_operation("spawner", spawner)
+    session.register_operation("follow_up", follow_up)
+
+    queued_ids: list[str] = []
+    session.observe(NodeQueued, handler=lambda s, _: queued_ids.append(s.op_id))
+
+    def node_builder(req: Any, emitter: Any) -> Any:
+        return create_operation("follow_up", parameters={})
+
+    builder = OperationGraphBuilder()
+    root = builder.add_operation("spawner")
+
+    run = Engine().new_run(session=session)
+    result = await run.run_dag(
+        builder.get_graph(),
+        reactive=True,
+        node_builder=node_builder,
+        max_spawn=1,
+        skip_signal_ops={root},
+    )
+
+    assert result["spawned_operations"] == 1
+    spawned = [op for op in queued_ids if op != str(root)]
+    assert spawned, f"the spawned node was suppressed by skip_signal_ops: {queued_ids}"


### PR DESCRIPTION
## Summary

- carry the execution phase's existing Engine run through the internal flow result
- run synthesis through that same `EngineRun.run_dag` lifecycle bridge instead of calling `Session.flow` directly
- keep that pass from re-signalling the worker nodes it re-runs, so a second set of terminal events is never recorded for work the pass did not do
- preserve synthesis result, duration, exception, and artifact-output semantics
- fail explicitly if an internal caller tries to synthesize without the execution Engine context instead of silently dropping lifecycle signals

## Why the pass has to stay quiet about the workers

Synthesis re-runs the whole graph, because the executor resolves the new node's dependencies from it. Routing that pass through the lifecycle bridge means the finished workers are reported a second time, and each report writes another terminal event. The persistent checkpoint observer reads those events, so a resume rebuilds the replayed nodes as completed work with no assignee, no spawn id and no response, and the synthesis inputs are rebuilt from that. The same pass also paid the bridge's per-node cost across the entire graph on every run.

`flow_progress_signals` now takes the ops that already ran and stays quiet for them. It names what to **skip** rather than what to signal, which is what keeps a node created during the pass audible: a spawn's first signal is emitted in the same synchronous admission call as the spawn notification, so there is no moment at which a caller could have added it to an allow list. Ids are normalised to `str` on the way in, since they travel as `UUID` from the builder and as `str` on the signals, and a set matching neither would silently replay everything it was given to suppress.

The fan-out path is a second site of the same defect rather than adjacent work, and it is fixed here deliberately: it runs the same second pass over an already-executed graph, the identical call is present on `main` today, and nothing else in this branch touches that file. Fixing one site and leaving its live twin in the tree would leave the twin as the copy source for the next caller written against it.

## What does not change

- The first pass over a fresh graph signals every node, which is the default when no skip set is given.
- The Studio caller of the bridge is untouched and keeps signalling every node.
- A node created during a pass still signals, spawns included.

## Tests

`tests/session/test_lifecycle_signals.py`, `tests/cli/orchestrate/`, `tests/operations/test_flow_lifecycle_terminal.py`: 1325 passed.

Added, each mutation-probed with the expected reddened arms stated before running and reconciled after:

- a second pass over an already-run graph does not repeat the finished node's terminal event, and the node the pass actually runs still signals
- a node spawned during a restricted pass is still signalled
- synthesis names exactly the executed workers as already-run, and leaves the synthesis node itself out of that set
- the fan-out synthesis pass does the same, with the worker ids snapshotted at call time rather than read back afterwards, since `get_graph()` hands back the builder's live graph

The `run_dag` test double previously told the execution and synthesis phases apart by comparing the whole set of keyword names, so it carried a second routing contract that had to be edited in step with every new `run_dag` option. It now routes on a difference belonging to the phases themselves: the execution phase builds worker branches and synthesis does not.

Closes #3035

