### PR TITLE
fix(heartbeat): ignore zero-rate peers in stall thresholds

### DIFF
--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -131,7 +131,11 @@ def _heartbeat_warning(
     max_activity_rate = max(activity_rates)
     peer_rates = activity_rates.copy()
     peer_rates.remove(max_activity_rate)
-    activity_floor = statistics.median(peer_rates) if peer_rates else 0.0
+    # Agent process trees contain many blocked infrastructure descendants.
+    # Their exact-zero rates are not a working peer baseline; including them
+    # drives the median to zero and makes this relative discriminator inert.
+    active_peer_rates = [rate for rate in peer_rates if rate > 0]
+    activity_floor = statistics.median(active_peer_rates) if active_peer_rates else 0.0
     ratio_activity_cutoff = activity_floor * _DESCENDANT_CPU_ACTIVITY_RATIO
     fallback_activity_seconds = _DESCENDANT_CPU_FALLBACK_SECONDS * math.sqrt(
         sample_interval_seconds / _DESCENDANT_CPU_FALLBACK_INTERVAL_SECONDS

--- a/tests/orchestration/test_heartbeat.py
+++ b/tests/orchestration/test_heartbeat.py
@@ -50,6 +50,32 @@ def test_floor_ticks_without_working_delta_emit_stall_warning():
     assert "60s sample" in warning
 
 
+def test_zero_idle_peers_do_not_erase_relative_activity_floor():
+    """Never-scheduled descendants must not make peer comparison inert.
+
+    Agent trees commonly contain one working process, one ticking helper, and
+    several blocked helpers.  Including the blocked zero-rate processes in the
+    median makes it zero, so the relative cutoff disappears and only the
+    absolute fallback can decide.  Here the busiest process is only 3x the one
+    active peer, below the declared 4x discriminator, even though it easily
+    clears the absolute floor.
+    """
+    warning = _warning(
+        (
+            {41: 8.0, 42: 3.0, 43: 5.0, 44: 2.0, 45: 4.0},
+            True,
+        ),
+        (
+            {41: 9.8, 42: 3.6, 43: 5.0, 44: 2.0, 45: 4.0},
+            True,
+        ),
+        sample_interval_seconds=60,
+    )
+
+    assert warning is not None
+    assert "median peer rate" in warning
+
+
 @pytest.mark.parametrize(
     "current",
     [


### PR DESCRIPTION
## Summary

- compute peer-relative stall cutoffs from the median of non-zero peer CPU rates
- prevent blocked or dormant descendants from collapsing the relative threshold to zero
- retain existing absolute floor and no-active-peer behavior

## Verification

- strict RED: a sparse process tree with one active peer and three zero-rate descendants produced no warning before the fix
- the same fixture now detects the stalled process
- both heartbeat suites: 47/47 passed
- Ruff, formatting, Pyright (0 errors), commit hooks, and diff checks passed
- temporary 439MB environment and worktree were removed

Closes #2964