### PR TITLE
chore: sync uv.lock to the 0.35.0 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3112,7 +3112,7 @@ wheels = [
 
 [[package]]
 name = "lionagi"
-version = "0.34.1"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
The 0.35.0 bump updated `pyproject.toml` and `lionagi/version.py` but not the lockfile's own lionagi entry, so every `uv run` against the repo re-locks and dirties the tree (deployment checkouts then report drift from a one-line lock delta). One line: lionagi 0.34.1 -> 0.35.0 in `uv.lock`.