### PR TITLE
fix(studio): report overdue cron schedules

### DIFF
--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -341,14 +341,38 @@ _HEALTH_FAILING_THRESHOLD = 1
 _HEALTH_FAILING_OUTCOMES = ("failed", "timed_out")
 
 
-def _schedule_cadence_seconds(row: dict[str, Any]) -> float | None:
-    # Shares the scheduler's own cadence resolution rather than retyping its
-    # fallback chain -- cron/at have no fixed period and resolve to None,
-    # which skips overdue detection for them rather than guessing from
-    # next_fire_at.
-    from ..scheduler.engine import resolve_schedule_cadence_seconds
+def _schedule_cadence_seconds(row: dict[str, Any], *, reference_at: float) -> float | None:
+    """Return the schedule's expected occurrence gap at ``reference_at``.
 
-    return resolve_schedule_cadence_seconds(row)
+    Fixed-period triggers share the scheduler's cadence resolver. Cron is not
+    fixed-period, so derive its local expected gap from two consecutive
+    occurrences after the last observed execution. This uses the same
+    timezone resolver as the scheduler and never trusts ``next_fire_at`` -- a
+    stored cursor is a promise, not execution evidence.
+    """
+    from ..scheduler.engine import resolve_schedule_cadence_seconds, resolve_schedule_timezone
+
+    cadence = resolve_schedule_cadence_seconds(row)
+    if cadence is not None or row.get("trigger_type") != "cron":
+        return cadence
+
+    expr = row.get("cron_expr")
+    if not expr:
+        return None
+    try:
+        from croniter import croniter
+
+        start = datetime.fromtimestamp(reference_at, tz=resolve_schedule_timezone(row).tzinfo)
+        occurrences = croniter(expr, start_time=start)
+        first = occurrences.get_next(float)
+        second = occurrences.get_next(float)
+        gap = second - first
+        return gap if math.isfinite(gap) and gap > 0 else None
+    except Exception:
+        # Creation/update validation prevents this for current rows. Preserve
+        # list/detail availability for malformed legacy rows instead of making
+        # a read-only health badge take the whole schedules endpoint down.
+        return None
 
 
 def compute_schedule_health(
@@ -391,7 +415,7 @@ def compute_schedule_health(
             "never-fired" if last_recorded_at is None and last_fired_at is None else "no-evidence"
         )
     else:
-        cadence_seconds = _schedule_cadence_seconds(row)
+        cadence_seconds = _schedule_cadence_seconds(row, reference_at=last_executed_at)
         overdue = (
             cadence_seconds is not None
             and cadence_seconds > 0

--- a/tests/apps_studio_server/test_schedule_health.py
+++ b/tests/apps_studio_server/test_schedule_health.py
@@ -314,10 +314,19 @@ async def test_disabled_takes_precedence_over_any_run_history(temp_db_path):
     assert detail["health_state"] == "disabled"
 
 
-async def test_cron_trigger_has_no_cadence_so_never_reports_overdue(temp_db_path):
+async def test_stopped_cron_schedule_reports_overdue(temp_db_path):
     sid = await _make_schedule(trigger_type="cron", cron_expr="0 18 * * *", interval_sec=None)
     now = time.time()
     await _seed_run(sid, status="completed", fired_at=now - 500_000)
+
+    row = await _list_row(sid)
+    assert row["health_state"] == "overdue"
+
+
+async def test_cron_schedule_firing_on_cadence_reports_healthy(temp_db_path):
+    sid = await _make_schedule(trigger_type="cron", cron_expr="*/5 * * * *", interval_sec=None)
+    now = time.time()
+    await _seed_run(sid, status="completed", fired_at=now - 60)
 
     row = await _list_row(sid)
     assert row["health_state"] == "healthy"


### PR DESCRIPTION
## Summary

- derive cron cadence from the next two occurrences after `last_executed_at` in the schedule's resolved timezone
- classify stopped cron schedules as overdue instead of permanently healthy
- keep on-cadence cron schedules healthy
- avoid trusting mutable `next_fire_at` as historical cadence evidence
- degrade safely for invalid legacy cron data without breaking schedule list/detail

## Verification

- strict RED→GREEN: a stopped daily cron changed from incorrect `healthy` to `overdue`
- on-cadence control remains `healthy`
- schedule health, timezone, recompute, and scheduler-engine suites: 152 passed
- Ruff format/check, Pyright (0 errors), and diff checks passed

Closes #3157