### PR TITLE
fix(operator): stop projecting 'healthy' beside a terminal run status

### DIFF
--- a/lionagi/studio/operator/run_detail.py
+++ b/lionagi/studio/operator/run_detail.py
@@ -30,6 +30,7 @@ from .redact import (
     redact_scalar,
     scrub_text,
 )
+from .run_progress import _terminal_safe_health
 
 __all__ = ("RunDetailInput", "run_detail")
 
@@ -112,7 +113,7 @@ def _project(run: dict[str, Any]) -> tuple[dict[str, Any], bool]:
         "createdAt": run.get("created_at"),
         "updatedAt": run.get("updated_at"),
         "lastMessageAt": run.get("last_message_at"),
-        "effectiveHealth": run.get("effective_health"),
+        "effectiveHealth": _terminal_safe_health(run),
         "branchCount": run.get("branch_count"),
         "messageCount": run.get("message_count"),
         "project": public_project(run.get("project")),

--- a/lionagi/studio/operator/run_progress.py
+++ b/lionagi/studio/operator/run_progress.py
@@ -96,6 +96,27 @@ def _scrub(value: Any) -> Any:
     return scrub_text(value) if isinstance(value, str) else value
 
 
+# The health classifier's own terminal set (lionagi/state/health.py): for
+# these statuses it answers "healthy" whenever the run left no residue
+# (no stale locks), because health is a LIVENESS concept and a finished
+# run has no liveness. Projected next to status="failed", though, the
+# word "healthy" reads as a claim about the run's outcome and misleads
+# the caller. So for terminal runs this projection drops the vacuous
+# "healthy" and keeps only a pathological verdict (e.g. a zombie's
+# leftover locks), which is the only health information a finished run
+# can still carry.
+_TERMINAL_STATUSES = frozenset(
+    {"completed", "completed_empty", "failed", "timed_out", "aborted", "cancelled"}
+)
+
+
+def _terminal_safe_health(run: dict[str, Any]) -> str | None:
+    health = run.get("effective_health")
+    if run.get("status") in _TERMINAL_STATUSES and health == "healthy":
+        return None
+    return health
+
+
 def _candidate(row: dict[str, Any]) -> dict[str, Any]:
     return {
         "id": row.get("id"),
@@ -530,7 +551,7 @@ async def run_progress(arguments: dict[str, Any]) -> dict[str, Any]:
         "ambiguous": False,
         "id": run.get("id"),
         "status": run.get("status"),
-        "effectiveHealth": run.get("effective_health"),
+        "effectiveHealth": _terminal_safe_health(run),
         "startedAt": started_at,
         "endedAt": ended_at,
         "elapsedSeconds": elapsed_seconds,

--- a/tests/apps_studio_server/test_operator_run_detail.py
+++ b/tests/apps_studio_server/test_operator_run_detail.py
@@ -421,7 +421,11 @@ async def test_run_detail_happy_path(db_path):
     assert result["runId"] == sid
     assert result["id"] == sid
     assert result["status"] == "completed"
-    assert result["effectiveHealth"] == "healthy"
+    # A terminal run's vacuous "healthy" is dropped from the projection:
+    # health is a liveness concept, and "healthy" beside a terminal status
+    # reads as a claim about the run's outcome. Only a pathological verdict
+    # (leftover locks) would still be projected here.
+    assert result["effectiveHealth"] is None
     assert result["project"] == "acme-research"
     assert result["totalCostUsd"] == 1.23
     assert result["task"] == ""

--- a/tests/apps_studio_server/test_operator_run_progress.py
+++ b/tests/apps_studio_server/test_operator_run_progress.py
@@ -928,3 +928,19 @@ async def test_run_progress_no_identity_at_all_stays_unscoped(db_path):
 
     result = await resolve_run(sid)
     assert result == {"found": True, "ambiguous": False, "session_id": sid}
+
+
+def test_terminal_safe_health_drops_only_the_vacuous_healthy():
+    """Health is a liveness concept: for a terminal run the classifier's
+    "healthy" only means "no residue", and projected beside status=failed it
+    reads as a claim about the run's outcome. The projection drops exactly
+    that pairing -- a live run's "healthy" and a terminal run's pathological
+    verdict (leftover locks) both pass through unchanged."""
+    from lionagi.studio.operator.run_progress import _terminal_safe_health
+
+    for terminal in ("completed", "completed_empty", "failed", "timed_out", "aborted", "cancelled"):
+        assert _terminal_safe_health({"status": terminal, "effective_health": "healthy"}) is None
+
+    assert _terminal_safe_health({"status": "running", "effective_health": "healthy"}) == "healthy"
+    assert _terminal_safe_health({"status": "failed", "effective_health": "zombie"}) == "zombie"
+    assert _terminal_safe_health({"status": "running", "effective_health": "stale"}) == "stale"


### PR DESCRIPTION
## Problem

`run_progress` and `run_detail` project `effectiveHealth: "healthy"` for terminal runs, including failed ones. The health classifier is answering a liveness question — "healthy" for a terminal run only means it left no residue — but sitting next to `status: "failed"` the word reads as a claim about the run's outcome, and callers reasonably flag "failed but healthy" as contradictory.

## Change

The two Operator projections drop exactly the vacuous pairing: a terminal status with classifier-healthy projects `effectiveHealth: null`. A live run's health and a terminal run's pathological answer (e.g. leftover locks) pass through unchanged, so no real signal is lost. The classifier itself is untouched — the dashboard and services keep their existing semantics.

## Tests

Unit coverage of all three arms (terminal+healthy → null, terminal+pathological → passes, live+any → passes), and the run_detail happy-path pin updated to the new contract. Full studio server suite green.
