### PR TITLE
fix(operator): let an exact run id through the project fence

### DIFF
--- a/lionagi/studio/operator/cancel_run.py
+++ b/lionagi/studio/operator/cancel_run.py
@@ -19,6 +19,7 @@ un-gate of a cancelled run's status.
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from typing import Any
 
@@ -93,6 +94,15 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+# A full canonical UUID (36 characters, 8-4-4-4-12 hex). Mirrors
+# ``run_progress.py``'s own copy, kept separate for the same reason
+# ``_allowed_project`` is: this module's identity/store handling stays
+# self-contained.
+_EXACT_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+
 async def _current_run_id(store: OperatorStore, request_id: str) -> str | None:
     """The run the human was looking at when this instruction was sent.
 
@@ -127,7 +137,9 @@ async def _allowed_project(store: OperatorStore, request_id: str) -> str:
     project = context.get("project") if isinstance(context, dict) else None
     if not isinstance(project, str) or not project:
         raise MissingOwnerContextError(
-            "operator turn has no project context -- refusing to resolve or cancel any run"
+            "operator turn has no project context -- refusing to resolve or "
+            "cancel a run by prefix or name. Pass the run's full 36-character "
+            "id instead, or cancel the run the human has open ('current')."
         )
     return project
 
@@ -219,7 +231,24 @@ async def _resolve_reference(store: OperatorStore, request_id: str, ref: str) ->
             return {"found": False}
         ref = run_id
 
-    project = await _allowed_project(store, request_id)
+    ref = ref.strip()
+    try:
+        project = await _allowed_project(store, request_id)
+    except MissingOwnerContextError:
+        if _EXACT_UUID_RE.fullmatch(ref) is None:
+            raise
+        # A turn with an owner but no declared project may still resolve one
+        # run by its full id: an exact 36-character UUID identifies at most
+        # one row and cannot enumerate anything, the same position
+        # ``run_detail`` already takes for a bare id. Prefix and
+        # name-substring resolution stay behind the fence, and a turn that
+        # *does* declare a project keeps full ownership scoping on every arm.
+        async with StateDB() as db:
+            row = await db.fetch_one("SELECT * FROM sessions WHERE id = ?", (ref,))
+            if row is None:
+                return {"found": False}
+            return {"found": True, "ambiguous": False, "run": db._row_to_dict(row)}
+
     async with StateDB() as db:
         try:
             row = await _resolve_run(db, ref, project=project)
@@ -322,6 +351,15 @@ async def cancel_run(arguments: dict[str, Any]) -> dict[str, Any]:
     row = resolution["run"]
     run_id = row["id"]
 
+    row_project = row.get("project")
+    if not isinstance(row_project, str) or not row_project:
+        # Only reachable through the exact-id arm: a fenced resolution always
+        # yields a row matching the turn's own non-empty project. The
+        # execute-time ownership guard below refuses a row with no project,
+        # so creating a proposal for one would burn a human approval on an
+        # act that cannot execute -- report it the way the executor would.
+        return {"cancelled": False, "reason": "not_found", "run_untouched": True}
+
     if row.get("status") != "running":
         # Nothing to propose: there is no action left to gate behind a human
         # decision, so no proposal is created and no mutation callback runs.
@@ -399,14 +437,14 @@ async def execute_cancel_command(command: dict[str, Any]) -> dict[str, Any]:
         if row is None:
             return {"status": "not_found", "id": run_id}
         row_dict = db._row_to_dict(row)
-        # A command built by cancel_run() above always carries the caller's
-        # own (non-empty) project -- _allowed_project() raises rather than
-        # letting a turn with no owner mapping reach this point. A missing
-        # or empty project here is therefore itself an ownership failure,
-        # not a value meaning "unscoped, allow any row" -- it fails exactly
-        # like a project mismatch, and exactly like a nonexistent id:
-        # confirming a foreign run's terminal status here would be the same
-        # disclosure the resolution-time ownership check exists to prevent.
+        # A command built by cancel_run() above always carries the resolved
+        # row's own (non-empty) project -- cancel_run() refuses to propose
+        # for a row without one. A missing or empty project here is
+        # therefore itself an ownership failure, not a value meaning
+        # "unscoped, allow any row" -- it fails exactly like a project
+        # mismatch, and exactly like a nonexistent id: confirming a foreign
+        # run's terminal status here would be the same disclosure the
+        # resolution-time ownership check exists to prevent.
         if not isinstance(project, str) or not project or row_dict.get("project") != project:
             return {"status": "not_found", "id": run_id}
         if row_dict.get("status") != "running":

--- a/lionagi/studio/operator/rename_session.py
+++ b/lionagi/studio/operator/rename_session.py
@@ -148,6 +148,16 @@ async def rename_session(arguments: dict[str, Any]) -> dict[str, Any]:
         # genuine race (the run was deleted), not an ownership question.
         return {"renamed": False, "reason": "not_found"}
 
+    row_project = row_dict.get("project")
+    if not isinstance(row_project, str) or not row_project:
+        # Only reachable through resolve_run()'s exact-id arm: a fenced
+        # resolution always yields a row matching the turn's own non-empty
+        # project. The execute-time ownership guard refuses a row with no
+        # project, so creating a proposal for one would burn a human
+        # approval on an act that cannot execute -- report it the way the
+        # executor would.
+        return {"renamed": False, "reason": "not_found"}
+
     # Carried through to `execute_rename_session_command` so ownership is
     # checked again immediately before the row is written, not only once at
     # resolution time -- the human's approval window is a gap a run's
@@ -204,7 +214,8 @@ async def execute_rename_session_command(command: dict[str, Any]) -> dict[str, A
             return {"status": "not_found", "id": run_id}
         row_dict = db._row_to_dict(row)
         # A command built by rename_session() above always carries the
-        # caller's own (non-empty) project -- a missing or empty project
+        # resolved row's own (non-empty) project -- rename_session() refuses
+        # to propose for a row without one. A missing or empty project
         # here is itself an ownership failure, not a value meaning
         # "unscoped, allow any row" -- it fails exactly like a project
         # mismatch and exactly like a nonexistent id, the same reasoning

--- a/lionagi/studio/operator/run_progress.py
+++ b/lionagi/studio/operator/run_progress.py
@@ -14,12 +14,21 @@ see docs/internals/studio.md ("Resolving a run reference").
 
 from __future__ import annotations
 
+import re
 import time
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from .redact import MAX_CANDIDATES, public_project, scrub_text
+
+# A full canonical UUID (36 characters, 8-4-4-4-12 hex). A reference in this
+# form identifies at most one row and cannot enumerate anything, which is what
+# lets it pass the project fence below the same way ``run_detail``'s bare-id
+# lookup does.
+_EXACT_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
 
 __all__ = ("MissingOwnerContextError", "RunProgressInput", "resolve_run", "run_progress")
 
@@ -163,7 +172,9 @@ async def _allowed_project() -> str | None:
     project = context.get("project") if isinstance(context, dict) else None
     if not isinstance(project, str) or not project:
         raise MissingOwnerContextError(
-            "operator turn has no project context -- refusing to resolve any run"
+            "operator turn has no project context -- refusing to resolve a run "
+            "by prefix or name. Pass the run's full 36-character id instead, "
+            "or ask about the run the human has open ('current')."
         )
     return project
 
@@ -199,8 +210,12 @@ async def resolve_run(ref: str) -> dict[str, Any]:
     name/playbook substring matching 2-``MAX_CANDIDATES`` sessions, comes
     back as candidates; more than ``MAX_CANDIDATES`` text matches come back
     as the newest ``MAX_CANDIDATES`` plus ``truncated: True``. Every arm is
-    scoped to the calling turn's project (when it names one) -- see
-    docs/internals/studio.md ("Resolving a run reference").
+    scoped to the calling turn's project (when it names one). A turn whose
+    identity is present but whose context names no project may still resolve
+    an exact full-UUID reference (or 'current') -- a bare id identifies at
+    most one row and cannot enumerate, so it is safe where prefix and
+    substring resolution are not -- see docs/internals/studio.md
+    ("Resolving a run reference").
     """
     from lionagi.cli._util import AmbiguousIdError, fetch_unique_row
     from lionagi.state.db import StateDB
@@ -209,17 +224,43 @@ async def resolve_run(ref: str) -> dict[str, Any]:
     if not normalized:
         return {"found": False}
 
-    project = await _allowed_project()
-
+    from_current_view = False
     if normalized.lower() == "current":
+        # Resolved before the project fence: this only reads the human's own
+        # view selection, it enumerates nothing. Whatever id it yields still
+        # goes through the same fence-or-exact-id logic as a typed reference.
         session_id = await _resolve_current()
         if session_id is None:
             return {"found": False}
+        normalized = session_id
+        from_current_view = True
+
+    try:
+        project = await _allowed_project()
+    except MissingOwnerContextError:
+        if _EXACT_UUID_RE.fullmatch(normalized) is None:
+            raise
+        # A turn with an owner but no declared project may still look up one
+        # run by its full id: an exact 36-character UUID identifies at most
+        # one row and cannot enumerate anything, the same position
+        # ``run_detail`` already takes for a bare id. Prefix and
+        # name-substring resolution stay behind the fence above, and a turn
+        # that *does* declare a project keeps full ownership scoping on
+        # every arm, including this one.
         async with StateDB(readonly=True) as db:
-            row = await db.fetch_one("SELECT * FROM sessions WHERE id = ?", (session_id,))
+            row = await db.fetch_one("SELECT id FROM sessions WHERE id = ?", (normalized,))
+        if row is None:
+            return {"found": False}
+        return {"found": True, "ambiguous": False, "session_id": row["id"]}
+
+    if from_current_view:
+        # A 'current' selection under a project-scoped turn keeps the
+        # pre-existing direct lookup + ownership check.
+        async with StateDB(readonly=True) as db:
+            row = await db.fetch_one("SELECT * FROM sessions WHERE id = ?", (normalized,))
         if row is None or not _owns(row.get("project"), project):
             return {"found": False}
-        return {"found": True, "ambiguous": False, "session_id": session_id}
+        return {"found": True, "ambiguous": False, "session_id": normalized}
 
     async with StateDB(readonly=True) as db:
         try:

--- a/tests/apps_studio_server/test_operator_cancel_run.py
+++ b/tests/apps_studio_server/test_operator_cancel_run.py
@@ -786,13 +786,70 @@ async def test_cancel_run_text_search_without_project_context_fails_closed(tmp_p
     with pytest.raises(MissingOwnerContextError):
         await cancel_run({"run": "nightly-triage"})
 
+    # A short id prefix is fenced the same way -- prefixes enumerate.
+    with pytest.raises(MissingOwnerContextError):
+        await cancel_run({"run": first[:8]})
+
     assert await store.list_proposals_for_request(request_id) == []
 
 
-async def test_cancel_run_current_without_project_context_fails_closed(tmp_path, monkeypatch):
-    """The 'current' arm must also refuse a turn with no owner mapping --
-    the selection lookup itself needs no project, but the row it resolves to
-    must never be read back without one."""
+async def test_cancel_run_exact_id_resolves_on_a_turn_with_no_project(tmp_path, monkeypatch):
+    """A turn with an owner but no declared project may still target one run
+    by its full id -- an exact 36-character UUID identifies at most one row
+    and cannot enumerate, so it passes the fence that keeps refusing prefix
+    and name resolution. The already-terminal outcome proves resolution
+    succeeded without any proposal machinery."""
+    from lionagi.state.db import StateDB
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    async with StateDB() as db:
+        run_id = await _seed_session(db, status="completed", pid=None)
+
+    store = OperatorStore(path)
+    cid, request_id = await _make_running_turn(
+        store, context={"space": "mission", "route": "/", "filters": {}}
+    )
+    _set_identity(monkeypatch, path, cid, request_id)
+
+    result = await cancel_run({"run": run_id})
+
+    assert result == {
+        "cancelled": False,
+        "status": "already_terminal",
+        "id": run_id,
+        "run_untouched": True,
+    }
+
+
+async def test_cancel_run_refuses_to_propose_for_a_row_with_no_project(tmp_path, monkeypatch):
+    """A running row with no project of its own resolves through the
+    exact-id arm, but the execute-time ownership guard would refuse it after
+    the human approved -- so no proposal is created at all and the outcome
+    is reported the way the executor would report it."""
+    from lionagi.state.db import StateDB
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    async with StateDB() as db:
+        run_id = await _seed_session(db, status="running", pid=None, project=None)
+
+    store = OperatorStore(path)
+    cid, request_id = await _make_running_turn(
+        store, context={"space": "mission", "route": "/", "filters": {}}
+    )
+    _set_identity(monkeypatch, path, cid, request_id)
+
+    result = await cancel_run({"run": run_id})
+
+    assert result == {"cancelled": False, "reason": "not_found", "run_untouched": True}
+    assert await store.list_proposals_for_request(request_id) == []
+
+
+async def test_cancel_run_current_resolves_via_the_exact_id_arm(tmp_path, monkeypatch):
+    """'Cancel the run the human is looking at' must work from any view:
+    the frozen selection is a full id the human's own browser reported, so
+    it rides the exact-id arm through the project fence."""
     from lionagi.state.db import StateDB
 
     path = tmp_path / "state.db"
@@ -812,8 +869,14 @@ async def test_cancel_run_current_without_project_context_fails_closed(tmp_path,
     )
     _set_identity(monkeypatch, path, cid, request_id)
 
-    with pytest.raises(MissingOwnerContextError):
-        await cancel_run({"run": "current"})
+    result = await cancel_run({"run": "current"})
+
+    assert result == {
+        "cancelled": False,
+        "status": "already_terminal",
+        "id": run_id,
+        "run_untouched": True,
+    }
 
 
 async def test_execute_cancel_command_without_project_fails_closed(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_operator_run_findings.py
+++ b/tests/apps_studio_server/test_operator_run_findings.py
@@ -777,9 +777,11 @@ async def test_run_findings_exact_id_of_a_foreign_project_run_is_not_found(db_pa
 
 async def test_run_findings_turn_with_no_project_context_fails_closed(db_path, monkeypatch):
     """A turn whose identity is present but whose own context names no
-    project must never fall back to matching every project's runs --
+    project must never fall back to enumerating every project's runs --
     run_findings inherits this from resolve_run() (run_progress.py) the same
-    way it already inherits project scoping."""
+    way it already inherits project scoping. An exact full-UUID reference is
+    the one deliberate exception (it cannot enumerate), so the fenced arms
+    are exercised with a name and an id prefix."""
     from lionagi.studio.operator.run_findings import run_findings
     from lionagi.studio.operator.run_progress import MissingOwnerContextError
     from lionagi.studio.operator.store import OperatorStore
@@ -801,7 +803,14 @@ async def test_run_findings_turn_with_no_project_context_fails_closed(db_path, m
     monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
 
     with pytest.raises(MissingOwnerContextError):
-        await run_findings({"run": sid})
+        await run_findings({"run": "nightly-triage"})
+
+    with pytest.raises(MissingOwnerContextError):
+        await run_findings({"run": sid[:8]})
+
+    # The exception: the full id rides the exact-id arm through the fence.
+    result = await run_findings({"run": sid})
+    assert result["found"] is True
 
 
 async def test_run_findings_env_secret_value_is_redacted_even_without_a_known_shape(

--- a/tests/apps_studio_server/test_operator_run_progress.py
+++ b/tests/apps_studio_server/test_operator_run_progress.py
@@ -850,9 +850,11 @@ async def test_run_progress_ambiguous_id_prefix_hides_foreign_project_candidates
 
 async def test_run_progress_turn_with_no_project_context_fails_closed(db_path, monkeypatch):
     """A turn whose identity is present but whose own context names no
-    project must never fall back to matching every project's runs -- it is
-    refused with a typed error before any row is read, not merely before one
-    foreign row is exposed."""
+    project must never fall back to enumerating every project's runs:
+    prefix and name-substring references are refused with a typed error
+    whose message names the remedy. The one deliberate exception is an
+    exact full-UUID reference -- it identifies at most one row and cannot
+    enumerate, the same position run_detail takes for a bare id."""
     from lionagi.studio.operator.run_progress import MissingOwnerContextError, resolve_run
 
     sid = str(uuid.uuid4())
@@ -863,14 +865,55 @@ async def test_run_progress_turn_with_no_project_context_fails_closed(db_path, m
     monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
     monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", request_id)
 
-    with pytest.raises(MissingOwnerContextError):
+    with pytest.raises(MissingOwnerContextError, match="full 36-character id"):
         await resolve_run("nightly-triage")
 
     with pytest.raises(MissingOwnerContextError):
-        await resolve_run(sid)
+        await resolve_run(sid[:8])
 
-    with pytest.raises(MissingOwnerContextError):
-        await resolve_run("current")
+    result = await resolve_run(sid)
+    assert result == {"found": True, "ambiguous": False, "session_id": sid}
+
+    # A nonexistent exact UUID is a clean not-found, not an error -- and not
+    # a fall-through into the fenced text-search arms.
+    result = await resolve_run(str(uuid.uuid4()))
+    assert result == {"found": False}
+
+
+async def test_run_progress_current_resolves_on_a_turn_with_no_project(db_path, monkeypatch):
+    """'Cancel/inspect the run the human is looking at' must work from any
+    view: the current-view selection is a full id the human's own browser
+    reported, so it rides the exact-id arm through the project fence. The
+    seeded row deliberately has no project -- the arm must not depend on
+    one."""
+    from lionagi.studio.operator.run_progress import run_progress
+    from lionagi.studio.operator.store import OperatorStore
+
+    sid = str(uuid.uuid4())
+    await seed_session(db_path, session_id=sid, status="completed", project=None)
+
+    store = OperatorStore(db_path)
+    cid = (await store.create_conversation())["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="how is this run going?",
+        context={
+            "space": "mission",
+            "route": "/",
+            "filters": {},
+            "selection": {"s": sid},
+        },
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(accepted["requestId"])
+    monkeypatch.setenv("LIONAGI_OPERATOR_DB_PATH", str(db_path))
+    monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
+    monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
+
+    result = await run_progress({"run": "current"})
+
+    assert result["found"] is True
+    assert result["id"] == sid
 
 
 async def test_run_progress_no_identity_at_all_stays_unscoped(db_path):


### PR DESCRIPTION
## Problem

`resolve_run()` refuses every reference form when the calling turn's identity is present but its context names no project. Five tools import it — `run_progress`, `run_findings`, `resume_run`, `rename_session`, `cancel_run` — so all run inspection and every action verb refused on such turns. The client currently reports a project on no view at all, so in practice the whole surface refused everywhere, while `run_detail` (which documents its own bare-id bypass) answered the same questions for the same runs.

## Change

- An exact 36-character UUID now resolves through the fence: a bare id identifies at most one row and cannot enumerate anything, the same position `run_detail` already takes. Prefix and name-substring resolution stay fenced — those are the arms that can enumerate.
- `current` rides the same arm: the selection it resolves is a full id the human's own client reported.
- A turn that **does** declare a project keeps full ownership scoping on every arm, including exact id. No cross-project behavior changes.
- The refusal message now names the remedy (pass the full id, or use `current`) instead of dead-ending.
- `cancel_run` and `rename_session` refuse to create a proposal for a row with no project of its own: the execute-time ownership guard would refuse it after approval, so proposing would burn a human approval on an act that cannot execute. The executors themselves are unchanged.

Both copies of the fence are updated (`run_progress.py` and `cancel_run.py`'s own).

## Tests

416 operator tests pass. The fence tests now pin the new contract: name and prefix references still raise, an exact UUID resolves, a nonexistent UUID is a clean not-found, `current` resolves from a project-less turn, and the no-project-row proposal refusal is covered on the cancel path. Cross-project isolation tests (foreign exact id, foreign `current`, candidate hiding) are unchanged and green.
