### PR TITLE
fix(mcp): distinguish declared from effective server sets

### DIFF
--- a/docs/internals/mcp.md
+++ b/docs/internals/mcp.md
@@ -297,12 +297,16 @@ Inconclusive (settle nothing about death):
 - `possibly_orphaned` flags a gone process with no end recorded whose loss
   wasn't conclusively established (unaskable pid, or an unpublishable
   transition) — advisory, never makes the run terminal.
-- `mcp_config*` mirror what `submit()`'s handle returned. `mcp_config_servers`:
-  `[]` means the question was settled with "none"; `null` means either the
-  caller named their own config (never read by this run), no config was found,
-  or the record predates the field — `mcp_config_reason` disambiguates the
-  first two. This reports what was RESOLVED, not that the child's provider
-  then actually started each server.
+- `mcp_config*` mirror what `submit()`'s handle returned.
+  `declared_mcp_servers` names only the servers in the config snapshot LionAGI
+  wrote: `[]` means that declaration was settled as empty; `null` means either
+  the caller named their own config (never read by this run), no config was
+  found, or the record predates the field — `mcp_config_reason` disambiguates
+  the first two. It is not an effective-capability report: a CLI provider may
+  merge global or cwd-resolved configuration and LionAGI does not observe which
+  declared servers started successfully. `mcp_config_servers` is retained as a
+  deprecated alias with the same value; it must not be read as the effective
+  server set.
 - `known` / `record_state`: only `"absent"` means the run is unknown;
   `"unreadable"`/`"wrong_shape"` mean a file is on disk and damaged — reporting
   either as unknown would send an operator away from a file that exists.

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1062,14 +1062,14 @@ def submit(
         mcp_config_source: str | None = None
         mcp_config_reason: str | None = None
         mcp_servers: dict[str, Any] | None = None
-        # Servers resolved for the run's workers, by name. `[]` means this run
-        # settled the question (caller disabled MCP, or a found config declares
-        # no servers) — `None` means it never resolved a set. This reports what
-        # was RESOLVED, not what the child's provider then managed to start.
-        mcp_config_servers: list[str] | None = None
+        # Server names declared in the config snapshot lionagi controls. `[]`
+        # means this layer settled its declaration as empty; `None` means it
+        # never inspected a set. Providers may merge their own global config,
+        # so this is deliberately not called the effective server set.
+        declared_mcp_servers: list[str] | None = None
         if no_mcp_config:
             mcp_config_reason = "mcp_disabled_by_caller"
-            mcp_config_servers = []
+            declared_mcp_servers = []
         elif mcp_config is not None:
             # Caller named the file; their flag is already on the line, so no
             # snapshot is taken or prepended (a second --mcp-config would let the
@@ -1098,13 +1098,13 @@ def submit(
                     # A settled "none" (as opposed to "no config found", which
                     # the resolver reports with the same null server map — only
                     # the reason string tells the two apart).
-                    mcp_config_servers = []
+                    declared_mcp_servers = []
                     mcp_config_source = str(resolution.source) if resolution.source else None
             else:
                 mcp_servers = resolution.servers
                 mcp_config_source = str(resolution.source) if resolution.source else None
                 mcp_config_path = str(d / _MCP_SNAPSHOT_FILENAME)
-                mcp_config_servers = sorted(
+                declared_mcp_servers = sorted(
                     mcp_servers
                 )  # readable order; child reads the snapshot file, not this list
                 options = ["--mcp-config", mcp_config_path, *options]
@@ -1174,7 +1174,9 @@ def submit(
         "mcp_config": mcp_config_path,
         "mcp_config_source": mcp_config_source,
         "mcp_config_reason": mcp_config_reason,
-        "mcp_config_servers": mcp_config_servers,
+        "declared_mcp_servers": declared_mcp_servers,
+        # Deprecated response/record alias; keep equal to the truthful name.
+        "mcp_config_servers": declared_mcp_servers,
         "submitted_at": _now_iso(),
         "finished_at": None,
         "status": "running",
@@ -1250,7 +1252,8 @@ def submit(
         "mcp_config": mcp_config_path,
         "mcp_config_source": mcp_config_source,
         "mcp_config_reason": mcp_config_reason,
-        "mcp_config_servers": mcp_config_servers,
+        "declared_mcp_servers": declared_mcp_servers,
+        "mcp_config_servers": declared_mcp_servers,
         "notify_sender": notify_sender,
     }
 
@@ -1631,6 +1634,12 @@ def status(run_id: str) -> dict[str, Any]:
     notify_delivery = (job or {}).get("notify_delivery")
     if notify_delivery is None and derived["terminal"]:
         notify_delivery = {"attempted": False}
+    declared_mcp_servers = (job or {}).get("declared_mcp_servers")
+    if job is not None and "declared_mcp_servers" not in job:
+        # Backfill the accurate name from records written before it existed.
+        # The old field is a deprecated alias for the same declared snapshot,
+        # never evidence of what a provider merged or actually loaded.
+        declared_mcp_servers = job.get("mcp_config_servers")
     persistence_degraded_reason = (
         manifest.get(_PERSISTENCE_DEGRADED_REASON_FIELD) if isinstance(manifest, dict) else None
     )
@@ -1662,7 +1671,8 @@ def status(run_id: str) -> dict[str, Any]:
         "mcp_config": (job or {}).get("mcp_config"),
         "mcp_config_source": (job or {}).get("mcp_config_source"),
         "mcp_config_reason": (job or {}).get("mcp_config_reason"),
-        "mcp_config_servers": (job or {}).get("mcp_config_servers"),
+        "declared_mcp_servers": declared_mcp_servers,
+        "mcp_config_servers": declared_mcp_servers,
         _PERSISTENCE_DEGRADED_REASON_FIELD: persistence_degraded_reason,
         "run": manifest,
         "log_tail": _tail((job or {}).get("log")),

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -436,7 +436,12 @@ _REGISTERED: tuple[Verb, ...] = (
     ),
     Verb(
         name="job.status",
-        summary="Current state of a background run: liveness, job record, CLI manifest.",
+        summary=(
+            "Current state of a background run: liveness, job record, CLI manifest. "
+            "declared_mcp_servers names only the servers in the config snapshot "
+            "LionAGI wrote; providers may merge other configuration, so it is not "
+            "the effective server set. mcp_config_servers is its deprecated alias."
+        ),
         executor="job",
         own_schema=_JOB_STATUS_SCHEMA,
     ),

--- a/tests/mcp/test_spawn_reports_its_server_set.py
+++ b/tests/mcp/test_spawn_reports_its_server_set.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""A run says which servers it gave its workers, without a read of the snapshot.
+"""A run names the servers LionAGI declared, without opening the snapshot.
 
 The set was already in hand when the snapshot was written and was simply not
-recorded, so a caller asking "did this leg even have the knowledge server" had to
-open the record on disk to find out. These tests pin the reported value in each
-way the question can be answered, and in particular that "none" and "cannot say"
-stay distinguishable — collapsing them would make the one case worth reporting,
-a run whose workers got no servers, read like a run nobody asked about.
+recorded, so a caller asking what LionAGI declared had to open the record on disk.
+These tests pin that value in each way the question can be answered, and keep
+"declared none" distinct from "LionAGI did not inspect the caller's config." A
+provider may merge its own configuration, so none of these assertions claim to
+describe the effective tool surface.
 
 Popen is doubled so no real `li` process is spawned.
 """
@@ -61,12 +61,26 @@ def test_a_resolved_set_is_reported_by_name_and_sorted(sandbox, submit_dir, no_s
 
     handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
 
-    assert handle["mcp_config_servers"] == ["khive", "lion"]
+    assert handle["declared_mcp_servers"] == ["khive", "lion"]
     # The snapshot on disk is the child's copy and has to agree with what the
     # handle claims; a handle describing a set the child was not given would be
     # worse than no handle at all.
     written = json.loads((sandbox / "jobs" / handle["run_id"] / "mcp-servers.json").read_text())
-    assert sorted(written["mcpServers"]) == handle["mcp_config_servers"]
+    assert sorted(written["mcpServers"]) == handle["declared_mcp_servers"]
+
+
+def test_submit_handle_names_the_snapshot_set_as_declared_not_effective(
+    sandbox, submit_dir, no_spawn
+):
+    """The handle must not imply this is the provider's effective server set."""
+    (submit_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"lion": {"command": "li"}, "khive": {"command": "kk"}}})
+    )
+
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    assert handle["declared_mcp_servers"] == ["khive", "lion"]
+    assert handle["mcp_config_servers"] == handle["declared_mcp_servers"]
 
 
 def test_status_carries_the_same_answer_as_the_handle(sandbox, submit_dir, no_spawn):
@@ -82,9 +96,47 @@ def test_status_carries_the_same_answer_as_the_handle(sandbox, submit_dir, no_sp
     handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
     st = jobs.status(handle["run_id"])
 
-    for field in ("mcp_config", "mcp_config_source", "mcp_config_reason", "mcp_config_servers"):
+    for field in (
+        "mcp_config",
+        "mcp_config_source",
+        "mcp_config_reason",
+        "declared_mcp_servers",
+        "mcp_config_servers",
+    ):
         assert st[field] == handle[field], field
-    assert st["mcp_config_servers"] == ["khive", "lion"]
+    assert st["declared_mcp_servers"] == ["khive", "lion"]
+
+
+def test_status_backfills_declared_name_from_the_deprecated_record_key(
+    sandbox, submit_dir, no_spawn
+):
+    """Existing records gain the truthful name without a migration."""
+    (submit_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"lion": {"command": "li"}, "khive": {"command": "kk"}}})
+    )
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+    record_path = sandbox / "jobs" / handle["run_id"] / "job.json"
+    record = json.loads(record_path.read_text())
+    assert record.pop("declared_mcp_servers") == ["khive", "lion"]
+    record_path.write_text(json.dumps(record))
+
+    st = jobs.status(handle["run_id"])
+
+    assert st["declared_mcp_servers"] == ["khive", "lion"]
+    assert st["mcp_config_servers"] == st["declared_mcp_servers"]
+
+
+def test_new_records_persist_the_declared_name_as_canonical(sandbox, submit_dir, no_spawn):
+    """A restarted server need not recover the new contract from an alias."""
+    (submit_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"lion": {"command": "li"}, "khive": {"command": "kk"}}})
+    )
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    record = json.loads((sandbox / "jobs" / handle["run_id"] / "job.json").read_text())
+
+    assert record["declared_mcp_servers"] == ["khive", "lion"]
+    assert record["mcp_config_servers"] == record["declared_mcp_servers"]
 
 
 def test_caller_asking_for_no_servers_reports_an_empty_set_not_null(sandbox, submit_dir, no_spawn):
@@ -93,9 +145,10 @@ def test_caller_asking_for_no_servers_reports_an_empty_set_not_null(sandbox, sub
 
     handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir), no_mcp_config=True)
 
-    assert handle["mcp_config_servers"] == []
+    assert handle["declared_mcp_servers"] == []
+    assert handle["mcp_config_servers"] == handle["declared_mcp_servers"]
     assert handle["mcp_config_reason"] == "mcp_disabled_by_caller"
-    assert jobs.status(handle["run_id"])["mcp_config_servers"] == []
+    assert jobs.status(handle["run_id"])["declared_mcp_servers"] == []
 
 
 def test_a_caller_named_config_reports_null_because_this_run_never_read_it(
@@ -114,16 +167,15 @@ def test_a_caller_named_config_reports_null_because_this_run_never_read_it(
         "agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir), mcp_config=str(theirs)
     )
 
-    assert handle["mcp_config_servers"] is None
+    assert handle["declared_mcp_servers"] is None
     assert handle["mcp_config_reason"] == "mcp_config_named_by_caller"
 
 
 def test_none_and_cannot_say_are_not_the_same_value(sandbox, submit_dir, no_spawn, tmp_path):
     """The distinction the whole field exists for, asserted directly.
 
-    Two runs, both of which gave their workers no servers this run can vouch
-    for, and they must not report the same thing: one settled the question, the
-    other never asked it.
+    LionAGI made an empty declaration for one run and did not inspect the
+    caller-owned config for the other. Those are not the same fact.
     """
     theirs = tmp_path / "theirs.json"
     theirs.write_text(json.dumps({"mcpServers": {"whatever": {"command": "w"}}}))
@@ -135,16 +187,16 @@ def test_none_and_cannot_say_are_not_the_same_value(sandbox, submit_dir, no_spaw
         "agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir), mcp_config=str(theirs)
     )
 
-    assert settled["mcp_config_servers"] == []
-    assert unasked["mcp_config_servers"] is None
-    assert settled["mcp_config_servers"] != unasked["mcp_config_servers"]
+    assert settled["declared_mcp_servers"] == []
+    assert unasked["declared_mcp_servers"] is None
+    assert settled["declared_mcp_servers"] != unasked["declared_mcp_servers"]
 
 
 def test_no_config_found_reports_null_and_says_where_it_looked(sandbox, submit_dir, no_spawn):
     """Nothing to resolve is "cannot say", and the reason names the search."""
     handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
 
-    assert handle["mcp_config_servers"] is None
+    assert handle["declared_mcp_servers"] is None
     assert handle["mcp_config_reason"].startswith("no_mcp_config_found_at_or_above:")
 
 
@@ -161,12 +213,12 @@ def test_a_config_declaring_no_servers_reports_an_empty_set(sandbox, submit_dir,
 
     handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
 
-    assert handle["mcp_config_servers"] == []
+    assert handle["declared_mcp_servers"] == []
     assert handle["mcp_config_reason"] == "mcp_config_declares_no_servers"
     # The file that answered is named, so a reader is not sent looking for a
     # config that was never consulted.
     assert handle["mcp_config_source"] == str(submit_dir / ".mcp.json")
-    assert jobs.status(handle["run_id"])["mcp_config_servers"] == []
+    assert jobs.status(handle["run_id"])["declared_mcp_servers"] == []
 
 
 def test_declaring_none_and_finding_no_config_are_different_answers(
@@ -184,8 +236,8 @@ def test_declaring_none_and_finding_no_config_are_different_answers(
     (submit_dir / ".mcp.json").unlink()
     nothing_found = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
 
-    assert declared_none["mcp_config_servers"] == []
-    assert nothing_found["mcp_config_servers"] is None
+    assert declared_none["declared_mcp_servers"] == []
+    assert nothing_found["declared_mcp_servers"] is None
 
 
 @pytest.mark.parametrize("kind", ["flow", "fanout"])
@@ -201,8 +253,8 @@ def test_other_kinds_report_their_server_set_too(sandbox, submit_dir, no_spawn, 
 
     handle = jobs.submit(kind, ["-m", "x"], prompt="do a thing", cwd=str(submit_dir))
 
-    assert handle["mcp_config_servers"] == ["khive", "lion"]
-    assert jobs.status(handle["run_id"])["mcp_config_servers"] == ["khive", "lion"]
+    assert handle["declared_mcp_servers"] == ["khive", "lion"]
+    assert jobs.status(handle["run_id"])["declared_mcp_servers"] == ["khive", "lion"]
 
 
 def test_a_record_written_before_the_field_existed_reads_as_cannot_say(
@@ -222,7 +274,9 @@ def test_a_record_written_before_the_field_existed_reads_as_cannot_say(
     record = json.loads(record_path.read_text())
     # Positive control: the key is there to begin with, so its removal is what
     # the assertion below is reading and not a path that never had it.
+    assert record.pop("declared_mcp_servers") == ["lion"]
     assert record.pop("mcp_config_servers") == ["lion"]
     record_path.write_text(json.dumps(record))
 
+    assert jobs.status(run_id)["declared_mcp_servers"] is None
     assert jobs.status(run_id)["mcp_config_servers"] is None


### PR DESCRIPTION
## Summary

- add canonical `declared_mcp_servers` to submit handles, persisted job records, and `job.status`
- keep `mcp_config_servers` as an equal-value deprecated alias for compatibility
- backfill the canonical field when reading legacy records that contain only the old key
- document that the snapshot reflects LionAGI's declared config, while providers may merge global or cwd config
- explicitly avoid presenting either field as the effective runtime tool surface

## Verification

- three strict RED→GREEN contracts cover submit handles, legacy status reads, and new-record persistence
- focused MCP suites: 325 passed
- Ruff check/format and commit hooks passed

Closes #2931