### PR TITLE
fix(mcp): ground detached agents against undeliverable waits

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -21,6 +21,7 @@ from lionagi.ln.concurrency import (
     cancelled_exc_classes,
     run_async,
 )
+from lionagi.mcp.config import JOB_MARKER_ENV_VAR
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.protocols.messages import ActionRequest, AssistantResponse
 from lionagi.state import provenance as _provenance
@@ -66,6 +67,9 @@ from ._util import EXIT_CODE_BY_STATUS, classify_exception, validate_cwd_exists
 # Preset names supported by --preset.
 _PRESET_CHOICES = ("coding",)
 
+_DETACHED_EXECUTION_BOUNDARY = """[DETACHED EXECUTION BOUNDARY]
+This process was launched as a detached MCP job. No interactive harness is attached, so this turn cannot receive a background completion notification. Keep every command in the foreground. If a command tool yields a live execution handle, poll that same handle until it reaches a terminal result. Do not arm a monitor or finish a turn waiting for an external notification. Verify the requested outputs before reporting completion."""
+
 # --image extension -> MIME type, matching InstructionContent's data-URI allowlist
 # (lionagi/protocols/messages/instruction.py _DATA_IMAGE_RE: png/jpe?g/gif/webp).
 _IMAGE_MEDIA_TYPES = {
@@ -83,6 +87,15 @@ _KHIVE_INJECTION_COUNTERS = (
     "writeback_records",
     "writeback_failed",
 )
+
+
+def _apply_detached_execution_boundary(prompt: str) -> str:
+    """Tell detached MCP legs which interactive wait channel they do not have."""
+    if not os.environ.get(JOB_MARKER_ENV_VAR):
+        return prompt
+    if prompt.startswith(_DETACHED_EXECUTION_BOUNDARY):
+        return prompt
+    return f"{_DETACHED_EXECUTION_BOUNDARY}\n\n{prompt}"
 
 
 def _fold_injection_stats(totals: dict[str, int], stats: object) -> None:
@@ -608,6 +621,7 @@ async def _run_agent(
 
     session_id is None whenever live persistence never started.
     """
+    prompt = _apply_detached_execution_boundary(prompt)
     seed_injection_totals = _injection_totals is None
     _injection_totals = (
         dict.fromkeys(_KHIVE_INJECTION_COUNTERS, 0)

--- a/tests/cli/test_agent_detached_execution_notice.py
+++ b/tests/cli/test_agent_detached_execution_notice.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Detached MCP agent runs must know that nobody can wake a background wait."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.cli.test_agent_resume_on_timeout import _wire_agent_stubs
+
+
+@pytest.mark.asyncio
+async def test_detached_agent_receives_undeliverable_wait_boundary(monkeypatch, tmp_path):
+    monkeypatch.setenv("LIONAGI_MCP_JOB_RUN_ID", "20260811T120000-abcdef")
+    _, instructions, _ = _wire_agent_stubs(
+        monkeypatch,
+        tmp_path,
+        operate_side_effect=lambda _: "output",
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent("codex/model", "run the long test gate", bypass=True)
+
+    [prompt] = instructions
+    assert prompt.endswith("run the long test gate")
+    assert "DETACHED EXECUTION BOUNDARY" in prompt
+    assert "cannot receive a background completion notification" in prompt
+    assert "foreground" in prompt
+    assert "poll" in prompt
+
+
+@pytest.mark.asyncio
+async def test_interactive_agent_prompt_is_unchanged(monkeypatch, tmp_path):
+    monkeypatch.delenv("LIONAGI_MCP_JOB_RUN_ID", raising=False)
+    _, instructions, _ = _wire_agent_stubs(
+        monkeypatch,
+        tmp_path,
+        operate_side_effect=lambda _: "output",
+    )
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent("codex/model", "run the long test gate", bypass=True)
+
+    assert instructions == ["run the long test gate"]


### PR DESCRIPTION
Closes #3158

## Summary

- detect `li agent` executions launched as detached MCP jobs through the stamped `LIONAGI_MCP_JOB_RUN_ID` identity
- prepend an idempotent detached-execution boundary to the agent context: there is no interactive harness or completion-notification channel, commands must stay foreground or be polled through the same handle, and outputs must be verified before completion
- leave interactive `li agent` prompts byte-for-byte unchanged

This implements option 2 from the issue. It makes the constraint part of the run's own planning context, but intentionally does not claim hard tool denial or a new terminal reason code.

## Verification

- strict RED: detached integration test observed the raw user prompt with no execution boundary; interactive control already passed
- focused detached/interactive tests: 2 passed
- MCP jobs/spawn suites: 227 passed
- agent suite: 543 passed; one known environment-sensitive test deselected because it also fails unchanged main under the local declared-secrets configuration
- Ruff, formatting, diff check, pre-commit, and targeted Pyright (0 errors) passed