### PR TITLE
fix(agent): report MCP reachability accurately

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -147,14 +147,18 @@ async def create_agent(
     _apply_permissions(spec)
     _register_tools(branch, spec)
     _register_providers(branch, spec)
+    native_mcp_servers: frozenset[str] = frozenset()
     if resolved_mcp_servers is Unset:
-        await _load_mcp(branch, spec, trust_project_settings=trust_project_settings)
+        native_mcp_servers = await _load_mcp(
+            branch, spec, trust_project_settings=trust_project_settings
+        )
     _forward_mcp_to_cli_request(
         branch,
         spec,
         trust_project_settings=trust_project_settings,
         resolved_servers=resolved_mcp_servers,
         resolved_servers_explicit=resolved_mcp_explicit,
+        native_mcp_servers=native_mcp_servers,
     )
     _wire_external_hooks(branch, spec)
 
@@ -544,10 +548,10 @@ async def _load_mcp(
     spec: AgentSpec,
     *,
     trust_project_settings: bool = False,
-) -> None:
+) -> frozenset[str]:
     mcp_path = _resolve_mcp_path(spec, trust_project_settings=trust_project_settings)
     if mcp_path is None:
-        return
+        return frozenset()
 
     from lionagi.service.connections.mcp_wrapper import MCPSecurityConfig
 
@@ -572,6 +576,8 @@ async def _load_mcp(
                     f"{tool_name!r}, but the branch registry does not contain it"
                 )
             _attach_hooks(tool, spec, tool_name)
+
+    return frozenset(loaded)
 
 
 _MCP_FORWARDING_PROVIDERS = frozenset({*_CLAUDE_PROVIDER_NAMES, "codex"})
@@ -713,6 +719,7 @@ def _forward_mcp_to_cli_request(
     trust_project_settings: bool = False,
     resolved_servers: dict[str, Any] | None | UnsetType = Unset,
     resolved_servers_explicit: bool = False,
+    native_mcp_servers: Collection[str] = (),
 ) -> None:
     """Forward an MCP server set into the CLI provider's own request.
 
@@ -745,19 +752,28 @@ def _forward_mcp_to_cli_request(
             asked_for_servers=asked_for_servers,
         )
         if has_config:
-            import logging
-
-            # Scope the claim to what this call can see: one branch, whose
-            # provider was resolved from this one spec. Sibling branches in the
-            logging.getLogger(__name__).warning(
-                "MCP config present in AgentSpec but the active provider (%s) has "
-                "no MCP passthrough; MCP servers will not be reachable for this "
-                "branch (role %s, branch %s). Other branches resolve their own "
-                "providers and are not covered by this warning.",
-                provider,
-                spec.profile.role.name,
-                branch.id,
-            )
+            if native_mcp_servers:
+                logger.debug(
+                    "The active provider (%s) has no MCP passthrough, but server(s) "
+                    "%s are available to this branch through LionAGI's native MCP "
+                    "registration (role %s, branch %s).",
+                    provider,
+                    sorted(native_mcp_servers),
+                    spec.profile.role.name,
+                    branch.id,
+                )
+            else:
+                # Scope the claim to what this call can see: one branch, whose
+                # provider was resolved from this one spec. Sibling branches in the
+                logger.warning(
+                    "MCP config present in AgentSpec but the active provider (%s) has "
+                    "no MCP passthrough; MCP servers will not be reachable for this "
+                    "branch (role %s, branch %s). Other branches resolve their own "
+                    "providers and are not covered by this warning.",
+                    provider,
+                    spec.profile.role.name,
+                    branch.id,
+                )
         # No MCP-capable request model for this provider to forward into,
         # so this stays a silent no-op (mirrors _load_mcp's own shape).
         return

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -211,6 +211,57 @@ async def test_mcp_loader_rejects_returned_name_missing_from_registry(tmp_path, 
         await create_agent(config, load_settings=False)
 
 
+async def test_native_mcp_registration_is_not_reported_unreachable(tmp_path, monkeypatch, caplog):
+    """An API provider can use tools registered by LionAGI's native MCP path."""
+    import logging
+
+    from lionagi.protocols.action.manager import ActionManager
+    from lionagi.protocols.action.tool import Tool
+
+    mcp_file = tmp_path / "custom.mcp.json"
+    mcp_file.write_text('{"mcpServers": {"khive": {"command": "true"}}}')
+
+    async def fake_load_mcp_config(
+        self, config_path, server_names=None, update=False, mcp_security=None
+    ):
+        async def request(**kwargs):
+            return kwargs
+
+        self.register_tool(Tool(func_callable=request), update=update)
+        return {"khive": ["request"]}
+
+    monkeypatch.setattr(ActionManager, "load_mcp_config", fake_load_mcp_config)
+
+    config = AgentSpec.compose("implementer", model="openai/gpt-4.1-mini")
+    config.mcp_config_path = str(mcp_file)
+    config.mcp_servers = ["khive"]
+
+    with caplog.at_level(logging.WARNING, logger="lionagi.agent.factory"):
+        branch = await create_agent(config, load_settings=False)
+
+    assert "request" in branch.acts.registry
+    assert not any("will not be reachable" in record.getMessage() for record in caplog.records)
+
+
+def test_unforwardable_mcp_without_native_registration_still_warns(tmp_path, caplog):
+    """Keep the strong warning when neither MCP delivery path succeeded."""
+    import logging
+
+    from lionagi.agent.factory import _forward_mcp_to_cli_request
+    from lionagi.service.imodel import iModel
+
+    mcp_file = tmp_path / "custom.mcp.json"
+    mcp_file.write_text('{"mcpServers": {"khive": {"command": "true"}}}')
+    config = AgentSpec.compose("implementer", model="openai/gpt-4.1-mini")
+    config.mcp_config_path = str(mcp_file)
+    branch = Branch(chat_model=iModel(provider="openai", model="gpt-4.1-mini"))
+
+    with caplog.at_level(logging.WARNING, logger="lionagi.agent.factory"):
+        _forward_mcp_to_cli_request(branch, config)
+
+    assert any("will not be reachable" in record.getMessage() for record in caplog.records)
+
+
 async def test_create_agent_coding_permissions_recheck_user_mutated_args(tmp_path):
     """User pre-hooks must not be able to rewrite safe args after permission checks."""
     from lionagi.agent.permissions import PermissionPolicy


### PR DESCRIPTION
## Summary

- have native MCP loading return the server names actually registered on the branch
- suppress the strong “will not be reachable” warning when native ActionManager tools are already available
- retain the warning when neither native registration nor CLI forwarding can deliver the requested MCP servers
- leave forwarding architecture and tool registration behavior unchanged

## Verification

- strict RED→GREEN: the native `request` tool was present while the old code still emitted an unreachable warning
- native-available and no-native warning controls both pass
- four adjacent agent/factory suites: 142 passed
- Ruff, Pyright (0 errors), commit hooks, and post-rebase regressions passed
- rebased onto current `origin/main`

Closes #2918