### PR TITLE
fix(flow): surface refused reactive spawns

### DIFF
--- a/docs/internals/mcp.md
+++ b/docs/internals/mcp.md
@@ -509,6 +509,14 @@ already finished, or a read that has already published a durable end, and
 neither can be failed by a notifier. Every way a delivery does not happen
 comes back as an outcome describing it.
 
+When this hook is launched by the flow terminal adapter, the adapter's
+versioned payload is already present in `LIONAGI_NOTIFY_PAYLOAD`. The hook
+accepts its `reason_code` only if it belongs to the controlled runtime
+vocabulary, then preserves it on the MCP job record and offers it to the
+configured downstream notifier. This prevents a degraded completed flow from
+being flattened back to `run.completed.ok` at the outer job boundary; malformed
+or unregistered environment content is ignored rather than persisted.
+
 ### `mcp/projection.py`
 
 #### accepts-no-values-required-unenforced

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -288,6 +288,12 @@ StateDB/legacy-transition compatibility mapping (`adapters`).
 
 ### `state/reasons.py`
 
+- `RunReasons.COMPLETED_SPAWN_REFUSED` — the planned DAG reached completion,
+  but one or more reactive `SpawnRequest`s were refused after the run exhausted
+  its spawn capacity. Status remains `completed`; the non-clean reason and
+  `refused_spawn` evidence distinguish it from a run that never requested more
+  work. The same reason is preserved when child sessions roll up to an
+  invocation.
 - `ScheduleReasons` — the `schedule.skipped.` prefix is **not** the full set of
   reasons a skipped `schedule_run` can carry. `DEFERRED_CAPACITY` and
   `BUDGET_EXHAUSTED` land on skipped rows without that prefix, and a third

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -525,6 +525,7 @@ async def _teardown_common(
     identity_markers: dict | None = None,
     escalated_evidence: list[dict] | None = None,
     failed_operation_evidence: list[dict] | None = None,
+    spawn_refusal_evidence: list[dict] | None = None,
     finalize_error: dict | None = None,
     artifact_write_error: dict | None = None,
     gate_rejected_evidence: list[dict] | None = None,
@@ -741,6 +742,25 @@ async def _teardown_common(
         )
         final_evidence_refs = gate_rejected_evidence
 
+    # A capacity-refused SpawnRequest is work the live DAG asked to perform
+    # but was not allowed to add. The planned graph may still complete, so keep
+    # the terminal status at ``completed`` while distinguishing it from a run
+    # that never needed to grow. The reason code reaches Studio status and the
+    # terminal-callback envelope; the evidence names each requesting node.
+    if spawn_refusal_evidence:
+        from lionagi.state.reasons import RunReasons
+
+        metadata = dict(metadata or {})
+        metadata["spawn_refusal_count"] = len(spawn_refusal_evidence)
+        metadata["spawn_refusals"] = spawn_refusal_evidence
+        if final_status == "completed":
+            final_reason_code = RunReasons.COMPLETED_SPAWN_REFUSED
+            final_reason_summary = (
+                f"{len(spawn_refusal_evidence)} reactive spawn request(s) were refused "
+                "because the run's spawn capacity was exhausted."
+            )
+            final_evidence_refs = spawn_refusal_evidence
+
     # Completion-trust gate: don't accept "completed" on faith. Require a git trace
     # (commits ahead/dirty tree) or a durable assistant response as real evidence.
     # Skipped when gate_rejected_evidence fired above: a gate rejection is itself
@@ -751,6 +771,7 @@ async def _teardown_common(
     if (
         final_status == "completed"
         and not gate_rejected_evidence
+        and not spawn_refusal_evidence
         and not (verification and verification.get("produced"))
     ):
         from lionagi.state.completion_evidence import (
@@ -941,6 +962,7 @@ async def teardown_persist(
     extras: dict | None = None,
     escalated_evidence: list[dict] | None = None,
     failed_operation_evidence: list[dict] | None = None,
+    spawn_refusal_evidence: list[dict] | None = None,
     finalize_error: dict | None = None,
     artifact_write_error: dict | None = None,
     gate_rejected_evidence: list[dict] | None = None,
@@ -966,6 +988,7 @@ async def teardown_persist(
             identity_markers=ctx.get("identity_markers"),
             escalated_evidence=escalated_evidence,
             failed_operation_evidence=failed_operation_evidence,
+            spawn_refusal_evidence=spawn_refusal_evidence,
             finalize_error=finalize_error,
             artifact_write_error=artifact_write_error,
             gate_rejected_evidence=gate_rejected_evidence,

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -533,6 +533,10 @@ class OrchestrationEnv:
     budget_deadline_epoch: float | None = None
     _live_persist: dict | None = field(default=None, repr=False)
     _run_manifest: dict[str, Any] = field(default_factory=dict, repr=False)
+    # Capacity-refused reactive work, populated after DAG execution and
+    # consumed by terminal persistence. Kept on the run env so it survives
+    # the phase boundary without being confused with operation failures.
+    _spawn_refusal_evidence: list[dict[str, Any]] = field(default_factory=list, repr=False)
     _name_counts: dict[str, int] = field(default_factory=dict)
     _all_names: list[str] = field(default_factory=list)
 
@@ -1652,6 +1656,7 @@ async def stop_live_persist(
     extras = getattr(env, "_finalize_extras", None)
     escalated_evidence = getattr(env, "_escalated_evidence", None)
     failed_operation_evidence = getattr(env, "_failed_operation_evidence", None)
+    spawn_refusal_evidence = getattr(env, "_spawn_refusal_evidence", None)
     finalize_error = getattr(env, "_finalize_error", None)
     artifact_write_error = getattr(env, "_artifact_write_error", None)
     gate_rejected_evidence = getattr(env, "_gate_rejected_evidence", None)
@@ -1662,6 +1667,7 @@ async def stop_live_persist(
         extras=extras,
         escalated_evidence=escalated_evidence,
         failed_operation_evidence=failed_operation_evidence,
+        spawn_refusal_evidence=spawn_refusal_evidence,
         finalize_error=finalize_error,
         artifact_write_error=artifact_write_error,
         gate_rejected_evidence=gate_rejected_evidence,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -164,17 +164,33 @@ def _heartbeat_warning(
 
 def _surface_dropped_spawns(env: OrchestrationEnv, dropped_spawns: list[dict]) -> None:
     rejected = [item for item in dropped_spawns if item.get("reason") == "builder_error"]
-    if not rejected:
-        return
+    if rejected:
+        evidence = []
+        for item in rejected:
+            assignee = item.get("assignee") or "unassigned"
+            error = item.get("error") or "spawn routing failed"
+            progress(f"  ⚠ SPAWN REJECTED: {assignee} — {error}")
+            evidence.append({"kind": "unroutable_spawn", "id": assignee, "label": error})
+        prior = getattr(env, "_failed_operation_evidence", None) or []
+        env._failed_operation_evidence = [*prior, *evidence]
 
-    evidence = []
-    for item in rejected:
-        assignee = item.get("assignee") or "unassigned"
-        error = item.get("error") or "spawn routing failed"
-        progress(f"  ⚠ SPAWN REJECTED: {assignee} — {error}")
-        evidence.append({"kind": "unroutable_spawn", "id": assignee, "label": error})
-    prior = getattr(env, "_failed_operation_evidence", None) or []
-    env._failed_operation_evidence = [*prior, *evidence]
+    refused = [item for item in dropped_spawns if item.get("reason") == "max_spawn_exceeded"]
+    if refused:
+        evidence = []
+        for item in refused:
+            assignee = item.get("assignee") or "unassigned"
+            emitter_id = str(item.get("emitter_id") or item.get("op_id") or assignee)
+            reason = str(item.get("reason"))
+            progress(f"  ⚠ SPAWN REFUSED: {emitter_id} → {assignee} — {reason}")
+            evidence.append(
+                {
+                    "kind": "refused_spawn",
+                    "id": emitter_id,
+                    "label": f"{assignee} ({reason})",
+                }
+            )
+        prior = getattr(env, "_spawn_refusal_evidence", None) or []
+        env._spawn_refusal_evidence = [*prior, *evidence]
 
 
 class FlowPlanError(LionError):
@@ -585,6 +601,25 @@ async def _resolve_invocation_terminal_flow(
                     metadata,
                 )
             if all(s == "completed" for s in child_statuses):
+                spawn_refused = [
+                    s
+                    for s in sessions
+                    if str(s.get("status_reason_code") or "") == RunReasons.COMPLETED_SPAWN_REFUSED
+                ]
+                if spawn_refused:
+                    spawn_metadata = dict(metadata)
+                    spawn_metadata["spawn_refused_session_ids"] = [
+                        s["id"] for s in spawn_refused if s.get("id")
+                    ]
+                    return (
+                        "completed",
+                        RunReasons.COMPLETED_SPAWN_REFUSED,
+                        "Flow completed, but at least one child session refused "
+                        "reactively requested work because its spawn capacity "
+                        "was exhausted.",
+                        [{"kind": "session", "id": s["id"]} for s in spawn_refused if s.get("id")],
+                        spawn_metadata,
+                    )
                 # A "completed" child may still carry COMPLETED_GATE_REJECTED
                 # (a gate rejected mid-DAG and short-circuited its dependent
                 # subtree) — surface that at the invocation level too, or it

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -177,6 +177,29 @@ def _delivery_env(sender: str) -> dict[str, str] | None:
     return env
 
 
+def _terminal_reason_from_env() -> str | None:
+    """Read the flow callback's controlled reason from its versioned payload.
+
+    The MCP hook is itself launched as a flow ``--notify`` adapter, whose
+    payload is already carried in ``LIONAGI_NOTIFY_PAYLOAD``. Accept only a
+    registered reason code so an inherited free-form environment value can
+    never become unbounded status data or downstream notification content.
+    """
+    raw = os.environ.get("LIONAGI_NOTIFY_PAYLOAD")
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+        reason_code = payload.get("reason_code") if isinstance(payload, dict) else None
+        if not isinstance(reason_code, str):
+            return None
+        from lionagi.state.reasons import validate_reason_code
+
+        return validate_reason_code(reason_code)
+    except (TypeError, ValueError):
+        return None
+
+
 def _resolve_delivery_cwd(
     job: dict[str, Any] | None, override: str | None
 ) -> tuple[str | None, str | None]:
@@ -359,6 +382,7 @@ def deliver_terminal_notice(
     target: str | None = None,
     command: str | None = None,
     sender: str | None = None,
+    reason_code: str | None = None,
 ) -> dict[str, Any]:
     """Attempt this run's configured terminal notice and report what came of it.
 
@@ -401,6 +425,8 @@ def deliver_terminal_notice(
             "target": target,
             "sender": sender,
         }
+        if reason_code:
+            fields["reason_code"] = reason_code
         return _deliver(
             _substitute(template, fields),
             fields,
@@ -434,7 +460,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = ap.parse_args(argv)
 
-    terminal = jobs.mark_terminal(args.run_id, args.status)
+    reason_code = _terminal_reason_from_env()
+    terminal = jobs.mark_terminal(args.run_id, args.status, reason_code=reason_code)
     if terminal.refused:
         # End not on disk — no notice sent, since it would assert a
         # completion the record contradicts; run stays non-terminal.
@@ -461,6 +488,7 @@ def main(argv: list[str] | None = None) -> int:
         target=args.target,
         command=args.command,
         sender=args.sender,
+        reason_code=(terminal.record or {}).get("reason_code") or reason_code,
     )
     recorded = jobs.record_notify_delivery(args.run_id, outcome)
     _note_delivery_in_console_log(args.run_id, outcome)

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -2352,7 +2352,7 @@ async def wait(
     }
 
 
-def mark_terminal(run_id: str, cli_status: str) -> WriteResult:
+def mark_terminal(run_id: str, cli_status: str, *, reason_code: str | None = None) -> WriteResult:
     """Record a terminal status for *run_id* (called by the CLI notify hook).
 
     The CLI's terminal status is trusted and recorded verbatim, never matched
@@ -2372,6 +2372,8 @@ def mark_terminal(run_id: str, cli_status: str) -> WriteResult:
             return WriteResult(job, guard.state)
         job["status"] = cli_status
         job["cli_status"] = cli_status
+        if reason_code:
+            job["reason_code"] = reason_code
         job["finished_at"] = _now_iso()
         # The hook fires as the run ends, so this is the end as it happened.
         job["finished_at_precision"] = FINISHED_AT_OBSERVED

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -71,6 +71,9 @@ class RunReasons:
     # baseline -- the run genuinely completed, so status stays "completed",
     # but the reason distinguishes it from a clean pass
     COMPLETED_GATE_REJECTED = "run.completed.gate_rejected"
+    # the planned DAG completed, but at least one reactive SpawnRequest was
+    # refused because the run had no remaining spawn capacity
+    COMPLETED_SPAWN_REFUSED = "run.completed.spawn_refused"
     # unlike COMPLETED_FINALIZE_ERROR, a raised write failure is a real failure
     # (status -> failed); distinct from FAILED_MISSING_ARTIFACT's post-hoc gap
     FAILED_ARTIFACT_WRITE = "run.failed.artifact_write"

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2131,6 +2131,52 @@ async def test_gate_rejection_reason_survives_child_to_invocation_resolution(
     assert any(entry.get("id") == ctx["session_id"] for entry in evidence)
 
 
+async def test_spawn_refusal_is_degraded_in_session_and_invocation_status(
+    temp_db_path: Path,
+):
+    """A refused reactive spawn stays a completed run but cannot read clean.
+
+    The session is Studio's run-detail status source and the invocation is the
+    terminal-notify source for an MCP flow. Both layers must retain the same
+    degraded reason instead of flattening it to ``run.completed.ok``.
+    """
+    from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
+    from lionagi.state.reasons import RunReasons
+
+    invocation_id = "inv-spawn-refused"
+    async with StateDB() as db:
+        await db.create_invocation({"id": invocation_id, "skill": "flow", "started_at": 0.0})
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", invocation_id=invocation_id)
+    ctx = env._live_persist
+    assert ctx is not None
+    env._spawn_refusal_evidence = [
+        {
+            "kind": "refused_spawn",
+            "id": "parent-op",
+            "label": "reviewer (max_spawn_exceeded)",
+        }
+    ]
+
+    assert await stop_live_persist(env, status="completed") == "completed"
+
+    async with StateDB() as db:
+        session = await db.get_session(ctx["session_id"])
+    assert session["status"] == "completed"
+    assert session["status_reason_code"] == RunReasons.COMPLETED_SPAWN_REFUSED
+    assert "1 reactive spawn" in (session["status_reason_summary"] or "")
+    assert session["status_evidence_refs"] == env._spawn_refusal_evidence
+
+    status, reason_code, _summary, evidence, _metadata = await _resolve_invocation_terminal_flow(
+        invocation_id, fallback_status="completed"
+    )
+    assert status == "completed"
+    assert reason_code == RunReasons.COMPLETED_SPAWN_REFUSED
+    assert reason_code != RunReasons.COMPLETED_OK
+    assert evidence == [{"kind": "session", "id": ctx["session_id"]}]
+
+
 async def test_all_legs_completed_resolves_invocation_completed(
     temp_db_path: Path,
     tmp_path: Path,

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -76,6 +76,42 @@ def test_marks_terminal_without_delivery(job, monkeypatch):
     assert jobs.status(job)["notify_delivery"] == {"attempted": False}
 
 
+def test_flow_terminal_reason_reaches_mcp_status_and_delivery(job, monkeypatch):
+    """The nested MCP hook must retain the flow callback's degraded reason.
+
+    The flow notify adapter supplies its versioned payload in the child env.
+    Losing that reason here flattens ``completed + spawn_refused`` back to a
+    clean MCP job and sends the downstream notice without the degradation.
+    """
+    captured: dict = {}
+
+    def fake_run(argv, **kw):
+        captured["argv"] = argv
+        captured["input"] = kw.get("input")
+        return _FakeCompleted(0)
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+    monkeypatch.setenv(
+        "LIONAGI_NOTIFY_PAYLOAD",
+        json.dumps(
+            {
+                "status": "completed",
+                "reason_code": "run.completed.spawn_refused",
+            }
+        ),
+    )
+    command = json.dumps(["notify", "{reason_code}"])
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    assert rc == 0
+    rec = jobs._read_job(job)
+    assert rec["reason_code"] == "run.completed.spawn_refused"
+    assert jobs.status(job)["reason_code"] == "run.completed.spawn_refused"
+    assert captured["argv"] == ["notify", "run.completed.spawn_refused"]
+    assert json.loads(captured["input"])["reason_code"] == "run.completed.spawn_refused"
+
+
 def test_command_override_substitutes_and_delivers(job, monkeypatch):
     captured: dict = {}
 

--- a/tests/orchestration/test_patterns.py
+++ b/tests/orchestration/test_patterns.py
@@ -123,6 +123,39 @@ class TestRoleNodeBuilder:
         ]
         assert any("SPAWN REJECTED" in line and "missing" in line for line in emitted)
 
+    def test_spawn_refused_by_capacity_is_visible_as_degraded_evidence(self, monkeypatch):
+        """A cap refusal is requested work the executor did not perform.
+
+        It must not be folded into the builder-error failure path, but it must
+        leave structured evidence for the run's status/terminal reason rather
+        than surviving only as the executor's warning line.
+        """
+        from lionagi.cli.orchestrate import flow as flow_mod
+
+        emitted: list[str] = []
+        env = SimpleNamespace()
+        dropped = [
+            {
+                "reason": "max_spawn_exceeded",
+                "assignee": "reviewer",
+                "emitter_id": "parent-op",
+                "op_id": "refused-child",
+            }
+        ]
+        monkeypatch.setattr(flow_mod, "progress", emitted.append)
+
+        flow_mod._surface_dropped_spawns(env, dropped)
+
+        assert env._spawn_refusal_evidence == [
+            {
+                "kind": "refused_spawn",
+                "id": "parent-op",
+                "label": "reviewer (max_spawn_exceeded)",
+            }
+        ]
+        assert not getattr(env, "_failed_operation_evidence", None)
+        assert any("SPAWN REFUSED" in line and "parent-op" in line for line in emitted)
+
     def test_custom_operation_preserved(self):
         session, roles = _roles("researcher")
         nb = role_node_builder(roles)


### PR DESCRIPTION
Closes #2983

## Summary

- record SpawnRequests refused by the reactive capacity cap as structured evidence naming the emitter and requested assignee
- preserve terminal `completed` while carrying the controlled degradation reason `run.completed.spawn_refused` through session and invocation state
- propagate the validated reason through MCP job status and terminal notification payloads so callers do not need raw logs to detect refused work
- keep builder errors as failures and leave duplicate, cycle, and null-child drop semantics unchanged

## Verification

- strict RED→GREEN for missing spawn-refusal evidence, missing controlled reason, and missing MCP notification propagation
- 397 related flow, persistence, MCP job, and notification tests passed
- 74 state-reason and CLI wait tests passed
- Ruff, formatting, diff check, commit hooks, and targeted Pyright (0 errors) passed

## Compatibility

The run status remains `completed`; consumers that understand reason codes can now distinguish successful completion from completed-with-refused-reactive-work.