### PR TITLE
fix(engines): isolate transport failures per review dimension

### DIFF
--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -289,6 +289,33 @@ def _cap_approvals_on_missing_coverage(
     return capped
 
 
+def _cap_verdict_text(text: str, failed: list[tuple[str, str]]) -> str:
+    """Front the returned verdict text with a refusal when a dimension never ran.
+
+    Capping the emitted events only reaches a ReviewVerdict that synthesis
+    actually issued. When it issues none, this string is the whole verdict as
+    far as the caller is concerned, so the same invariant has to hold here:
+    otherwise the channel that lacks it becomes the way an approval over
+    missing coverage gets out. The synthesis output is kept underneath as
+    quoted context so nothing is lost, and so a decision line inside it can no
+    longer be read as this run's decision.
+    """
+    if not failed:
+        return text
+    blocking = "".join(f"- {name} dimension did not run ({err})\n" for name, err in failed)
+    quoted = "\n".join(f"> {line}" for line in text.splitlines()) if text else "> (no output)"
+    return (
+        "DECISION: REQUEST-CHANGES\n"
+        f"BLOCKING:\n{blocking}"
+        "RATIONALE: the dimensions listed above did not execute. They produced "
+        "no findings because they never ran, not because the artifact is clean "
+        "along them, so their silence is missing coverage and this run cannot "
+        "issue an approval.\n\n"
+        "--- synthesis output below is context, not this run's decision ---\n"
+        f"{quoted}"
+    )
+
+
 def _verdict_instruction(
     artifact: str,
     dimensions: tuple[str, ...],
@@ -583,6 +610,10 @@ class ReviewEngine(Engine):
         # but an instruction is steering, not a gate: the model can still emit
         # APPROVE. Enforce it structurally — a run in which a dimension never
         # executed cannot produce an approval, whatever the synthesis text says.
-        if failed and _cap_approvals_on_missing_coverage(run.by_type(ReviewVerdict), failed):
+        # Both channels carry the cap: the emitted verdict, and the returned
+        # text, which is the only verdict a caller sees when synthesis emits
+        # nothing structured at all.
+        if failed:
+            _cap_approvals_on_missing_coverage(run.by_type(ReviewVerdict), failed)
             run.notify("verdict_capped", failed=", ".join(name for name, _ in failed))
-        return str(res) if res is not None else ""
+        return _cap_verdict_text(str(res) if res is not None else "", failed or [])

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -289,6 +289,34 @@ def _cap_approvals_on_missing_coverage(
     return capped
 
 
+def _missing_coverage(
+    run: Any, dimensions: tuple[str, ...], failed: list[tuple[str, str]]
+) -> list[tuple[str, str]]:
+    """Dimensions this run cannot claim to have reviewed, derived from evidence.
+
+    A dimension counts as covered only when it produced something: an issue, or
+    an affirmative clean. Deriving the gap from what arrived rather than from
+    failure bookkeeping is what makes it complete. A reviewer that exhausts its
+    emission repairs raises nothing, so it never reaches the isolated-failure
+    recorder and never lands in *failed* — and a dimension that emitted nothing
+    is indistinguishable from a clean one to everything downstream. This is the
+    same predicate the repair loop uses to decide a dimension arrived, so a
+    dimension the engine gave up on is exactly a dimension named here.
+
+    *failed* entries keep their specific error label and their order; anything
+    else missing is appended.
+    """
+    gap: list[tuple[str, str]] = list(failed)
+    named = {name for name, _ in gap}
+    covered = {i.dimension for i in run.by_type(IssueFound)} | {
+        c.dimension for c in run.by_type(DimensionClean)
+    }
+    for dimension in dimensions:
+        if dimension not in named and dimension not in covered:
+            gap.append((dimension, "no evidence emitted"))
+    return gap
+
+
 def _cap_verdict_text(text: str, failed: list[tuple[str, str]]) -> str:
     """Front the returned verdict text with a refusal when a dimension never ran.
 
@@ -418,6 +446,12 @@ class ReviewEngine(Engine):
         if not verdicts:
             return ""
         verdict = verdicts[-1]
+        # Exhaustion is the one exit that skips _verdict, so the cap has to be
+        # applied here too. A run cut short by its deadline is the likeliest
+        # one to be missing a dimension, which makes this the worst channel to
+        # let an approval out of.
+        gap = _missing_coverage(run, tuple(dimensions) if dimensions else self.dimensions, [])
+        _cap_approvals_on_missing_coverage([verdict], gap)
         run.notify("verdict_emitted_on_exhaustion", verdict=verdict.verdict)
         status_header = (
             "**status: budget_exhausted (verdict emitted on exhaustion)** — "
@@ -425,7 +459,9 @@ class ReviewEngine(Engine):
             f"({run.agents_made} agents)\n\n"
         )
         blocking = f"\n\nBlocking: {', '.join(verdict.blocking)}" if verdict.blocking else ""
-        return f"{status_header}{verdict.verdict}: {verdict.rationale}{blocking}"
+        return _cap_verdict_text(
+            f"{status_header}{verdict.verdict}: {verdict.rationale}{blocking}", gap
+        )
 
     async def _run(
         self, run: EngineRun, artifact: str, *, dimensions: tuple[str, ...] | None = None
@@ -433,12 +469,24 @@ class ReviewEngine(Engine):
         dims = tuple(dimensions) if dimensions else self.dimensions
         run.root = artifact
         run.observe(IssueFound, lambda i, _c: self._on_issue(run, i))
+        failed: list[tuple[str, str]] = []
+        # Cap the verdict where it arrives, not after synthesis returns.
+        # Everything downstream — persistence, subscribers, the notify stream —
+        # reads the verdict from this flow, so rewriting it later leaves an
+        # approval already delivered to whoever was listening. Synthesis runs
+        # after every reviewer, so the coverage gap is final by the time this
+        # fires.
+        run.observe(
+            ReviewVerdict,
+            lambda v, _c: _cap_approvals_on_missing_coverage(
+                [v], _missing_coverage(run, dims, failed)
+            ),
+        )
 
         # Fan out one reviewer per dimension. Ordinary provider/transport
         # failures are isolated per dimension so completed sibling evidence is
         # still usable; run-wide budget exhaustion and cancellation keep their
         # existing structured-concurrency semantics.
-        failed: list[tuple[str, str]] = []
         try:
             await ln_gather(
                 *(
@@ -613,7 +661,8 @@ class ReviewEngine(Engine):
         # Both channels carry the cap: the emitted verdict, and the returned
         # text, which is the only verdict a caller sees when synthesis emits
         # nothing structured at all.
-        if failed:
-            _cap_approvals_on_missing_coverage(run.by_type(ReviewVerdict), failed)
-            run.notify("verdict_capped", failed=", ".join(name for name, _ in failed))
-        return _cap_verdict_text(str(res) if res is not None else "", failed or [])
+        gap = _missing_coverage(run, dimensions, failed or [])
+        if gap:
+            _cap_approvals_on_missing_coverage(run.by_type(ReviewVerdict), gap)
+            run.notify("verdict_capped", failed=", ".join(name for name, _ in gap))
+        return _cap_verdict_text(str(res) if res is not None else "", gap)

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -9,10 +9,16 @@ import hashlib
 import re
 from typing import Any
 
+import anyio
 from pydantic import Field
 
 from lionagi.casts.emission import Finding, Verdict
 from lionagi.ln import gather as ln_gather
+from lionagi.ln.concurrency._compat import (
+    ExceptionGroup,
+    get_exception_group_exceptions,
+    is_exception_group,
+)
 from lionagi.providers._provider_errors import ProviderError
 
 from .engine import Engine, EngineEvent, EngineRun
@@ -25,6 +31,47 @@ __all__ = (
     "ReviewEngine",
     "DEFAULT_DIMENSIONS",
 )
+
+# Transport failures that kill one dimension's worker without saying anything
+# about the run. A dropped MCP connection surfaces as the MCP SDK's own
+# McpError, which derives from Exception rather than from ProviderError, and a
+# dropped stream surfaces as anyio's — so neither is reachable by a
+# ProviderError-only except clause even though both are exactly the
+# "ordinary provider/transport failure" this stage means to isolate.
+_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+    anyio.ClosedResourceError,
+    anyio.BrokenResourceError,
+)
+
+try:  # mcp is an optional extra ([mcp]); absent installs simply have no McpError to catch.
+    from mcp.shared.exceptions import McpError
+except ImportError:
+    pass
+else:
+    _TRANSPORT_ERRORS = (*_TRANSPORT_ERRORS, McpError)
+
+_ISOLATED_ERRORS: tuple[type[BaseException], ...] = (ProviderError, *_TRANSPORT_ERRORS)
+
+
+def _is_all_isolated_failure(exc: BaseException) -> bool:
+    """True iff every leaf is a per-dimension provider/transport failure, recursing into nested groups."""
+    if isinstance(exc, _ISOLATED_ERRORS):
+        return True
+    if is_exception_group(exc):
+        return all(_is_all_isolated_failure(e) for e in get_exception_group_exceptions(exc))
+    return False
+
+
+def _failure_label(exc: BaseException) -> str:
+    """Name the leaf cause(s), so a group reports what actually failed rather than 'ExceptionGroup'."""
+    if not is_exception_group(exc):
+        return type(exc).__name__
+    seen: list[str] = []
+    for leaf in get_exception_group_exceptions(exc):
+        name = _failure_label(leaf)
+        if name not in seen:
+            seen.append(name)
+    return "+".join(seen) if seen else type(exc).__name__
 
 
 class IssueFound(Finding):
@@ -303,8 +350,15 @@ class ReviewEngine(Engine):
     ) -> None:
         try:
             await self._review_dimension(run, artifact, dimension)
-        except ProviderError as exc:
-            error_type = type(exc).__name__
+        except (*_ISOLATED_ERRORS, ExceptionGroup) as exc:
+            # A group reaches here when the dimension's own task group collects
+            # several transport failures at once. Isolate only when every leaf
+            # is one: a mixed group carries something this stage has no claim
+            # to swallow (budget exhaustion, a genuine defect), and laundering
+            # it into a per-dimension degrade would hide it behind a verdict.
+            if not _is_all_isolated_failure(exc):
+                raise
+            error_type = _failure_label(exc)
             run.notify(
                 "dimension_failed",
                 dimension=dimension,

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+from functools import lru_cache
 from typing import Any
 
 import anyio
@@ -15,7 +16,6 @@ from pydantic import Field
 from lionagi.casts.emission import Finding, Verdict
 from lionagi.ln import gather as ln_gather
 from lionagi.ln.concurrency._compat import (
-    ExceptionGroup,
     get_exception_group_exceptions,
     is_exception_group,
 )
@@ -41,21 +41,45 @@ __all__ = (
 _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
     anyio.ClosedResourceError,
     anyio.BrokenResourceError,
+    # A closed MCP response stream surfaces here: the SDK reads replies with
+    # `await response_stream_reader.receive()`, which raises EndOfStream rather
+    # than ClosedResourceError once the peer is gone.
+    anyio.EndOfStream,
 )
 
-try:  # mcp is an optional extra ([mcp]); absent installs simply have no McpError to catch.
-    from mcp.shared.exceptions import McpError
-except ImportError:
-    pass
-else:
-    _TRANSPORT_ERRORS = (*_TRANSPORT_ERRORS, McpError)
-
 _ISOLATED_ERRORS: tuple[type[BaseException], ...] = (ProviderError, *_TRANSPORT_ERRORS)
+
+
+@lru_cache(maxsize=1)
+def _mcp_error_type() -> type[BaseException] | None:
+    """Return mcp's ``McpError``, or ``None`` when the optional extra is absent.
+
+    Resolved on first use rather than at module import. ``mcp`` is an optional
+    extra, importing it pulls the whole package in, and every process that
+    touches the engines package would pay that cost to obtain a type only a
+    transport failure ever consults.
+
+    A missing ``mcp`` is a normal configuration and yields ``None``. An ``mcp``
+    that is present but fails to import is a broken installation and raises, so
+    it cannot masquerade as "the extra is not installed" and silently disable
+    the isolation this module depends on.
+    """
+    try:
+        from mcp.shared.exceptions import McpError
+    except ModuleNotFoundError as exc:
+        if (exc.name or "").partition(".")[0] != "mcp":
+            # mcp itself imported; something it depends on is missing.
+            raise
+        return None
+    return McpError
 
 
 def _is_all_isolated_failure(exc: BaseException) -> bool:
     """True iff every leaf is a per-dimension provider/transport failure, recursing into nested groups."""
     if isinstance(exc, _ISOLATED_ERRORS):
+        return True
+    mcp_error = _mcp_error_type()
+    if mcp_error is not None and isinstance(exc, mcp_error):
         return True
     if is_exception_group(exc):
         return all(_is_all_isolated_failure(e) for e in get_exception_group_exceptions(exc))
@@ -218,11 +242,29 @@ def _verdict_instruction(
     issues: list,
     verifications: list,
     clean: list[str] | None = None,
+    failed: list[tuple[str, str]] | None = None,
 ) -> str:
+    # A dimension whose reviewer died is not a dimension that was reviewed.
+    # Naming it under "Dimensions reviewed" asserts coverage that does not
+    # exist, and since a dead reviewer emits no issues, its silence otherwise
+    # reads exactly like a clean result.
+    failed = list(failed or [])
+    failed_names = {name for name, _ in failed}
+    reviewed = [d for d in dimensions if d not in failed_names]
     parts = [
         "Issue a single ReviewVerdict over the artifact from the issues below.\n",
-        f"Dimensions reviewed: {', '.join(dimensions)}\n",
+        f"Dimensions reviewed: {', '.join(reviewed) if reviewed else '(none)'}\n",
     ]
+    if failed:
+        parts.append(
+            "\nDID NOT RUN: "
+            + "; ".join(f"{name} ({err})" for name, err in failed)
+            + "\nThese dimensions failed. They produced no findings because they "
+            "did not execute, not because the artifact is clean along them, so "
+            "their silence is not evidence. Do not issue APPROVE on coverage "
+            "that is missing: name the gap in the rationale and choose a "
+            "verdict that reflects what was actually reviewed.\n"
+        )
     if clean:
         parts.append(f"Affirmed clean: {', '.join(dict.fromkeys(clean))}\n")
     parts.append(f"\n# Issues ({len(issues)})")
@@ -316,9 +358,13 @@ class ReviewEngine(Engine):
         # failures are isolated per dimension so completed sibling evidence is
         # still usable; run-wide budget exhaustion and cancellation keep their
         # existing structured-concurrency semantics.
+        failed: list[tuple[str, str]] = []
         try:
             await ln_gather(
-                *(self._review_dimension_isolated(run, artifact, dimension) for dimension in dims)
+                *(
+                    self._review_dimension_isolated(run, artifact, dimension, failed)
+                    for dimension in dims
+                )
             )
         except BaseException:
             # Cancel any verifier tasks spawned before the failure so no
@@ -335,7 +381,7 @@ class ReviewEngine(Engine):
         # executed evidence rather than absence.
         if self.verify_clean and not run.by_type(VerifyResult):
             await self._verify_clean(run, artifact, dims)
-        return await self._verdict(run, artifact, dims)
+        return await self._verdict(run, artifact, dims, failed)
 
     # -- reactions ------------------------------------------------------------
 
@@ -346,11 +392,17 @@ class ReviewEngine(Engine):
     # -- stages ---------------------------------------------------------------
 
     async def _review_dimension_isolated(
-        self, run: EngineRun, artifact: str, dimension: str
+        self, run: EngineRun, artifact: str, dimension: str, failed: list[tuple[str, str]]
     ) -> None:
         try:
             await self._review_dimension(run, artifact, dimension)
-        except (*_ISOLATED_ERRORS, ExceptionGroup) as exc:
+        except Exception as exc:
+            # Catch broadly and let the predicate decide, rather than naming the
+            # isolated types in the clause: McpError is resolved lazily and so
+            # cannot appear in a static tuple here. Anything the predicate does
+            # not claim is re-raised unchanged. Cancellation derives from
+            # BaseException and is therefore never caught.
+            #
             # A group reaches here when the dimension's own task group collects
             # several transport failures at once. Isolate only when every leaf
             # is one: a mixed group carries something this stage has no claim
@@ -364,6 +416,11 @@ class ReviewEngine(Engine):
                 dimension=dimension,
                 error_type=error_type,
             )
+            # Record it for the verdict stage as well as the run's degrade
+            # markers. Synthesis is otherwise handed the full requested
+            # dimension list and no indication that one of them never ran,
+            # which reads as "reviewed and found nothing".
+            failed.append((dimension, error_type))
             marker = f"review-{dimension} ({error_type})"
             if marker not in run._emission_failures:
                 run._emission_failures.append(marker)
@@ -440,12 +497,22 @@ class ReviewEngine(Engine):
                 retries=self.repair_retries,
             )
 
-    async def _verdict(self, run: EngineRun, artifact: str, dimensions: tuple[str, ...]) -> str:
+    async def _verdict(
+        self,
+        run: EngineRun,
+        artifact: str,
+        dimensions: tuple[str, ...],
+        failed: list[tuple[str, str]] | None = None,
+    ) -> str:
         issues = run.by_type(IssueFound)
         verifications = run.by_type(VerifyResult)
         clean = [c.dimension for c in run.by_type(DimensionClean)]
         run.notify(
-            "verdict", issues=len(issues), verifications=len(verifications), clean=len(clean)
+            "verdict",
+            issues=len(issues),
+            verifications=len(verifications),
+            clean=len(clean),
+            failed=len(failed or []),
         )
         synth = await run.make_agent(
             self.synthesis_role,
@@ -455,6 +522,8 @@ class ReviewEngine(Engine):
             exempt=True,
         )
         res = await synth.operate(
-            instruction=_verdict_instruction(artifact, dimensions, issues, verifications, clean)
+            instruction=_verdict_instruction(
+                artifact, dimensions, issues, verifications, clean, failed
+            )
         )
         return str(res) if res is not None else ""

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -67,19 +67,40 @@ def _mcp_error_type() -> type[BaseException] | None:
     try:
         from mcp.shared.exceptions import McpError
     except ModuleNotFoundError as exc:
-        if (exc.name or "").partition(".")[0] != "mcp":
-            # mcp itself imported; something it depends on is missing.
+        if exc.name != "mcp":
+            # The top-level package resolved but a submodule or dependency is
+            # missing — a broken install, not an uninstalled extra.
             raise
         return None
     return McpError
+
+
+# The MCP SDK spells only two conditions as McpError itself: a closed
+# connection and a request timeout. Every other McpError relays a server-side
+# error object verbatim — authorization refusals, application failures — which
+# says something about the request, not the transport, and must not be
+# swallowed as if the wire had dropped.
+_MCP_TRANSPORT_CODES: frozenset[int] = frozenset(
+    {
+        -32000,  # mcp.types.CONNECTION_CLOSED
+        408,  # httpx.codes.REQUEST_TIMEOUT, used by the SDK's own timeout raise
+    }
+)
+
+
+def _is_transport_mcp_error(exc: BaseException) -> bool:
+    mcp_error = _mcp_error_type()
+    if mcp_error is None or not isinstance(exc, mcp_error):
+        return False
+    error = getattr(exc, "error", None)
+    return getattr(error, "code", None) in _MCP_TRANSPORT_CODES
 
 
 def _is_all_isolated_failure(exc: BaseException) -> bool:
     """True iff every leaf is a per-dimension provider/transport failure, recursing into nested groups."""
     if isinstance(exc, _ISOLATED_ERRORS):
         return True
-    mcp_error = _mcp_error_type()
-    if mcp_error is not None and isinstance(exc, mcp_error):
+    if _is_transport_mcp_error(exc):
         return True
     if is_exception_group(exc):
         return all(_is_all_isolated_failure(e) for e in get_exception_group_exceptions(exc))
@@ -234,6 +255,38 @@ def _verify_clean_instruction(artifact: str, clean: list[DimensionClean], ref: s
         "verdict does or does not hold).\n\n"
         f"# Clean claims under audit\n{claims}\n\n# Artifact\n{artifact}"
     )
+
+
+def _cap_approvals_on_missing_coverage(
+    verdicts: list[ReviewVerdict], failed: list[tuple[str, str]]
+) -> bool:
+    """Rewrite any APPROVE-family verdict to REQUEST-CHANGES when a dimension
+    never ran, recording each dead dimension as a blocking entry.
+
+    Returns True when at least one verdict was capped. The mutation is on the
+    emitted event itself so every downstream reader — not just the return
+    string — sees a verdict that a run with missing coverage can actually
+    stand behind.
+    """
+    if not failed:
+        return False
+    gap = ", ".join(f"{name} ({err})" for name, err in failed)
+    capped = False
+    for verdict in verdicts:
+        if not verdict.verdict.strip().upper().startswith("APPROVE"):
+            continue
+        verdict.verdict = "REQUEST-CHANGES"
+        verdict.rationale = (
+            f"{verdict.rationale}\n[engine] Approval withdrawn: the following "
+            f"dimensions did not run: {gap}. Their silence is missing coverage, "
+            "not clean evidence, so an approval cannot be issued for this run."
+        ).strip()
+        for name, err in failed:
+            entry = f"{name} dimension did not run ({err})"
+            if entry not in verdict.blocking:
+                verdict.blocking.append(entry)
+        capped = True
+    return capped
 
 
 def _verdict_instruction(
@@ -526,4 +579,10 @@ class ReviewEngine(Engine):
                 artifact, dimensions, issues, verifications, clean, failed
             )
         )
+        # The instruction tells synthesis not to approve on missing coverage,
+        # but an instruction is steering, not a gate: the model can still emit
+        # APPROVE. Enforce it structurally — a run in which a dimension never
+        # executed cannot produce an approval, whatever the synthesis text says.
+        if failed and _cap_approvals_on_missing_coverage(run.by_type(ReviewVerdict), failed):
+            run.notify("verdict_capped", failed=", ".join(name for name, _ in failed))
         return str(res) if res is not None else ""

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -257,91 +257,146 @@ def _verify_clean_instruction(artifact: str, clean: list[DimensionClean], ref: s
     )
 
 
-def _cap_approvals_on_missing_coverage(
-    verdicts: list[ReviewVerdict], failed: list[tuple[str, str]]
-) -> bool:
-    """Rewrite any APPROVE-family verdict to REQUEST-CHANGES when a dimension
-    never ran, recording each dead dimension as a blocking entry.
+class _RunCoverage:
+    """Reads this run's evidence out of a flow that may hold more than this run's.
 
-    Returns True when at least one verdict was capped. The mutation is on the
-    emitted event itself so every downstream reader — not just the return
-    string — sees a verdict that a run with missing coverage can actually
-    stand behind.
+    ``run.by_type()`` reads the *session's* accumulated flow, and a session can
+    outlive a run: ``EngineRun`` takes a caller-supplied ``Session`` and
+    ``Engine.run()`` passes one through. On a reused session a previous run's
+    evidence is therefore indistinguishable from this one's, which lets a
+    dimension that emitted nothing this run pass as covered because it emitted
+    something last run. That is the precise failure the coverage check exists
+    to catch.
+
+    Scoping is by exclusion: ``_run`` records which events were already in the
+    flow before it started, and everything else in the flow belongs to this run.
+    Filtering at read time rather than accumulating at emit time is what keeps
+    it correct regardless of when the ledger is created relative to the
+    evidence — accumulating from a subscription can only ever see what was
+    emitted after the subscription, so a stage reached without one reports every
+    dimension missing while the same artifact lists the issues they found.
+
+    Constructed with no *run* the prior set is empty, meaning "nothing is known
+    to predate this run, so treat the whole flow as ours". That is the only
+    sound default when the run boundary was never recorded.
     """
-    if not failed:
-        return False
-    gap = ", ".join(f"{name} ({err})" for name, err in failed)
-    capped = False
-    for verdict in verdicts:
-        if not verdict.verdict.strip().upper().startswith("APPROVE"):
-            continue
-        verdict.verdict = "REQUEST-CHANGES"
-        verdict.rationale = (
-            f"{verdict.rationale}\n[engine] Approval withdrawn: the following "
-            f"dimensions did not run: {gap}. Their silence is missing coverage, "
-            "not clean evidence, so an approval cannot be issued for this run."
-        ).strip()
-        for name, err in failed:
-            entry = f"{name} dimension did not run ({err})"
-            if entry not in verdict.blocking:
-                verdict.blocking.append(entry)
-        capped = True
-    return capped
+
+    __slots__ = ("_prior",)
+
+    def __init__(self, run: Any = None) -> None:
+        tracked = (IssueFound, DimensionClean, ReviewVerdict)
+        self._prior: dict[type, set[int]] = {
+            event_type: ({id(e) for e in run.by_type(event_type)} if run is not None else set())
+            for event_type in tracked
+        }
+
+    def _mine(self, run: Any, event_type: type) -> list[Any]:
+        """Events of *event_type* in the flow that were not there before this run."""
+        prior = self._prior.get(event_type, set())
+        return [e for e in run.by_type(event_type) if id(e) not in prior]
+
+    def issued(self, run: Any) -> set[str]:
+        return {i.dimension for i in self._mine(run, IssueFound)}
+
+    def clean(self, run: Any) -> set[str]:
+        return {c.dimension for c in self._mine(run, DimensionClean)}
+
+    def verdicts(self, run: Any) -> list[ReviewVerdict]:
+        return self._mine(run, ReviewVerdict)
+
+    def missing(
+        self, run: Any, dimensions: tuple[str, ...], failed: list[tuple[str, str]]
+    ) -> list[tuple[str, str]]:
+        """Dimensions this run cannot claim to have reviewed, derived from evidence.
+
+        A dimension counts as covered only when it produced something: an issue,
+        or an affirmative clean. Deriving the gap from what arrived rather than
+        from failure bookkeeping is what makes it complete. A reviewer that
+        exhausts its emission repairs raises nothing, so it never reaches the
+        isolated-failure recorder and never lands in *failed* — and a dimension
+        that emitted nothing is indistinguishable from a clean one to everything
+        downstream.
+
+        *failed* entries keep their specific error label and their order;
+        anything else missing is appended.
+        """
+        gap: list[tuple[str, str]] = list(failed)
+        named = {name for name, _ in gap}
+        covered = self.issued(run) | self.clean(run)
+        for dimension in dimensions:
+            if dimension not in named and dimension not in covered:
+                gap.append((dimension, "no evidence emitted"))
+        return gap
 
 
-def _missing_coverage(
-    run: Any, dimensions: tuple[str, ...], failed: list[tuple[str, str]]
-) -> list[tuple[str, str]]:
-    """Dimensions this run cannot claim to have reviewed, derived from evidence.
+def _gap_blocking(gap: list[tuple[str, str]]) -> list[str]:
+    return [f"{name} dimension did not run ({err})" for name, err in gap]
 
-    A dimension counts as covered only when it produced something: an issue, or
-    an affirmative clean. Deriving the gap from what arrived rather than from
-    failure bookkeeping is what makes it complete. A reviewer that exhausts its
-    emission repairs raises nothing, so it never reaches the isolated-failure
-    recorder and never lands in *failed* — and a dimension that emitted nothing
-    is indistinguishable from a clean one to everything downstream. This is the
-    same predicate the repair loop uses to decide a dimension arrived, so a
-    dimension the engine gave up on is exactly a dimension named here.
 
-    *failed* entries keep their specific error label and their order; anything
-    else missing is appended.
+_GAP_RATIONALE = (
+    "The dimensions listed as blocking did not execute. They produced no "
+    "findings because they never ran, not because the artifact is clean along "
+    "them, so their silence is missing coverage and this run cannot issue an "
+    "approval."
+)
+
+
+def _gap_verdict(gap: list[tuple[str, str]], summary: str) -> ReviewVerdict:
+    """The verdict a run with missing coverage is entitled to, authored here.
+
+    Engine-authored rather than model-authored: when coverage is incomplete the
+    synthesis agent is never granted the ability to emit a ``ReviewVerdict``
+    (see ``_verdict``), so this is the only one that exists for such a run. That
+    is what makes the invariant structural — there is no approval to withdraw,
+    because none was ever created.
     """
-    gap: list[tuple[str, str]] = list(failed)
-    named = {name for name, _ in gap}
-    covered = {i.dimension for i in run.by_type(IssueFound)} | {
-        c.dimension for c in run.by_type(DimensionClean)
-    }
-    for dimension in dimensions:
-        if dimension not in named and dimension not in covered:
-            gap.append((dimension, "no evidence emitted"))
-    return gap
-
-
-def _cap_verdict_text(text: str, failed: list[tuple[str, str]]) -> str:
-    """Front the returned verdict text with a refusal when a dimension never ran.
-
-    Capping the emitted events only reaches a ReviewVerdict that synthesis
-    actually issued. When it issues none, this string is the whole verdict as
-    far as the caller is concerned, so the same invariant has to hold here:
-    otherwise the channel that lacks it becomes the way an approval over
-    missing coverage gets out. The synthesis output is kept underneath as
-    quoted context so nothing is lost, and so a decision line inside it can no
-    longer be read as this run's decision.
-    """
-    if not failed:
-        return text
-    blocking = "".join(f"- {name} dimension did not run ({err})\n" for name, err in failed)
-    quoted = "\n".join(f"> {line}" for line in text.splitlines()) if text else "> (no output)"
-    return (
-        "DECISION: REQUEST-CHANGES\n"
-        f"BLOCKING:\n{blocking}"
-        "RATIONALE: the dimensions listed above did not execute. They produced "
-        "no findings because they never ran, not because the artifact is clean "
-        "along them, so their silence is missing coverage and this run cannot "
-        "issue an approval.\n\n"
-        "--- synthesis output below is context, not this run's decision ---\n"
-        f"{quoted}"
+    rationale = _GAP_RATIONALE
+    if summary.strip():
+        rationale = f"{rationale}\n\n{summary.strip()}"
+    return ReviewVerdict(
+        verdict="REQUEST-CHANGES",
+        rationale=rationale,
+        blocking=_gap_blocking(gap),
+        reversible_by=(
+            "Re-run the review with every dimension executing; the gap is "
+            "missing evidence, not an adverse finding."
+        ),
     )
+
+
+def _gap_verdict_text(verdict: ReviewVerdict) -> str:
+    """Render an engine-authored gap verdict in the shape synthesis output uses.
+
+    A gap run issues no synthesis call, so this string is the whole verdict as
+    far as the caller is concerned. It keeps the ``DECISION:`` / ``BLOCKING:``
+    shape that downstream readers already parse rather than inventing a second
+    one for the degraded path.
+    """
+    blocking = "".join(f"- {entry}\n" for entry in verdict.blocking)
+    return f"DECISION: {verdict.verdict}\nBLOCKING:\n{blocking}RATIONALE: {verdict.rationale}"
+
+
+def _verdict_text(verdict: ReviewVerdict, prefix: str = "") -> str:
+    blocking = f"\n\nBlocking: {', '.join(verdict.blocking)}" if verdict.blocking else ""
+    return f"{prefix}{verdict.verdict}: {verdict.rationale}{blocking}"
+
+
+def _issue_digest(issues: list[IssueFound]) -> str:
+    """Render the issues the surviving dimensions did find.
+
+    A run with a coverage gap issues no synthesis call, so nothing else would
+    carry these into the returned text — and issues found by the dimensions
+    that *did* run are the actionable half of a degraded review. Rendered here
+    rather than summarised by a model so the degraded path stays deterministic
+    and costs no agent.
+    """
+    if not issues:
+        return ""
+    lines = []
+    for issue in issues:
+        severity = f"{issue.severity}: " if issue.severity else ""
+        lines.append(f"- [{issue.dimension}] {severity}{issue.description}")
+    return f"Issues found by the dimensions that did run ({len(issues)}):\n" + "\n".join(lines)
 
 
 def _verdict_instruction(
@@ -442,46 +497,35 @@ class ReviewEngine(Engine):
 
         See docs/internals/providers.md#review-engine-partial-export-on-deadline.
         """
-        verdicts = run.by_type(ReviewVerdict)
+        # This run's verdicts, not the session's: run.by_type() reads the
+        # session-accumulated flow, so on a reused session this exit would
+        # export a *previous* run's verdict as this one's result.
+        verdicts = self._coverage(run).verdicts(run)
         if not verdicts:
             return ""
         verdict = verdicts[-1]
-        # Exhaustion is the one exit that skips _verdict, so the cap has to be
-        # applied here too. A run cut short by its deadline is the likeliest
-        # one to be missing a dimension, which makes this the worst channel to
-        # let an approval out of.
-        gap = _missing_coverage(run, tuple(dimensions) if dimensions else self.dimensions, [])
-        _cap_approvals_on_missing_coverage([verdict], gap)
+        # No coverage cap is applied here, and none is needed. A ReviewVerdict
+        # exists in this run only if _verdict granted synthesis the capability
+        # to emit one, and it grants that only when coverage is complete. An
+        # exhausted run that never reached _verdict has no verdict to export.
         run.notify("verdict_emitted_on_exhaustion", verdict=verdict.verdict)
         status_header = (
             "**status: budget_exhausted (verdict emitted on exhaustion)** — "
             "run terminated by deadline/budget after the verdict was computed "
             f"({run.agents_made} agents)\n\n"
         )
-        blocking = f"\n\nBlocking: {', '.join(verdict.blocking)}" if verdict.blocking else ""
-        return _cap_verdict_text(
-            f"{status_header}{verdict.verdict}: {verdict.rationale}{blocking}", gap
-        )
+        return _verdict_text(verdict, status_header)
 
     async def _run(
         self, run: EngineRun, artifact: str, *, dimensions: tuple[str, ...] | None = None
     ) -> str:
         dims = tuple(dimensions) if dimensions else self.dimensions
         run.root = artifact
+        # Marks where this run begins in a flow the session may already have
+        # filled, so coverage read later is this run's and not a previous one's.
+        self._coverage(run, mark_start=True)
         run.observe(IssueFound, lambda i, _c: self._on_issue(run, i))
         failed: list[tuple[str, str]] = []
-        # Cap the verdict where it arrives, not after synthesis returns.
-        # Everything downstream — persistence, subscribers, the notify stream —
-        # reads the verdict from this flow, so rewriting it later leaves an
-        # approval already delivered to whoever was listening. Synthesis runs
-        # after every reviewer, so the coverage gap is final by the time this
-        # fires.
-        run.observe(
-            ReviewVerdict,
-            lambda v, _c: _cap_approvals_on_missing_coverage(
-                [v], _missing_coverage(run, dims, failed)
-            ),
-        )
 
         # Fan out one reviewer per dimension. Ordinary provider/transport
         # failures are isolated per dimension so completed sibling evidence is
@@ -512,6 +556,28 @@ class ReviewEngine(Engine):
         return await self._verdict(run, artifact, dims, failed)
 
     # -- reactions ------------------------------------------------------------
+
+    @staticmethod
+    def _coverage(run: EngineRun, *, mark_start: bool = False) -> _RunCoverage:
+        """This run's evidence reader, created once per run.
+
+        Attached to the run rather than the engine: one engine serves many
+        runs, and keying per-run state off the engine is how a previous run's
+        coverage leaks into this one's, which is the same mistake as reading it
+        back from a shared session.
+
+        ``mark_start=True`` records what the flow already held, and only ``_run``
+        passes it, because only ``_run`` knows where this run begins. Reached any
+        other way the reader is built with an empty prior set, which treats the
+        whole flow as this run's — the only sound reading when the boundary was
+        never recorded, and the behaviour a direct call to a single stage has
+        always had.
+        """
+        existing = getattr(run, "_review_coverage", None)
+        if existing is None:
+            existing = _RunCoverage(run if mark_start else None)
+            run._review_coverage = existing  # type: ignore[attr-defined]
+        return existing
 
     def _on_issue(self, run: EngineRun, issue: IssueFound) -> None:
         if issue.severity in self.verify_severities and not run.seen(_verify_key(issue)):
@@ -632,9 +698,12 @@ class ReviewEngine(Engine):
         dimensions: tuple[str, ...],
         failed: list[tuple[str, str]] | None = None,
     ) -> str:
+        coverage = self._coverage(run)
         issues = run.by_type(IssueFound)
         verifications = run.by_type(VerifyResult)
-        clean = [c.dimension for c in run.by_type(DimensionClean)]
+        affirmed_clean = coverage.clean(run)
+        clean = [d for d in dimensions if d in affirmed_clean]
+        gap = coverage.missing(run, dimensions, list(failed or []))
         run.notify(
             "verdict",
             issues=len(issues),
@@ -642,6 +711,22 @@ class ReviewEngine(Engine):
             clean=len(clean),
             failed=len(failed or []),
         )
+        # Every reviewer has returned by now, so the coverage gap is final.
+        #
+        # When a dimension never ran, synthesis is not given the ability to
+        # issue a verdict at all: no agent is created with a ReviewVerdict
+        # emission grant, so no approval can be constructed, dispatched, or
+        # observed. The earlier shape of this code let synthesis emit freely and
+        # rewrote an approval afterwards, which cannot be airtight — the bus
+        # gathers handlers concurrently and a subscriber registered before the
+        # run has already received the event by the time any rewrite runs. An
+        # approval that is never created needs no withdrawing.
+        if gap:
+            run.notify("verdict_withheld", failed=", ".join(name for name, _ in gap))
+            verdict = _gap_verdict(gap, _issue_digest(issues))
+            await run.emit(verdict)
+            return _gap_verdict_text(verdict)
+
         synth = await run.make_agent(
             self.synthesis_role,
             name="verdict",
@@ -654,15 +739,4 @@ class ReviewEngine(Engine):
                 artifact, dimensions, issues, verifications, clean, failed
             )
         )
-        # The instruction tells synthesis not to approve on missing coverage,
-        # but an instruction is steering, not a gate: the model can still emit
-        # APPROVE. Enforce it structurally — a run in which a dimension never
-        # executed cannot produce an approval, whatever the synthesis text says.
-        # Both channels carry the cap: the emitted verdict, and the returned
-        # text, which is the only verdict a caller sees when synthesis emits
-        # nothing structured at all.
-        gap = _missing_coverage(run, dimensions, failed or [])
-        if gap:
-            _cap_approvals_on_missing_coverage(run.by_type(ReviewVerdict), gap)
-            run.notify("verdict_capped", failed=", ".join(name for name, _ in gap))
-        return _cap_verdict_text(str(res) if res is not None else "", gap)
+        return str(res) if res is not None else ""

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -11,7 +11,13 @@ import anyio
 import pytest
 
 from lionagi.engines.engine import Engine, EngineBudgetError
-from lionagi.engines.review import ReviewEngine, _is_all_isolated_failure
+from lionagi.engines.review import (
+    DimensionClean,
+    IssueFound,
+    ReviewEngine,
+    ReviewVerdict,
+    _is_all_isolated_failure,
+)
 from lionagi.ln.concurrency._compat import ExceptionGroup
 from lionagi.providers._provider_errors import ProviderContextError
 
@@ -239,96 +245,87 @@ def test_application_mcp_errors_are_not_isolated_as_transport_failures() -> None
     assert _is_all_isolated_failure(mixed) is False
 
 
-def test_an_approve_emitted_over_a_dead_dimension_is_structurally_capped() -> None:
-    """The prompt tells synthesis not to approve on missing coverage; the
-    engine must not depend on it complying. If a dimension never ran and the
-    synthesis model emits APPROVE anyway, the verdict event is rewritten to
-    REQUEST-CHANGES with the dead dimensions as blocking entries — approval
-    on absent coverage must be unrepresentable, not merely discouraged."""
-    from lionagi.engines.review import ReviewVerdict, _cap_approvals_on_missing_coverage
+async def test_missing_coverage_grants_no_agent_the_ability_to_issue_a_verdict() -> None:
+    """The structural invariant, asserted at the grant rather than the outcome.
 
-    approve = ReviewVerdict(verdict="APPROVE", rationale="looks clean", blocking=[])
-    with_fixes = ReviewVerdict(verdict="approve-with-fixes", rationale="minor nits", blocking=[])
-    already_blocking = ReviewVerdict(
-        verdict="REQUEST-CHANGES", rationale="real issue", blocking=["x"]
-    )
-    failed = [("security", "McpError"), ("performance", "EndOfStream")]
-
-    capped = _cap_approvals_on_missing_coverage([approve, with_fixes, already_blocking], failed)
-
-    assert capped is True
-    # Both APPROVE-family verdicts are rewritten, case-insensitively.
-    for verdict in (approve, with_fixes):
-        assert verdict.verdict == "REQUEST-CHANGES"
-        assert "security dimension did not run (McpError)" in verdict.blocking
-        assert "performance dimension did not run (EndOfStream)" in verdict.blocking
-        assert "cannot be issued" in verdict.rationale
-    # A verdict that already refuses approval is left alone.
-    assert already_blocking.rationale == "real issue"
-    assert already_blocking.blocking == ["x"]
-
-    # No dead dimensions -> nothing to cap; an APPROVE stands.
-    clean_approve = ReviewVerdict(verdict="APPROVE", rationale="fine", blocking=[])
-    assert _cap_approvals_on_missing_coverage([clean_approve], []) is False
-    assert clean_approve.verdict == "APPROVE"
-
-
-def test_the_returned_verdict_text_is_capped_even_with_no_verdict_to_rewrite() -> None:
-    """Rewriting emitted verdicts reaches nothing when synthesis emits none.
-
-    The returned string is then the entire verdict the caller sees, so it
-    carries the same refusal; the synthesis output survives as quoted context
-    where its own decision line cannot be read as the run's decision.
+    Rewriting an approval after synthesis emits it can never be airtight: the
+    session bus gathers handlers concurrently, so a subscriber registered
+    before the run already holds the APPROVE by the time any rewrite runs. The
+    engine therefore does not create a ReviewVerdict-emitting agent at all when
+    a dimension is missing. Asserting on the grant is what makes this checkable
+    — an approval that is never constructed cannot leak through any channel.
     """
-    from lionagi.engines.review import _cap_verdict_text
-
-    failed = [("security", "McpError")]
-    capped = _cap_verdict_text("DECISION: APPROVE\nAll dimensions look clean.", failed)
-
-    assert capped.startswith("DECISION: REQUEST-CHANGES\n")
-    assert "- security dimension did not run (McpError)" in capped
-    # The synthesis decision line survives only as quoted context.
-    assert "> DECISION: APPROVE" in capped
-    assert not any(line.startswith("DECISION: APPROVE") for line in capped.splitlines())
-
-    # Nothing failed -> the synthesis text is returned untouched.
-    assert _cap_verdict_text("DECISION: APPROVE", []) == "DECISION: APPROVE"
-
-
-async def test_a_raw_approve_with_no_emitted_verdict_does_not_yield_approval() -> None:
-    """End-to-end on _verdict: synthesis emits no ReviewVerdict and returns a
-    bare approval. The event cap has nothing to rewrite, so the refusal has to
-    come from the returned text or the run approves on a dimension that never
-    executed."""
-
-    class _RawApproveAgent:
-        async def operate(self, instruction: str):
-            return "DECISION: APPROVE"
-
-    class _RunWithNoVerdictEmitted:
-        def __init__(self) -> None:
-            self.notices: list[tuple[str, dict]] = []
-
-        def by_type(self, event_type):
-            return []
-
-        def notify(self, kind: str, **data) -> None:
-            self.notices.append((kind, data))
-
-        async def make_agent(self, role: str, **kwargs):
-            return _RawApproveAgent()
-
     engine = ReviewEngine()
-    run = _RunWithNoVerdictEmitted()
+    run = _CoverageRun(clean=("correctness",))
 
-    result = await engine._verdict(
+    await engine._verdict(run, "artifact.py", ("correctness", "security"), [])
+
+    granted = [kwargs.get("emits", ()) for _role, kwargs in run.agent_calls]
+    assert not any(ReviewVerdict in emits for emits in granted), (
+        f"an agent was granted the ability to emit a ReviewVerdict over missing "
+        f"coverage; grants were {granted!r}"
+    )
+    # Not merely ungranted: no synthesis agent is created at all, so the
+    # degraded path also costs no model call.
+    assert run.agent_calls == []
+
+
+async def test_the_verdict_a_gap_run_emits_is_engine_authored_and_refuses() -> None:
+    """Downstream readers take the verdict off the bus, not from the returned
+    string, so the run has to put a real REQUEST-CHANGES event there. It names
+    each dimension that did not run as a blocking entry."""
+    engine = ReviewEngine()
+    run = _CoverageRun(clean=("correctness",))
+
+    await engine._verdict(
         run, "artifact.py", ("correctness", "security"), [("security", "McpError")]
     )
 
-    assert not result.startswith("DECISION: APPROVE")
+    emitted = [e for e in run.emitted if isinstance(e, ReviewVerdict)]
+    assert len(emitted) == 1, f"expected exactly one engine-authored verdict, got {emitted!r}"
+    assert emitted[0].verdict == "REQUEST-CHANGES"
+    assert "security dimension did not run (McpError)" in emitted[0].blocking
+    assert "correctness" not in " ".join(emitted[0].blocking)
+    assert emitted[0].reversible_by and "Re-run" in emitted[0].reversible_by
+    assert any(kind == "verdict_withheld" for kind, _ in run.notices)
+
+
+async def test_a_gap_run_still_reports_what_the_surviving_dimensions_found() -> None:
+    """Skipping synthesis must not throw away the actionable half of a degraded
+    review. The issues the dimensions that did run found are rendered by the
+    engine, deterministically and at no model cost."""
+    engine = ReviewEngine()
+    issue = IssueFound(
+        dimension="correctness",
+        description="off-by-one in the retry bound",
+        severity="major",
+    )
+    run = _CoverageRun(issues=(issue,))
+
+    result = await engine._verdict(run, "artifact.py", ("correctness", "security"), [])
+
     assert result.startswith("DECISION: REQUEST-CHANGES")
-    assert "security dimension did not run (McpError)" in result
-    assert any(kind == "verdict_capped" for kind, _ in run.notices)
+    assert "security dimension did not run" in result
+    assert "off-by-one in the retry bound" in result
+    assert "[correctness]" in result
+
+
+async def test_complete_coverage_still_grants_synthesis_and_returns_its_text() -> None:
+    """The must-not-over-fire arm. With every dimension covered there is no gap,
+    so synthesis is granted the verdict capability as before and its output is
+    returned untouched. Without this arm the refusal path would pass even if it
+    fired on every run."""
+    engine = ReviewEngine()
+    run = _CoverageRun(clean=("correctness", "security"))
+
+    result = await engine._verdict(run, "artifact.py", ("correctness", "security"), [])
+
+    granted = [kwargs.get("emits", ()) for _role, kwargs in run.agent_calls]
+    assert any(ReviewVerdict in emits for emits in granted), (
+        "synthesis was not granted the verdict capability on a fully covered run"
+    )
+    assert result == "DECISION: APPROVE"
+    assert not any(kind == "verdict_withheld" for kind, _ in run.notices)
 
 
 def test_verdict_prompt_refuses_to_present_a_dead_dimension_as_reviewed() -> None:
@@ -444,17 +441,45 @@ def test_a_missing_mcp_extra_is_a_normal_configuration(monkeypatch) -> None:
 
 
 class _CoverageRun:
-    """Minimal run exposing the surface the cap paths read."""
+    """Minimal run exposing the surface the verdict paths read.
 
-    def __init__(self, *, verdicts=None, clean=(), issues=()) -> None:
-        from lionagi.engines.review import DimensionClean, IssueFound, ReviewVerdict
+    *clean* / *issues* / *verdicts* seed both this run's coverage ledger and the
+    session flow, which is what a real run produces. The ``stale_*`` arguments
+    seed the session flow **only**, standing in for a previous run on a reused
+    session: ``run.by_type()`` reads the session's accumulated flow, so anything
+    that derives this run's coverage from it counts a previous run's evidence as
+    this one's.
+    """
 
+    def __init__(
+        self,
+        *,
+        verdicts=None,
+        clean=(),
+        issues=(),
+        stale_verdicts=None,
+        stale_clean=(),
+        stale_issues=(),
+    ) -> None:
+        from lionagi.engines.review import _RunCoverage
+
+        # The stale events are in the flow first, exactly as a previous run on a
+        # reused session would have left them.
         self._by_type = {
-            ReviewVerdict: list(verdicts or []),
-            DimensionClean: [DimensionClean(dimension=d) for d in clean],
-            IssueFound: list(issues),
+            ReviewVerdict: list(stale_verdicts or []),
+            DimensionClean: [DimensionClean(dimension=d) for d in stale_clean],
+            IssueFound: list(stale_issues),
         }
+        # Mark the run boundary here, the way _run does, then add this run's own
+        # events after it.
+        self._review_coverage = _RunCoverage(self)
+        self._by_type[ReviewVerdict].extend(verdicts or [])
+        self._by_type[DimensionClean].extend(DimensionClean(dimension=d) for d in clean)
+        self._by_type[IssueFound].extend(issues)
+
         self.notices: list[tuple[str, dict]] = []
+        self.emitted: list = []
+        self.agent_calls: list[tuple[str, dict]] = []
         self.agents_made = 3
 
     def by_type(self, event_type):
@@ -463,7 +488,13 @@ class _CoverageRun:
     def notify(self, kind: str, **data) -> None:
         self.notices.append((kind, data))
 
+    async def emit(self, event):
+        self.emitted.append(event)
+        return []
+
     async def make_agent(self, role: str, **kwargs):
+        self.agent_calls.append((role, kwargs))
+
         class _Approve:
             async def operate(self, instruction: str):
                 return "DECISION: APPROVE"
@@ -490,43 +521,80 @@ async def test_a_dimension_that_emitted_nothing_cannot_be_approved_over() -> Non
     assert "correctness dimension did not run" not in result
 
 
-async def test_partial_export_does_not_hand_back_an_approval_over_missing_coverage() -> None:
-    """Exhaustion is the one exit that never reaches _verdict.
+async def test_a_previous_runs_evidence_on_a_reused_session_is_not_this_runs_coverage() -> None:
+    """``run.by_type()`` reads the *session's* accumulated flow, and a session
+    outlives a run: ``EngineRun`` takes a caller-supplied ``Session`` and
+    ``Engine.run()`` passes one through. Deriving coverage from there lets a
+    dimension that emitted nothing this run pass as covered because it emitted
+    something last run, which is the exact failure the coverage check exists to
+    catch. Coverage must come from observers this run registered."""
+    engine = ReviewEngine()
+    stale = IssueFound(
+        dimension="security", description="found on a previous run", severity="major"
+    )
+    # The session flow says security produced evidence. This run's ledger says
+    # it did not, and this run's ledger is the one that counts.
+    run = _CoverageRun(clean=("correctness",), stale_issues=(stale,), stale_clean=("security",))
 
-    A run cut short by its deadline is also the likeliest to be missing a
-    dimension, so this is the worst channel to let a stored approval out of.
+    result = await engine._verdict(run, "artifact.py", ("correctness", "security"), [])
+
+    assert "security dimension did not run (no evidence emitted)" in result, (
+        "a previous run's evidence was counted as this run's coverage"
+    )
+    assert result.startswith("DECISION: REQUEST-CHANGES")
+
+
+async def test_partial_export_returns_this_runs_verdict_not_a_previous_runs() -> None:
+    """Exhaustion is the one exit that never reaches ``_verdict``.
+
+    Reading the stored verdict off the session flow means that on a reused
+    session an exhausted run exports the *previous* run's verdict as its own
+    result, over an artifact it may never have finished reviewing.
     """
     from lionagi.engines.review import ReviewVerdict
 
-    verdict = ReviewVerdict(verdict="APPROVE", rationale="nothing came up", blocking=[])
+    previous = ReviewVerdict(verdict="APPROVE", rationale="a previous run", blocking=[])
     engine = ReviewEngine()
-    run = _CoverageRun(verdicts=[verdict], clean=("correctness",))
+    run = _CoverageRun(stale_verdicts=[previous], clean=("correctness", "security"))
 
     out = await engine._partial_export(run, "artifact.py", dimensions=("correctness", "security"))
 
-    assert "REQUEST-CHANGES" in out
-    assert not any(line.startswith("DECISION: APPROVE") for line in out.splitlines())
-    # The stored verdict is rewritten too, not just the text built from it.
-    assert verdict.verdict == "REQUEST-CHANGES"
-    assert any("security" in b for b in verdict.blocking)
+    assert out == "", f"exported a verdict this run never issued: {out!r}"
+    assert previous.verdict == "APPROVE", "a previous run's stored verdict was mutated"
 
 
-async def test_a_verdict_is_capped_when_it_arrives_not_after_synthesis_returns() -> None:
-    """Persistence and subscribers read the verdict from the run's flow.
-
-    Rewriting it after synthesis returns leaves an approval already delivered
-    to whoever was listening, so the cap runs on arrival.
-    """
+async def test_partial_export_still_returns_a_verdict_this_run_did_issue() -> None:
+    """The must-not-over-fire arm for the exit above: a verdict this run issued
+    is still exported, with the budget-exhaustion header. No coverage cap is
+    applied, and none is needed, because a ReviewVerdict exists for this run
+    only where synthesis was granted the capability to emit one."""
     from lionagi.engines.review import ReviewVerdict
 
-    observers: dict[type, list] = {}
+    mine = ReviewVerdict(verdict="APPROVE", rationale="every dimension reported", blocking=[])
+    engine = ReviewEngine()
+    run = _CoverageRun(verdicts=[mine], clean=("correctness", "security"))
+
+    out = await engine._partial_export(run, "artifact.py", dimensions=("correctness", "security"))
+
+    assert "budget_exhausted" in out
+    assert "APPROVE: every dimension reported" in out
+    assert any(kind == "verdict_emitted_on_exhaustion" for kind, _ in run.notices)
+
+
+async def test_run_marks_the_boundary_that_makes_coverage_run_scoped() -> None:
+    """Scoping is only real if ``_run`` actually records where the run begins.
+
+    Without this, every coverage test above would still pass against a reader
+    whose prior set is empty, which is the permissive default — it treats a
+    previous run's evidence as this run's, the exact defect being fixed.
+    """
 
     class _ObservingRun(_CoverageRun):
         root = ""
         _sem = asyncio.Semaphore(1)
 
         def observe(self, event_type, handler):
-            observers.setdefault(event_type, []).append(handler)
+            return None
 
         async def wait_quiescence(self):
             return None
@@ -537,17 +605,25 @@ async def test_a_verdict_is_capped_when_it_arrives_not_after_synthesis_returns()
         async def operate_with_repair(self, agent, instruction, **kwargs):
             return ""
 
+    stale = IssueFound(dimension="security", description="previous run", severity="major")
     engine = ReviewEngine(verify_clean=False)
-    run = _ObservingRun(clean=("correctness",))
+    run = _ObservingRun(stale_issues=(stale,))
+    # Drop the reader the stub pre-built, so _run is the thing that marks the
+    # boundary rather than the fixture.
+    run._review_coverage = None
+
     await engine._run(run, "artifact.py", dimensions=("correctness", "security"))
 
-    assert ReviewVerdict in observers, "no verdict observer registered, so nothing caps on arrival"
-    arriving = ReviewVerdict(verdict="APPROVE", rationale="looks clean", blocking=[])
-    for handler in observers[ReviewVerdict]:
-        handler(arriving, None)
-
-    assert arriving.verdict == "REQUEST-CHANGES", (
-        "the verdict object handed to subscribers still says APPROVE while a "
-        "dimension produced no evidence"
+    reader = engine._coverage(run)
+    assert reader.issued(run) == set(), (
+        "a previous run's issue was counted as this run's evidence, so _run did "
+        "not mark the boundary"
     )
-    assert any("security" in b for b in arriving.blocking)
+
+    # Evidence arriving after the mark is this run's.
+    mine = IssueFound(dimension="correctness", description="this run", severity="minor")
+    run._by_type[IssueFound].append(mine)
+    assert reader.issued(run) == {"correctness"}
+    assert reader.missing(run, ("correctness", "security"), []) == [
+        ("security", "no evidence emitted")
+    ]

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 from types import SimpleNamespace
 
+import anyio
 import pytest
 
-from lionagi.engines.engine import Engine
-from lionagi.engines.review import ReviewEngine
+from lionagi.engines.engine import Engine, EngineBudgetError
+from lionagi.engines.review import ReviewEngine, _is_all_isolated_failure
+from lionagi.ln.concurrency._compat import ExceptionGroup
 from lionagi.providers._provider_errors import ProviderContextError
 
 
@@ -95,3 +98,110 @@ async def test_review_dimension_failure_does_not_cancel_siblings_or_verdict() ->
         and event["error_type"] == "ProviderContextError"
         for event in events
     )
+
+
+class _TransportFailingReview(ReviewEngine):
+    """One dimension dies of `failure`; the sibling must still finish and reach a verdict."""
+
+    def __init__(self, failure: BaseException) -> None:
+        super().__init__(dimensions=("broken", "healthy"), verify_clean=False)
+        self._failure = failure
+        self.healthy_started = asyncio.Event()
+        self.healthy_finished = asyncio.Event()
+
+    async def _review_dimension(self, run, artifact: str, dimension: str) -> None:
+        if dimension == "broken":
+            await self.healthy_started.wait()
+            raise self._failure
+        self.healthy_started.set()
+        await asyncio.sleep(0.05)
+        self.healthy_finished.set()
+
+    async def _verdict(self, run, artifact: str, dimensions: tuple[str, ...]) -> str:
+        assert self.healthy_finished.is_set()
+        return "healthy dimension survived"
+
+
+def _mcp_error(message: str) -> BaseException:
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    return McpError(ErrorData(code=-32000, message=message))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("make_failure", "expected_label"),
+    [
+        (lambda: anyio.ClosedResourceError(), "ClosedResourceError"),
+        (lambda: anyio.BrokenResourceError(), "BrokenResourceError"),
+        (
+            lambda: ExceptionGroup(
+                "unhandled errors in a TaskGroup",
+                [anyio.ClosedResourceError(), anyio.ClosedResourceError()],
+            ),
+            "ClosedResourceError",
+        ),
+        (
+            pytest.param(
+                lambda: _mcp_error("Connection closed"),
+                "McpError",
+                marks=pytest.mark.skipif(
+                    importlib.util.find_spec("mcp") is None,
+                    reason="mcp is an optional extra",
+                ),
+            )
+        ),
+    ],
+)
+async def test_review_isolates_transport_failures_like_provider_failures(
+    make_failure, expected_label: str
+) -> None:
+    """A dropped transport is a per-dimension failure, so it must degrade one dimension, not kill the run.
+
+    Before this, only ProviderError was isolated. A dropped MCP connection
+    raises the MCP SDK's McpError (an Exception, not a ProviderError) and a
+    dropped stream raises anyio's, so both escaped the isolation clause and
+    propagated to the run-level handler that cancels every sibling — turning
+    one dead dimension into ENGINE-UNAVAILABLE with no verdict at all.
+    """
+    events: list[dict] = []
+    engine = _TransportFailingReview(make_failure())
+
+    result = await engine.run("artifact", on_event=events.append)
+
+    assert result == "healthy dimension survived"
+    assert result.degraded is True
+    assert result.skipped == [f"review-broken ({expected_label})"]
+    assert any(
+        event["type"] == "dimension_failed"
+        and event["dimension"] == "broken"
+        and event["error_type"] == expected_label
+        for event in events
+    )
+
+
+def test_isolation_predicate_refuses_a_group_carrying_a_non_transport_leaf() -> None:
+    """Isolate only when EVERY leaf is a transport/provider failure.
+
+    A group mixing a transport drop with budget exhaustion must propagate:
+    swallowing it would launder a run-wide stop into a per-dimension degrade
+    and hide it behind a verdict that looks reasoned.
+    """
+    all_transport = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [anyio.ClosedResourceError(), anyio.BrokenResourceError()],
+    )
+    assert _is_all_isolated_failure(all_transport) is True
+
+    mixed = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [anyio.ClosedResourceError(), EngineBudgetError("agent budget exhausted (12/12)")],
+    )
+    assert _is_all_isolated_failure(mixed) is False
+
+    nested_mixed = ExceptionGroup(
+        "outer",
+        [ExceptionGroup("inner", [anyio.ClosedResourceError(), EngineBudgetError("exhausted")])],
+    )
+    assert _is_all_isolated_failure(nested_mixed) is False

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -438,3 +438,116 @@ def test_a_missing_mcp_extra_is_a_normal_configuration(monkeypatch) -> None:
     monkeypatch.setattr(builtins, "__import__", fake_import)
     assert review_mod._mcp_error_type() is None
     review_mod._mcp_error_type.cache_clear()
+
+
+# -- the approval cap has to hold on every channel a verdict can leave by ------
+
+
+class _CoverageRun:
+    """Minimal run exposing the surface the cap paths read."""
+
+    def __init__(self, *, verdicts=None, clean=(), issues=()) -> None:
+        from lionagi.engines.review import DimensionClean, IssueFound, ReviewVerdict
+
+        self._by_type = {
+            ReviewVerdict: list(verdicts or []),
+            DimensionClean: [DimensionClean(dimension=d) for d in clean],
+            IssueFound: list(issues),
+        }
+        self.notices: list[tuple[str, dict]] = []
+        self.agents_made = 3
+
+    def by_type(self, event_type):
+        return self._by_type.get(event_type, [])
+
+    def notify(self, kind: str, **data) -> None:
+        self.notices.append((kind, data))
+
+    async def make_agent(self, role: str, **kwargs):
+        class _Approve:
+            async def operate(self, instruction: str):
+                return "DECISION: APPROVE"
+
+        return _Approve()
+
+
+async def test_a_dimension_that_emitted_nothing_cannot_be_approved_over() -> None:
+    """A reviewer that exhausts its emission repairs raises nothing.
+
+    So it never reaches the isolated-failure recorder and the failed list stays
+    empty. If coverage is read from that list alone, a dimension that produced
+    no output at all is indistinguishable from one that came back clean, and
+    the run approves over it.
+    """
+    engine = ReviewEngine()
+    run = _CoverageRun(clean=("correctness",))
+
+    result = await engine._verdict(run, "artifact.py", ("correctness", "security"), [])
+
+    assert result.startswith("DECISION: REQUEST-CHANGES")
+    assert "security dimension did not run (no evidence emitted)" in result
+    # The dimension that actually reported is not accused of silence.
+    assert "correctness dimension did not run" not in result
+
+
+async def test_partial_export_does_not_hand_back_an_approval_over_missing_coverage() -> None:
+    """Exhaustion is the one exit that never reaches _verdict.
+
+    A run cut short by its deadline is also the likeliest to be missing a
+    dimension, so this is the worst channel to let a stored approval out of.
+    """
+    from lionagi.engines.review import ReviewVerdict
+
+    verdict = ReviewVerdict(verdict="APPROVE", rationale="nothing came up", blocking=[])
+    engine = ReviewEngine()
+    run = _CoverageRun(verdicts=[verdict], clean=("correctness",))
+
+    out = await engine._partial_export(run, "artifact.py", dimensions=("correctness", "security"))
+
+    assert "REQUEST-CHANGES" in out
+    assert not any(line.startswith("DECISION: APPROVE") for line in out.splitlines())
+    # The stored verdict is rewritten too, not just the text built from it.
+    assert verdict.verdict == "REQUEST-CHANGES"
+    assert any("security" in b for b in verdict.blocking)
+
+
+async def test_a_verdict_is_capped_when_it_arrives_not_after_synthesis_returns() -> None:
+    """Persistence and subscribers read the verdict from the run's flow.
+
+    Rewriting it after synthesis returns leaves an approval already delivered
+    to whoever was listening, so the cap runs on arrival.
+    """
+    from lionagi.engines.review import ReviewVerdict
+
+    observers: dict[type, list] = {}
+
+    class _ObservingRun(_CoverageRun):
+        root = ""
+        _sem = asyncio.Semaphore(1)
+
+        def observe(self, event_type, handler):
+            observers.setdefault(event_type, []).append(handler)
+
+        async def wait_quiescence(self):
+            return None
+
+        async def cancel_active(self):
+            return None
+
+        async def operate_with_repair(self, agent, instruction, **kwargs):
+            return ""
+
+    engine = ReviewEngine(verify_clean=False)
+    run = _ObservingRun(clean=("correctness",))
+    await engine._run(run, "artifact.py", dimensions=("correctness", "security"))
+
+    assert ReviewVerdict in observers, "no verdict observer registered, so nothing caps on arrival"
+    arriving = ReviewVerdict(verdict="APPROVE", rationale="looks clean", blocking=[])
+    for handler in observers[ReviewVerdict]:
+        handler(arriving, None)
+
+    assert arriving.verdict == "REQUEST-CHANGES", (
+        "the verdict object handed to subscribers still says APPROVE while a "
+        "dimension produced no evidence"
+    )
+    assert any("security" in b for b in arriving.blocking)

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -77,8 +77,9 @@ class _PartiallyFailingReview(ReviewEngine):
         await asyncio.sleep(0.05)
         self.healthy_finished.set()
 
-    async def _verdict(self, run, artifact: str, dimensions: tuple[str, ...]) -> str:
+    async def _verdict(self, run, artifact: str, dimensions: tuple[str, ...], failed=None) -> str:
         assert self.healthy_finished.is_set()
+        self.failed_seen = list(failed or [])
         return "healthy dimension survived"
 
 
@@ -117,8 +118,9 @@ class _TransportFailingReview(ReviewEngine):
         await asyncio.sleep(0.05)
         self.healthy_finished.set()
 
-    async def _verdict(self, run, artifact: str, dimensions: tuple[str, ...]) -> str:
+    async def _verdict(self, run, artifact: str, dimensions: tuple[str, ...], failed=None) -> str:
         assert self.healthy_finished.is_set()
+        self.failed_seen = list(failed or [])
         return "healthy dimension survived"
 
 
@@ -135,6 +137,9 @@ def _mcp_error(message: str) -> BaseException:
     [
         (lambda: anyio.ClosedResourceError(), "ClosedResourceError"),
         (lambda: anyio.BrokenResourceError(), "BrokenResourceError"),
+        # The MCP SDK reads replies with `await response_stream_reader.receive()`,
+        # which raises EndOfStream (not ClosedResourceError) once the peer closes.
+        (lambda: anyio.EndOfStream(), "EndOfStream"),
         (
             lambda: ExceptionGroup(
                 "unhandled errors in a TaskGroup",
@@ -205,3 +210,97 @@ def test_isolation_predicate_refuses_a_group_carrying_a_non_transport_leaf() -> 
         [ExceptionGroup("inner", [anyio.ClosedResourceError(), EngineBudgetError("exhausted")])],
     )
     assert _is_all_isolated_failure(nested_mixed) is False
+
+
+def test_verdict_prompt_refuses_to_present_a_dead_dimension_as_reviewed() -> None:
+    """A dimension whose reviewer died must not be listed as reviewed.
+
+    Isolating a transport failure keeps the run alive, but a dead reviewer
+    emits no issues, and an unqualified "Dimensions reviewed: ... security ..."
+    tells synthesis that security WAS reviewed and found nothing. That is a
+    fail-open review gate: the strongest evidence for approval becomes the
+    silence of a dimension that never executed.
+    """
+    from lionagi.engines.review import _verdict_instruction
+
+    prompt = _verdict_instruction(
+        "artifact",
+        ("correctness", "security"),
+        issues=[],
+        verifications=[],
+        clean=["correctness"],
+        failed=[("security", "McpError")],
+    )
+
+    reviewed_line = next(
+        line for line in prompt.splitlines() if line.startswith("Dimensions reviewed:")
+    )
+    assert "security" not in reviewed_line
+    assert "correctness" in reviewed_line
+
+    assert "DID NOT RUN: security (McpError)" in prompt
+    assert "not evidence" in prompt
+    # The instruction must actively steer away from approving on absent
+    # coverage, not merely mention that something failed.
+    assert "Do not issue APPROVE" in prompt
+
+
+def test_verdict_prompt_is_unchanged_when_every_dimension_ran() -> None:
+    """The all-healthy prompt keeps its previous shape: no empty warning block."""
+    from lionagi.engines.review import _verdict_instruction
+
+    prompt = _verdict_instruction(
+        "artifact",
+        ("correctness", "security"),
+        issues=[],
+        verifications=[],
+        clean=["correctness", "security"],
+    )
+
+    assert "Dimensions reviewed: correctness, security" in prompt
+    assert "DID NOT RUN" not in prompt
+
+
+def test_a_broken_mcp_install_is_not_silently_treated_as_absent(monkeypatch) -> None:
+    """An mcp that fails to import must raise, not disable isolation quietly.
+
+    Reporting a broken install as "extra not present" would silently drop
+    McpError out of the isolated set, and the first symptom would be a run
+    dying with no verdict, far from the cause.
+    """
+    import builtins
+
+    from lionagi.engines import review as review_mod
+
+    review_mod._mcp_error_type.cache_clear()
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mcp.shared.exceptions":
+            # mcp itself is importable; one of ITS dependencies is missing.
+            raise ModuleNotFoundError("No module named 'pydantic_core'", name="pydantic_core")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ModuleNotFoundError):
+        review_mod._mcp_error_type()
+    review_mod._mcp_error_type.cache_clear()
+
+
+def test_a_missing_mcp_extra_is_a_normal_configuration(monkeypatch) -> None:
+    """The other arm: mcp genuinely absent yields None rather than raising."""
+    import builtins
+
+    from lionagi.engines import review as review_mod
+
+    review_mod._mcp_error_type.cache_clear()
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mcp.shared.exceptions":
+            raise ModuleNotFoundError("No module named 'mcp'", name="mcp")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert review_mod._mcp_error_type() is None
+    review_mod._mcp_error_type.cache_clear()

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -212,6 +212,67 @@ def test_isolation_predicate_refuses_a_group_carrying_a_non_transport_leaf() -> 
     assert _is_all_isolated_failure(nested_mixed) is False
 
 
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="mcp is an optional extra")
+def test_application_mcp_errors_are_not_isolated_as_transport_failures() -> None:
+    """Only connection-shaped McpErrors are per-dimension transport failures.
+
+    The SDK spells just two conditions as McpError itself: connection closed
+    and request timeout. Every other McpError relays a server-side error —
+    an authorization refusal, an application failure — which describes the
+    request, not the wire. Swallowing those as transport drops turns e.g. a
+    permission denial into a silent one-dimension degrade.
+    """
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    from lionagi.engines.review import _is_all_isolated_failure
+
+    connection_closed = McpError(ErrorData(code=-32000, message="Connection closed"))
+    assert _is_all_isolated_failure(connection_closed) is True
+
+    permission_denied = McpError(ErrorData(code=-32603, message="permission denied"))
+    assert _is_all_isolated_failure(permission_denied) is False
+
+    mixed = ExceptionGroup(
+        "unhandled errors in a TaskGroup", [connection_closed, permission_denied]
+    )
+    assert _is_all_isolated_failure(mixed) is False
+
+
+def test_an_approve_emitted_over_a_dead_dimension_is_structurally_capped() -> None:
+    """The prompt tells synthesis not to approve on missing coverage; the
+    engine must not depend on it complying. If a dimension never ran and the
+    synthesis model emits APPROVE anyway, the verdict event is rewritten to
+    REQUEST-CHANGES with the dead dimensions as blocking entries — approval
+    on absent coverage must be unrepresentable, not merely discouraged."""
+    from lionagi.engines.review import ReviewVerdict, _cap_approvals_on_missing_coverage
+
+    approve = ReviewVerdict(verdict="APPROVE", rationale="looks clean", blocking=[])
+    with_fixes = ReviewVerdict(verdict="approve-with-fixes", rationale="minor nits", blocking=[])
+    already_blocking = ReviewVerdict(
+        verdict="REQUEST-CHANGES", rationale="real issue", blocking=["x"]
+    )
+    failed = [("security", "McpError"), ("performance", "EndOfStream")]
+
+    capped = _cap_approvals_on_missing_coverage([approve, with_fixes, already_blocking], failed)
+
+    assert capped is True
+    # Both APPROVE-family verdicts are rewritten, case-insensitively.
+    for verdict in (approve, with_fixes):
+        assert verdict.verdict == "REQUEST-CHANGES"
+        assert "security dimension did not run (McpError)" in verdict.blocking
+        assert "performance dimension did not run (EndOfStream)" in verdict.blocking
+        assert "cannot be issued" in verdict.rationale
+    # A verdict that already refuses approval is left alone.
+    assert already_blocking.rationale == "real issue"
+    assert already_blocking.blocking == ["x"]
+
+    # No dead dimensions -> nothing to cap; an APPROVE stands.
+    clean_approve = ReviewVerdict(verdict="APPROVE", rationale="fine", blocking=[])
+    assert _cap_approvals_on_missing_coverage([clean_approve], []) is False
+    assert clean_approve.verdict == "APPROVE"
+
+
 def test_verdict_prompt_refuses_to_present_a_dead_dimension_as_reviewed() -> None:
     """A dimension whose reviewer died must not be listed as reviewed.
 
@@ -282,6 +343,21 @@ def test_a_broken_mcp_install_is_not_silently_treated_as_absent(monkeypatch) -> 
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ModuleNotFoundError):
+        review_mod._mcp_error_type()
+    review_mod._mcp_error_type.cache_clear()
+
+    # The subtler arm: the top-level package resolved but the submodule itself
+    # is missing. exc.name is then "mcp.shared.exceptions", which a prefix
+    # check reads as "mcp is absent" — it is not, the install is broken.
+    def fake_import_submodule(name, *args, **kwargs):
+        if name == "mcp.shared.exceptions":
+            raise ModuleNotFoundError(
+                "No module named 'mcp.shared.exceptions'", name="mcp.shared.exceptions"
+            )
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import_submodule)
     with pytest.raises(ModuleNotFoundError):
         review_mod._mcp_error_type()
     review_mod._mcp_error_type.cache_clear()

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -273,6 +273,64 @@ def test_an_approve_emitted_over_a_dead_dimension_is_structurally_capped() -> No
     assert clean_approve.verdict == "APPROVE"
 
 
+def test_the_returned_verdict_text_is_capped_even_with_no_verdict_to_rewrite() -> None:
+    """Rewriting emitted verdicts reaches nothing when synthesis emits none.
+
+    The returned string is then the entire verdict the caller sees, so it
+    carries the same refusal; the synthesis output survives as quoted context
+    where its own decision line cannot be read as the run's decision.
+    """
+    from lionagi.engines.review import _cap_verdict_text
+
+    failed = [("security", "McpError")]
+    capped = _cap_verdict_text("DECISION: APPROVE\nAll dimensions look clean.", failed)
+
+    assert capped.startswith("DECISION: REQUEST-CHANGES\n")
+    assert "- security dimension did not run (McpError)" in capped
+    # The synthesis decision line survives only as quoted context.
+    assert "> DECISION: APPROVE" in capped
+    assert not any(line.startswith("DECISION: APPROVE") for line in capped.splitlines())
+
+    # Nothing failed -> the synthesis text is returned untouched.
+    assert _cap_verdict_text("DECISION: APPROVE", []) == "DECISION: APPROVE"
+
+
+async def test_a_raw_approve_with_no_emitted_verdict_does_not_yield_approval() -> None:
+    """End-to-end on _verdict: synthesis emits no ReviewVerdict and returns a
+    bare approval. The event cap has nothing to rewrite, so the refusal has to
+    come from the returned text or the run approves on a dimension that never
+    executed."""
+
+    class _RawApproveAgent:
+        async def operate(self, instruction: str):
+            return "DECISION: APPROVE"
+
+    class _RunWithNoVerdictEmitted:
+        def __init__(self) -> None:
+            self.notices: list[tuple[str, dict]] = []
+
+        def by_type(self, event_type):
+            return []
+
+        def notify(self, kind: str, **data) -> None:
+            self.notices.append((kind, data))
+
+        async def make_agent(self, role: str, **kwargs):
+            return _RawApproveAgent()
+
+    engine = ReviewEngine()
+    run = _RunWithNoVerdictEmitted()
+
+    result = await engine._verdict(
+        run, "artifact.py", ("correctness", "security"), [("security", "McpError")]
+    )
+
+    assert not result.startswith("DECISION: APPROVE")
+    assert result.startswith("DECISION: REQUEST-CHANGES")
+    assert "security dimension did not run (McpError)" in result
+    assert any(kind == "verdict_capped" for kind, _ in run.notices)
+
+
 def test_verdict_prompt_refuses_to_present_a_dead_dimension_as_reviewed() -> None:
     """A dimension whose reviewer died must not be listed as reviewed.
 

--- a/tests/engines/test_engine_result_degradation.py
+++ b/tests/engines/test_engine_result_degradation.py
@@ -15,7 +15,7 @@ from lionagi.engines.engine import Engine, EngineBudgetError, EngineResult, Engi
 from lionagi.engines.hypothesis import HypothesisEngine
 from lionagi.engines.planning import PlanningEngine
 from lionagi.engines.research import FindingEmitted, ResearchEngine
-from lionagi.engines.review import IssueFound, ReviewEngine, ReviewVerdict
+from lionagi.engines.review import DimensionClean, IssueFound, ReviewEngine, ReviewVerdict
 from lionagi.ln import gather as ln_gather
 from lionagi.ln.concurrency._compat import (
     ExceptionGroup,
@@ -163,11 +163,19 @@ async def test_review_verdict_emitted_on_exhaustion_not_dropped(monkeypatch):
     )
 
     class _FastReviewBranch:
-        def __init__(self, dimension: str):
+        def __init__(self, dimension: str, run: Any) -> None:
             self.name = f"review-{dimension}"
+            self._dimension = dimension.removeprefix("review-")
+            self._run = run
 
         async def operate(self, *, instruction: str) -> str:
-            return ""  # no issues found — keeps the repro focused on the verdict stage
+            # No issues found, said as an affirmative clean rather than as
+            # silence. A dimension that emits nothing has not reviewed anything
+            # as far as the engine can tell, and the run would refuse to reach
+            # the verdict stage at all — which would move this test off its own
+            # subject, the verdict already captured before the deadline.
+            await self._run.emit(DimensionClean(dimension=self._dimension))
+            return ""
 
     class _SlowSynthBranch:
         name = "verdict"
@@ -192,7 +200,7 @@ async def test_review_verdict_emitted_on_exhaustion_not_dropped(monkeypatch):
     async def fake_make_agent(role: str, *, name: str | None = None, exempt: bool = False, **kw):
         if name == "verdict":
             return _SlowSynthBranch(run)
-        return _FastReviewBranch(name or role)
+        return _FastReviewBranch(name or role, run)
 
     monkeypatch.setattr(run, "make_agent", fake_make_agent)
     monkeypatch.setattr(eng, "new_run", lambda **kw: run)


### PR DESCRIPTION
## Problem

A review dimension whose worker lost its transport took the whole run down with it.

`ReviewEngine._review_dimension_isolated` isolated only `ProviderError`. A dropped MCP connection raises the MCP SDK's `McpError`, which derives from `Exception` rather than from `ProviderError`, and a dropped stream raises anyio's `ClosedResourceError` / `BrokenResourceError`. None of those are reachable by a `ProviderError`-only `except` clause, so they propagated to the run-level handler that cancels every sibling.

The result was the exact outcome the isolation was added to prevent: one dead dimension became a cancelled run emitting no verdict at all, discarding the evidence from dimensions that had already finished cleanly.

## Two independent gaps in the isolation

1. **Wrong class.** The `except` clause named a class that transport failures do not derive from, so they were never isolated in the first place.
2. **Grouped errors.** When several dimensions lost their transport at once the errors arrived as an `ExceptionGroup`, and a plain `except` cannot catch a group even when every leaf would have matched it individually.

Isolation now requires **every** leaf to be a provider or transport failure, recursing into nested groups. This mirrors the `_is_all_budget_error` handling that already exists in `engine.py` rather than introducing a new shape.

A group mixing a transport drop with budget exhaustion still propagates. Swallowing it would launder a run-wide stop into a per-dimension degrade and hide it behind a verdict that reads as reasoned.

The `mcp` import is guarded, since `mcp` is an optional extra. A missing `mcp` is a normal configuration; an `mcp` that is present but fails to import raises, so a broken install cannot masquerade as an uninstalled extra and silently disable the isolation.

Failure events and the `skipped` list name the leaf cause instead of `ExceptionGroup`, so a degraded run says what actually broke.

## Why this change has to carry a coverage guarantee

Isolating a per-dimension failure is exactly what removes the abort that was implicitly guaranteeing coverage. Before, a dead dimension killed the run, so no verdict could ever be issued over one. After, the run survives and reaches synthesis with a dimension that produced nothing, and a dimension that produced nothing is indistinguishable from one that came back clean. Without a coverage guarantee this change converts a loud failure into a silent approval over unreviewed code.

So the guarantee is a required consequence of the isolation, not adjacent work.

### The verdict capability is withheld, not withdrawn

A run that is missing a dimension does not get an agent capable of issuing a verdict. No `ReviewVerdict` emission grant is created, so no approval is ever constructed, dispatched, or observed, and the engine authors the `REQUEST-CHANGES` itself.

The alternative, letting synthesis emit whatever it likes and rewriting an approval afterwards, cannot be made airtight. The session bus gathers handlers concurrently, so a subscriber registered before the run already holds the approval by the time any rewrite runs. It also has to be repeated at every exit from the run, and each repetition is a place to forget one.

The withheld path costs no model call, and it still reports the issues the surviving dimensions found, rendered directly rather than summarised by an agent.

### Coverage is this run's evidence, not the session's

`EngineRun.by_type` reads the session-accumulated flow, and a session outlives a run: `EngineRun` takes a caller-supplied `Session` and `Engine.run` passes one through. On a reused session a previous run's issues and verdicts are indistinguishable from this run's, so a dimension that emitted nothing this run passed as covered because it emitted something last run.

The run now records what the flow already held when it started, and everything after that mark is its own. That also fixes budget-exhaustion export, which could otherwise hand back a previous run's verdict as the result for an artifact this run never finished reviewing.

Scoping is by exclusion at read time rather than by accumulating from a subscription. A subscription only ever sees what was emitted after it, so a stage reached without one reported every dimension missing while the same artifact listed the issues those dimensions had found.

## Tests

`tests/engines/` passes in full (320 tests).

Transport isolation is parametrized over `ClosedResourceError`, `BrokenResourceError`, a group of transport errors, and `McpError`. Each asserts the sibling dimension still finishes and the run still reaches a verdict. A separate test pins the predicate directly: an all-transport group isolates, while both a mixed group and a nested mixed group must propagate.

Coverage is asserted at the grant rather than at the outcome, since an approval that is never constructed cannot leak through any channel. The complementary arm asserts that a fully covered run still grants synthesis the capability and returns its output untouched, so the refusal cannot pass by firing on every run.

Verified by mutation, with the expected reddened arms written down before running and reconciled arm by arm after:

- reverting the `except` clause to `ProviderError` reddens exactly the four transport cases and leaves the predicate test green
- granting the verdict capability unconditionally reddens the five coverage tests and leaves the complementary arm and both export tests green
- making the run boundary unrecorded reddens only the session-reuse tests
- reading stored verdicts from the session flow again reddens only the export test

Closes #3188
