### PR TITLE
fix(orchestrate): honor routing-pack role models

### DIFF
--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -775,8 +775,14 @@ def _resolve_worker_model_spec(
     model_override: str | None = None,
 ) -> tuple[str, AgentProfile | None, Any]:
     """Resolve which model spec a worker with this role/override would use,
-    without building anything. Shared by `build_worker_branch` and
-    `worker_is_cli` so the resolution logic lives in exactly one place."""
+    without building anything.
+
+    Explicit ``--workers`` routing wins, then the selected pack's per-role
+    model, then the role profile's model. The profile is still returned when a
+    pack selects the model so its prompt and behavior remain attached. Shared
+    by `build_worker_branch` and `worker_is_cli` so the resolution logic lives
+    in exactly one place.
+    """
     # Pack per-role config (ADR-0043): model/effort/modes defaults for casts
     # roles. Ignored in bare mode (workers are the raw CLI spec there).
     w_cfg = None if env.bare else role_config(role, env.pack)
@@ -788,10 +794,10 @@ def _resolve_worker_model_spec(
         resolved_model, w_profile = resolve_worker_spec(role)
         if model_override:
             w_model = model_override
-        elif w_profile:
-            w_model = resolved_model
         elif w_cfg and w_cfg.model:
             w_model = w_cfg.model
+        elif w_profile:
+            w_model = resolved_model
         else:
             w_model = env.default_model_spec
 

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -45,6 +45,7 @@ from ._notify import register_flow_notify_scope, unregister_flow_notify_scope
 from ._orchestration import (
     EFFORT_MAP,
     OrchestrationEnv,
+    _resolve_worker_model_spec,
     attribute_worker_build_failure,
     available_roles,
     build_worker_branch,
@@ -54,8 +55,6 @@ from ._orchestration import (
     parse_orchestrator_provider,
     register_branch_hook,
     resolve_modes,
-    resolve_worker_spec,
-    role_config,
     role_roster,
     setup_orchestration,
     start_live_persist,
@@ -2841,17 +2840,16 @@ async def _run_flow_inner(
             if env.bare:
                 lines.append(f"  {agent_ids[i]}: {model_spec} (bare)")
                 continue
-            rm, rp = resolve_worker_spec(ta.assignee)
-            cfg = role_config(ta.assignee, env.pack)
-            if rp:
+            model, rp, cfg = _resolve_worker_model_spec(env, ta.assignee)
+            if cfg and cfg.model:
+                src = "pack"
+                modes = [] if rp else resolve_modes(ta.assignee, ta.modes or None, env.pack)
+            elif rp:
                 # A user profile supplies its own body — casts modes don't apply
                 # (profile shadows casts; ADR-0043 follow-up makes them compose).
-                model, src, modes = rm, "profile", []
-            elif cfg and cfg.model:
-                model, src = cfg.model, "pack"
-                modes = resolve_modes(ta.assignee, ta.modes or None, env.pack)
+                src, modes = "profile", []
             else:
-                model, src = model_spec, "default"
+                src = "default"
                 modes = resolve_modes(ta.assignee, ta.modes or None, env.pack)
             mode_str = f"  modes={modes}" if modes else ""
             lines.append(f"  {agent_ids[i]}: {model} ({src}){mode_str}")

--- a/tests/cli/orchestrate/test_flow_planning.py
+++ b/tests/cli/orchestrate/test_flow_planning.py
@@ -22,10 +22,10 @@ from lionagi.cli.orchestrate.flow import FlowPlanError, _parse_reactive, _run_fl
 def stub_profiles(monkeypatch):
     """Serve agent profiles from a dict instead of the machine's agents directories.
 
-    A user profile outranks a pack in model resolution, and profiles are
-    discovered from the git root, the working directory and its parents, and the
-    home directory — so a test that asserts on which source supplied a model
-    reads whatever profiles happen to be installed unless the loader is stubbed.
+    Profiles are discovered from the git root, the working directory and its
+    parents, and the home directory, so a test that asserts on which source
+    supplied a model reads whatever profiles happen to be installed unless the
+    loader is stubbed.
     """
     table: dict[str, AgentProfile] = {}
 
@@ -432,6 +432,50 @@ async def test_pack_routing_shown_in_dry_run(tmp_path, stub_profiles):
     )
     out = await _run_flow_inner("codex/gpt-5.5", "task", env=env, dry_run=True)
     assert "writer: codex/codex-cheap (pack)" in out
+
+
+def test_pack_model_overrides_profile_model_but_preserves_profile(tmp_path, stub_profiles):
+    """A pack routes the model while the role profile still supplies behavior."""
+    profile = AgentProfile(
+        name="writer",
+        model="openai/profile-model",
+        system_prompt="profile behavior",
+        raw_body="profile behavior",
+    )
+    stub_profiles["writer"] = profile
+    env = _pack_env(
+        tmp_path,
+        _FakeOrcBranch([]),
+        "name: test-routing\nroles:\n  writer:\n    model: codex/pack-model\n",
+    )
+
+    model, resolved_profile, _ = orch._resolve_worker_model_spec(env, "writer")
+
+    assert model == "codex/pack-model"
+    assert resolved_profile is profile
+
+
+@pytest.mark.asyncio
+async def test_pack_model_with_profile_is_reported_as_pack_in_dry_run(tmp_path, stub_profiles):
+    """Dry-run reports the same routing precedence the worker builder uses."""
+    stub_profiles["writer"] = AgentProfile(
+        name="writer",
+        model="openai/profile-model",
+        system_prompt="profile behavior",
+        raw_body="profile behavior",
+    )
+    orc = _FakeOrcBranch(
+        [SimpleNamespace(assignments=[TaskAssignment(task="draft docs", assignee="writer")])]
+    )
+    env = _pack_env(
+        tmp_path,
+        orc,
+        "name: test-routing\nroles:\n  writer:\n    model: codex/pack-model\n",
+    )
+
+    out = await _run_flow_inner("codex/gpt-5.5", "task", env=env, dry_run=True)
+
+    assert "writer: codex/pack-model (pack)" in out
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- use one model-resolution precedence: explicit `--workers` override, selected routing-pack role model, agent-profile model, then environment default
- preserve the selected `AgentProfile` for prompt, behavior, and injection even when the routing pack supplies the model
- make flow dry-run use the same resolver as runtime branch construction and CLI detection
- label routing-pack choices truthfully as `(pack)`

## Verification

- strict RED→GREEN: runtime previously returned the profile model and dry-run reported `(profile)`
- related planning/messenger/role-config suites: 79/79 passed
- full `tests/cli/orchestrate`: 855/855 passed
- Ruff, Pyright (0 errors), diff checks, and commit hooks passed

Closes #2982