### PR TITLE
fix(admission): bound agent and scheduled prompts

### DIFF
--- a/docs/internals/support-libs.md
+++ b/docs/internals/support-libs.md
@@ -10,14 +10,20 @@ in-source essay. Source points here with `# See docs/internals/support-libs.md#<
 
 ## _spec_limits: MAX_SPEC_PROMPT_CHARS
 
-`MAX_SPEC_PROMPT_CHARS` is one number, read by every surface that validates an
-orchestration spec. The readers are named rather than counted, because a count
-goes stale silently when a reader is added while a missing name is visible:
+`MAX_SPEC_PROMPT_CHARS` is one number, read by every admission surface that
+validates an agent or orchestration prompt. The readers are named rather than
+counted, because a count goes stale silently when a reader is added while a
+missing name is visible:
 
+- `lionagi/_flow_spec.py`
+- `lionagi/cli/agent.py`
 - `lionagi/cli/orchestrate/__init__.py`
-- `lionagi/studio/services/schedules.py`
+- `lionagi/mcp/dispatch.py`
+- `lionagi/studio/scheduler/subprocess.py`
 - `lionagi/studio/services/run_resume.py`
-- `lionagi/studio/services/playbooks.py`
+
+Schedule create/update and ad-hoc launch validation delegate to the scheduler
+subprocess validator; playbook validation delegates to the flow-spec validator.
 
 It was written out separately in each of them, which meant that many chances for
 the copies to disagree and no single place to raise the bound.
@@ -26,13 +32,18 @@ The module deliberately imports nothing. Most of its readers are Studio services
 whose import cost is paid on startup, and a constant that arrives with a module
 graph behind it charges every one of them for a number.
 
-The bound exists for the pathological file, not for the long prompt. An
-orchestration prompt carries the whole task — the brief, the constraints, the
-exit criteria — and a real one had already been squeezed to fit the old 8192
-limit, close enough to normal writing that an ordinary edit could push a
-working spec over it and kill the run at submit. `256 * 1024` is set far
-enough out that no honest spec reaches it, while still refusing a file that
-isn't a prompt.
+The bound exists for the pathological file, not for the long prompt. An agent
+or orchestration prompt carries the whole task — the brief, the constraints,
+the exit criteria — and a real one had already been squeezed to fit the old
+8192 limit, close enough to normal writing that an ordinary edit could push a
+working spec over it and kill the run at submit. `256 * 1024` is set far enough
+out that no honest prompt reaches it, while still refusing a file that isn't a
+prompt. Single-agent runs use the same bound because their prompt enters the
+same provider and persistence substrate; transporting it through a file removes
+the operating system's argv ceiling but is not a reason to admit unbounded
+request memory. File readers consume at most the cap plus one character, which
+is enough to distinguish an accepted prompt from an oversized one without
+loading the rest.
 
 <a id="class-registry-builtin-modules"></a>
 

--- a/lionagi/_spec_limits.py
+++ b/lionagi/_spec_limits.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Bounds shared by every surface that validates an orchestration spec.
+"""Bounds shared by surfaces that validate agent and orchestration prompts.
 
 Deliberately importing nothing — see docs/internals/support-libs.md#_spec_limits-max_spec_prompt_chars.
 """

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -15,6 +15,7 @@ from lionagi import Branch
 from lionagi._auto import CliDeclaration, auto_register
 from lionagi._errors import ConfigurationError
 from lionagi._errors import TimeoutError as LionTimeoutError
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.ln.concurrency import (
     SigtermInterrupt,
     cache_cancelled_exc_class,
@@ -1545,10 +1546,11 @@ def _resolve_model_and_prompt(args: argparse.Namespace) -> tuple[str | None, str
             log_error("pass --prompt or --prompt-file, not both")
             return None
         if args.prompt_file == "-":
-            flag_prompt = sys.stdin.read()
+            flag_prompt = sys.stdin.read(MAX_SPEC_PROMPT_CHARS + 1)
         else:
             try:
-                flag_prompt = Path(args.prompt_file).read_text()
+                with Path(args.prompt_file).open() as prompt_stream:
+                    flag_prompt = prompt_stream.read(MAX_SPEC_PROMPT_CHARS + 1)
             except OSError as exc:
                 log_error(f"could not read --prompt-file: {exc}")
                 return None
@@ -1614,6 +1616,9 @@ def run_agent(args: argparse.Namespace) -> int:
             form_prompt_prefix = _form_to_context_block(work_form) + "\n\n"
 
     prompt = form_prompt_prefix + prompt_text
+    if len(prompt) > MAX_SPEC_PROMPT_CHARS:
+        log_error(f"agent prompt exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters")
+        return 1
 
     # --image: load and validate BEFORE any LLM call, same contract as --form.
     image_uris: list[str] | None = None

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -21,6 +21,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
+
 from . import config, jobs, projection, roster
 from .verbs import (
     ABSENT,
@@ -485,6 +487,11 @@ def _resolve_prompt(args: dict[str, Any]) -> str | None:
     prompt = args.get("prompt")
     prompt_file = args.get("prompt_file")
     if prompt_file is None:
+        if prompt is not None and len(prompt) > MAX_SPEC_PROMPT_CHARS:
+            raise OpError(
+                "invalid_input",
+                f"prompt exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters",
+            )
         return prompt
     if prompt is not None:
         raise OpError("invalid_input", "pass prompt or prompt_file, not both")
@@ -498,9 +505,15 @@ def _resolve_prompt(args: dict[str, Any]) -> str | None:
             "so a relative path would resolve against the server's directory and not the run's",
         )
     try:
-        text = path.read_text()
+        with path.open() as prompt_stream:
+            text = prompt_stream.read(MAX_SPEC_PROMPT_CHARS + 1)
     except OSError as exc:
         raise OpError("invalid_input", f"could not read prompt_file {path}: {exc}") from exc
+    if len(text) > MAX_SPEC_PROMPT_CHARS:
+        raise OpError(
+            "invalid_input",
+            f"prompt_file content exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters",
+        )
     if not text.strip():
         raise OpError("invalid_input", f"prompt_file is empty: {path}")
     return text

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -17,6 +17,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
+
 __all__ = (
     "Verb",
     "AbsentVerb",
@@ -105,10 +107,12 @@ class AbsentVerb:
 
 _PROMPT = {
     "type": "string",
+    "maxLength": MAX_SPEC_PROMPT_CHARS,
     "description": (
         "The instruction text. It is written to a file inside the job record and "
         "the run is spawned with an argv list and no shell, so quotes, newlines "
-        "and code in it are safe. Give it here or as prompt_file, never both."
+        "and code in it are safe. Give it here or as prompt_file, never both. "
+        f"Maximum length: {MAX_SPEC_PROMPT_CHARS} characters."
     ),
     "x-server-owned": True,
 }
@@ -119,7 +123,7 @@ _PROMPT_FILE = {
         "Absolute path to a file holding the instruction. The server reads it now "
         "and snapshots the text, so editing the file afterwards cannot change what "
         "an already-submitted run executes. '-' is refused: a detached run has no "
-        "stdin to read."
+        f"stdin to read. File content is capped at {MAX_SPEC_PROMPT_CHARS} characters."
     ),
     "x-server-owned": True,
 }

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -16,6 +16,7 @@ from collections.abc import Awaitable, Callable
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.ln._proc import aterminate_process_group
 
 _log = logging.getLogger(__name__)
@@ -227,12 +228,18 @@ def _render_command_arg(template: str, context: dict) -> str:
 
 
 def _validate_prompt(prompt: str) -> None:
-    """Raise ValueError if *prompt* is exactly the end-of-options sentinel '--'.
+    """Raise ValueError when *prompt* cannot be admitted safely.
 
     build_argv places '--' before positionals, so a prompt value of exactly
     '--' would be consumed by argparse as the separator, never reaching the
-    runner. All other content (including leading '-') is safe.
+    runner. The shared character cap also keeps stored and rendered schedule
+    prompts aligned with the orchestration surfaces instead of accepting work
+    that can only fail when it fires.
     """
+    if len(prompt) > MAX_SPEC_PROMPT_CHARS:
+        raise ValueError(
+            f"action_prompt exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters"
+        )
     if prompt == "--":
         raise ValueError(
             "action_prompt value '--' is not allowed: the literal end-of-options "
@@ -270,7 +277,9 @@ def render_action_prompt(schedule: dict, trigger_context: dict) -> str | None:
     prompt = schedule.get("action_prompt") or ""
     if not prompt:
         return None
-    return _render_template(prompt, trigger_context)
+    rendered = _render_template(prompt, trigger_context)
+    _validate_prompt(rendered)
+    return rendered
 
 
 def resolve_li_executable() -> tuple[list[str] | None, str | None]:

--- a/tests/cli/test_agent_prompt_bound.py
+++ b/tests/cli/test_agent_prompt_bound.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The single-agent CLI refuses oversized prompt files before starting a run."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
+
+
+async def _fake_run_agent(
+    model: str | None, prompt: str, **kwargs: Any
+) -> tuple[str, str, str, str, str]:
+    return "output", model or "provider", "branch-id", "completed", "session-id"
+
+
+def _run(argv: list[str]) -> int:
+    import lionagi.cli.agent as agent_mod
+    from lionagi.cli.main import main
+
+    with patch.object(agent_mod, "_run_agent", _fake_run_agent):
+        return main(argv)
+
+
+def test_agent_prompt_file_over_shared_limit_is_refused_before_run(tmp_path, capsys):
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("x" * (MAX_SPEC_PROMPT_CHARS + 1))
+
+    with patch("lionagi.cli.agent._run_agent", new_callable=AsyncMock) as run:
+        from lionagi.cli.main import main
+
+        assert main(["agent", "codex", "--prompt-file", str(prompt_file)]) == 1
+        run.assert_not_called()
+
+    assert str(MAX_SPEC_PROMPT_CHARS) in capsys.readouterr().err
+
+
+def test_agent_prompt_at_shared_limit_is_accepted(tmp_path):
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("x" * MAX_SPEC_PROMPT_CHARS)
+
+    assert _run(["agent", "codex", "--prompt-file", str(prompt_file)]) == 0

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.mcp import dispatch, jobs, verbs
 
 
@@ -89,6 +90,15 @@ def test_help_for_a_verb_returns_the_projected_schema():
     assert schema["properties"]["timeout"]["type"] == "integer"
     assert schema["properties"]["yolo"]["type"] == "boolean"
     assert schema["properties"]["agent"]["x-flag"] == "--agent"
+
+
+def test_agent_submit_schema_discloses_the_prompt_admission_cap():
+    schema = call(help="agent.submit")
+    prompt = schema["schema"]["properties"]["prompt"]
+    prompt_file = schema["schema"]["properties"]["prompt_file"]
+
+    assert prompt["maxLength"] == MAX_SPEC_PROMPT_CHARS
+    assert str(MAX_SPEC_PROMPT_CHARS) in prompt_file["description"]
 
 
 def test_help_for_an_unavailable_verb_says_why_instead_of_failing():
@@ -912,6 +922,41 @@ def test_a_submission_that_names_a_model_still_spawns(submitted, op, args):
     answer = call(ops=[spawn_op(op, args)])["ops"][0]
     assert answer["ok"] is True
     assert submitted["kind"]
+
+
+def test_agent_submit_rejects_inline_prompt_over_shared_limit_before_spawn(submitted):
+    answer = call(
+        ops=[
+            spawn_op(
+                "agent.submit",
+                {"query": ["codex"], "prompt": "x" * (MAX_SPEC_PROMPT_CHARS + 1)},
+            )
+        ]
+    )["ops"][0]
+
+    assert answer["ok"] is False
+    assert answer["error"]["kind"] == "invalid_input"
+    assert str(MAX_SPEC_PROMPT_CHARS) in answer["error"]["message"]
+    assert submitted == {}
+
+
+def test_agent_submit_rejects_prompt_file_over_shared_limit_before_spawn(submitted, tmp_path):
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("x" * (MAX_SPEC_PROMPT_CHARS + 1))
+
+    answer = call(
+        ops=[
+            spawn_op(
+                "agent.submit",
+                {"query": ["codex"], "prompt_file": str(prompt_file)},
+            )
+        ]
+    )["ops"][0]
+
+    assert answer["ok"] is False
+    assert answer["error"]["kind"] == "invalid_input"
+    assert str(MAX_SPEC_PROMPT_CHARS) in answer["error"]["message"]
+    assert submitted == {}
 
 
 def test_a_spec_file_may_be_the_thing_that_names_the_model(submitted):

--- a/tests/studio/test_schedule_prompt_bound.py
+++ b/tests/studio/test_schedule_prompt_bound.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Schedule prompt admission stays bounded at rest and after rendering."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
+from lionagi.studio.scheduler.subprocess import render_action_prompt
+from lionagi.studio.services.schedules import create_schedule, update_schedule
+
+
+def _schedule_data(prompt: str) -> dict:
+    return {
+        "name": "prompt-bound",
+        "trigger_type": "cron",
+        "cron_expr": "0 * * * *",
+        "action_kind": "agent",
+        "action_prompt": prompt,
+    }
+
+
+def test_create_rejects_prompt_over_shared_limit_before_db_write():
+    async def _run() -> None:
+        with patch("lionagi.studio.services.schedules.StateDB") as state_db:
+            db = AsyncMock()
+            state_db.return_value.__aenter__ = AsyncMock(return_value=db)
+            state_db.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(ValueError, match=str(MAX_SPEC_PROMPT_CHARS)):
+                await create_schedule(_schedule_data("x" * (MAX_SPEC_PROMPT_CHARS + 1)))
+            db.create_schedule.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_update_rejects_prompt_over_shared_limit_before_db_write():
+    async def _run() -> None:
+        with patch("lionagi.studio.services.schedules.StateDB") as state_db:
+            db = AsyncMock()
+            db.get_schedule.return_value = _schedule_data("old") | {"id": "sched-1"}
+            state_db.return_value.__aenter__ = AsyncMock(return_value=db)
+            state_db.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(ValueError, match=str(MAX_SPEC_PROMPT_CHARS)):
+                await update_schedule(
+                    "sched-1", {"action_prompt": "x" * (MAX_SPEC_PROMPT_CHARS + 1)}
+                )
+            db.update_schedule.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_render_rejects_template_expansion_over_shared_limit():
+    with pytest.raises(ValueError, match=str(MAX_SPEC_PROMPT_CHARS)):
+        render_action_prompt(
+            {"action_prompt": "{{payload}}"},
+            {"payload": "x" * (MAX_SPEC_PROMPT_CHARS + 1)},
+        )
+
+
+def test_render_accepts_prompt_at_shared_limit():
+    prompt = "x" * MAX_SPEC_PROMPT_CHARS
+    assert render_action_prompt({"action_prompt": prompt}, {}) == prompt


### PR DESCRIPTION
Closes #2656

## Summary

- enforce the existing 262,144-character prompt policy at schedule create/update admission and again after trigger-template expansion, before invocation or subprocess creation
- apply the same cap to the final assembled direct-agent prompt, including form context
- bound direct-agent and MCP prompt-file reads to cap + 1 characters and reject oversized inline/file prompts before provider or job admission
- publish the MCP `maxLength` contract and document why single-agent prompts share the orchestration bound

## Verification

- strict RED→GREEN for schedule create/update/render, direct agent, MCP inline/file admission, and MCP schema disclosure
- 296 related tests passed
- 64 MiB sparse prompt file rejected in 0.177 ms with a 531,775-byte tracemalloc peak
- Ruff, formatting, Markdownlint, diff check, commit hooks, and targeted Pyright (0 errors) passed

## Compatibility

Prompts above 262,144 Unicode code points now fail admission; exact-limit prompts remain accepted. Existing oversized schedules remain stored but are refused before invocation/spawn after rendering. The cap bounds decoded content rather than upstream HTTP raw-body buffering.