### PR TITLE
fix(studio): separate Fleet orchestrations from agents

### DIFF
--- a/apps/studio/frontend/src/components/fleet/FleetView.groups.test.tsx
+++ b/apps/studio/frontend/src/components/fleet/FleetView.groups.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+import enMessages from "@/messages/en.json";
+import type { AgentRow } from "./fleetReducer";
+import { AgentSections } from "./FleetView";
+
+function row(id: string, name: string, invocationKind: string | null): AgentRow {
+  return {
+    id,
+    name,
+    status: "running",
+    effectiveHealth: null,
+    elapsedSec: 12,
+    branch_count: 1,
+    message_count: 2,
+    kind: "run",
+    invocation_id: null,
+    invocationKind,
+  };
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  container?.remove();
+  vi.unstubAllGlobals();
+  root = null;
+  container = null;
+});
+
+function renderRows(rows: AgentRow[]) {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(
+      <IntlProvider locale="en" messages={enMessages}>
+        <AgentSections agents={rows} selectedId={null} onSelectAgent={() => {}} />
+      </IntlProvider>,
+    );
+  });
+  return container;
+}
+
+describe("Fleet live rows", () => {
+  it("separates orchestration roots from single agents without exposing orchestration style", () => {
+    const view = renderRows([
+      row("flow-root", "Quarterly research", "fanout"),
+      row("agent-1", "Draft findings", "agent"),
+    ]);
+
+    const orchestrations = view.querySelector('[data-fleet-group="orchestrations"]');
+    const agents = view.querySelector('[data-fleet-group="agents"]');
+
+    expect(orchestrations).not.toBeNull();
+    expect(agents).not.toBeNull();
+    expect(orchestrations?.textContent).toContain("Quarterly research");
+    expect(orchestrations?.textContent).not.toContain("Draft findings");
+    expect(agents?.textContent).toContain("Draft findings");
+    expect(agents?.textContent).not.toContain("Quarterly research");
+
+    expect(view.textContent).not.toContain("fanout");
+    expect(view.querySelector('[title="fanout"]')).toBeNull();
+  });
+
+  it("keeps every row and preserves order inside each group", () => {
+    const view = renderRows([
+      row("agent-1", "First agent", "agent"),
+      row("flow-1", "First orchestration", "flow"),
+      row("agent-2", "Second agent", null),
+      row("play-2", "Second orchestration", "show-play"),
+    ]);
+
+    const names = (group: string) =>
+      Array.from(view.querySelectorAll(`[data-fleet-group="${group}"] button`)).map(
+        (button) => button.textContent,
+      );
+
+    expect(names("orchestrations")).toEqual([
+      expect.stringContaining("First orchestration"),
+      expect.stringContaining("Second orchestration"),
+    ]);
+    expect(names("agents")).toEqual([
+      expect.stringContaining("First agent"),
+      expect.stringContaining("Second agent"),
+    ]);
+  });
+});

--- a/apps/studio/frontend/src/components/fleet/FleetView.tsx
+++ b/apps/studio/frontend/src/components/fleet/FleetView.tsx
@@ -63,14 +63,6 @@ function AgentRowItem({
       aria-label={t("agentRow.ariaLabel", { name: agent.name })}
     >
       <StatusDot status={agent.status} />
-      {isPlayRoot(agent.invocationKind) && (
-        <span
-          className="shrink-0 rounded border border-edge px-1 py-0.5 font-data text-[length:var(--t-xs)] uppercase tracking-[0.04em] text-content-muted"
-          title={agent.invocationKind ?? undefined}
-        >
-          play
-        </span>
-      )}
       <span className="min-w-0 flex-1 truncate font-data text-[length:var(--t-sm)] text-content-primary">
         {agent.name}
       </span>
@@ -94,6 +86,46 @@ function AgentRowItem({
         {formatElapsed(agent.elapsedSec)}
       </span>
     </button>
+  );
+}
+
+export function AgentSections({
+  agents,
+  selectedId,
+  onSelectAgent,
+}: {
+  agents: AgentRow[];
+  selectedId: string | null;
+  onSelectAgent: (id: string) => void;
+}) {
+  const t = useTranslations("fleet");
+  const orchestrations = agents.filter((agent) => isPlayRoot(agent.invocationKind));
+  const singleAgents = agents.filter((agent) => !isPlayRoot(agent.invocationKind));
+  const groups = [
+    { key: "orchestrations", rows: orchestrations },
+    { key: "agents", rows: singleAgents },
+  ] as const;
+
+  return groups.map(({ key, rows }) =>
+    rows.length > 0 ? (
+      <section
+        key={key}
+        data-fleet-group={key}
+        aria-label={t(`counts.${key}`, { count: rows.length })}
+      >
+        <div className="border-t border-edge bg-surface-overlay px-4 py-1.5 font-ui text-[length:var(--t-xs)] font-semibold uppercase tracking-[0.08em] text-content-muted">
+          {t(`counts.${key}`, { count: rows.length })}
+        </div>
+        {rows.map((agent) => (
+          <AgentRowItem
+            key={agent.id}
+            agent={agent}
+            selected={selectedId === agent.id}
+            onSelect={onSelectAgent}
+          />
+        ))}
+      </section>
+    ) : null,
   );
 }
 
@@ -144,15 +176,7 @@ function OrgUnitGroup({
         </span>
       </div>
 
-      {/* Agent rows */}
-      {unit.agents.map((agent) => (
-        <AgentRowItem
-          key={agent.id}
-          agent={agent}
-          selected={selectedId === agent.id}
-          onSelect={onSelectAgent}
-        />
-      ))}
+      <AgentSections agents={unit.agents} selectedId={selectedId} onSelectAgent={onSelectAgent} />
 
       {unit.agents.length === 0 && (
         <div className="border-t border-edge px-4 py-2">


### PR DESCRIPTION
## Summary

- split Fleet's live rows into semantic `Orchestrations` and `Agents` sections using the existing play-root classification
- preserve row order and retain every matching live item
- remove the implementation-style `play` badge and raw flow/fanout/show-play tooltip
- keep existing search and filtering behavior unchanged

## Verification

- strict RED→GREEN DOM coverage for both sections and row preservation
- focused Fleet suite: 99 passed
- full Studio frontend: 78 files, 1,734 tests passed
- ESLint, TypeScript, production Vite build, Prettier, and diff checks passed

Closes #3052