### PR TITLE
feat(engines): let an engine declare the MCP config its agents resolve

### DIFF
--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -383,6 +383,7 @@ class EngineRun:
         secure: bool = True,
         exempt: bool = False,
         mcp_servers: list[str] | None = None,
+        mcp_config_path: str | None = None,
         extra_prompt: str | None = None,
         khive_injection: Any = None,
     ) -> Branch:
@@ -398,6 +399,8 @@ class EngineRun:
             cwd = self.engine.agent_cwd
         if extra_prompt is None:
             extra_prompt = self.engine.agent_extra_prompt
+        if mcp_config_path is None:
+            mcp_config_path = self.engine.agent_mcp_config_path
         # Resolution order: explicit call > engine-wide > role profile. An
         # effort suffix baked into the model spec outranks prof_effort too.
         prof_model, prof_effort = role_profile_route(role)
@@ -437,6 +440,8 @@ class EngineRun:
         )
         if mcp_servers is not None:
             spec.mcp_servers = mcp_servers
+        if mcp_config_path is not None:
+            spec.mcp_config_path = mcp_config_path
         if secure and tools:
             from lionagi.agent.spec import _wire_secure_guards
 
@@ -758,6 +763,7 @@ class Engine:
         cancel_timeout_s: float = 30.0,
         agent_cwd: str | None = None,
         agent_extra_prompt: str | None = None,
+        agent_mcp_config_path: str | None = None,
         khive_injection: Any = None,
         yolo: bool = False,
     ) -> None:
@@ -766,6 +772,15 @@ class Engine:
         # make_agent(cwd=..., extra_prompt=...) still wins.
         self.agent_cwd = agent_cwd
         self.agent_extra_prompt = agent_extra_prompt
+        # Which .mcp.json this engine's agents resolve. Left unset, every agent
+        # falls through to the user-level ~/.lionagi/.mcp.json, which is a
+        # machine-global file other tools write: a run then depends on a config
+        # it never named and cannot see change underneath it, and an unrelated
+        # write to that file breaks every engine on the machine at once. Naming
+        # it also makes a bad path fail loudly at resolution instead of silently
+        # falling back to the global one. Per-call
+        # make_agent(mcp_config_path=...) still wins.
+        self.agent_mcp_config_path = agent_mcp_config_path
         # Auto-approve tool permission requests for every agent this engine
         # spawns, applied per provider from the same table the CLI and profile
         # paths use. Default False: auto-approving tool execution is not

--- a/lionagi/engines/planning.py
+++ b/lionagi/engines/planning.py
@@ -72,7 +72,7 @@ class PlanningEngine(Engine):
         # assignment on a clone. Every assignee role may grow the live DAG when reactive.
         assignees = {ta.assignee for ta in assignments}
         spawners = tuple(assignees) if self.reactive else ()
-        roles = await spawn_roles(run.session, {a: a for a in assignees}, spawners=spawners)
+        roles = await spawn_roles(run.session, self._worker_specs(assignees), spawners=spawners)
 
         graph, node_ids = build_dag_graph(run.session, assignments, roles)
         run.notify("executing", assignments=len(assignments))
@@ -87,6 +87,25 @@ class PlanningEngine(Engine):
         return await self._synthesize(run, prompt, assignments, node_ids, result)
 
     # -- stages ---------------------------------------------------------------
+
+    def _worker_specs(self, assignees: set[str]) -> dict[str, Any]:
+        """Compose one worker spec per assignee, carrying the engine-wide MCP config.
+
+        Workers are spawned through ``spawn_roles`` rather than ``make_agent``,
+        so nothing on that path reads the engine's agent settings. Passing bare
+        role strings therefore had every worker resolve ambient MCP
+        configuration, silently exempting the fan-out from the config the
+        engine declared for its agents.
+        """
+        from lionagi.agent import AgentSpec  # noqa: PLC0415
+
+        specs: dict[str, Any] = {}
+        for assignee in assignees:
+            spec = AgentSpec.compose(assignee)
+            if self.agent_mcp_config_path is not None:
+                spec.mcp_config_path = self.agent_mcp_config_path
+            specs[assignee] = spec
+        return specs
 
     async def _plan(self, run: EngineRun, prompt: str, max_ops: int) -> list:
         """Decompose *prompt* into TaskAssignment list; retries once with explicit guidance, then raises PlanError."""

--- a/tests/engines/test_engine.py
+++ b/tests/engines/test_engine.py
@@ -458,3 +458,34 @@ async def test_unset_mcp_config_path_leaves_resolution_untouched(monkeypatch, tm
     await run.make_agent("researcher", name="r1")
 
     assert specs[-1].mcp_config_path is None
+
+
+def test_planning_worker_specs_carry_the_engine_wide_mcp_config(tmp_path):
+    """Planning workers must not be exempt from the config the engine declared.
+
+    They are spawned through the role-spawning helper rather than make_agent,
+    so nothing on that path reads engine-wide agent settings: bare role
+    strings had every worker resolve ambient MCP configuration while the
+    engine's own orchestrator and synthesizer honoured the declared file —
+    the feature working on the paths that were tested and silently not on
+    the fan-out.
+    """
+    from lionagi.agent import AgentSpec
+    from lionagi.engines.planning import PlanningEngine
+
+    declared = _mcp_file(tmp_path, "declared.mcp.json")
+    engine = PlanningEngine(agent_mcp_config_path=declared)
+
+    specs = engine._worker_specs({"researcher", "analyst"})
+
+    assert set(specs) == {"researcher", "analyst"}
+    for spec in specs.values():
+        # Composed specs, not bare strings: the spawning helper applies its
+        # own compose to strings, which cannot see the engine's setting.
+        assert isinstance(spec, AgentSpec)
+        assert spec.mcp_config_path == declared
+
+    # Unset engine-wide config keeps the workers on ambient resolution,
+    # exactly as bare role strings behaved.
+    for spec in PlanningEngine()._worker_specs({"researcher"}).values():
+        assert spec.mcp_config_path is None

--- a/tests/engines/test_engine.py
+++ b/tests/engines/test_engine.py
@@ -380,3 +380,81 @@ async def test_successful_tasks_do_not_raise():
     run.spawn(work("b"))
     await run.wait_quiescence()
     assert sorted(results) == ["a", "b"]
+
+
+def _capture_specs(monkeypatch):
+    """Record every AgentSpec create_agent receives, without changing what it does."""
+    from lionagi.engines import engine as engine_mod
+
+    specs = []
+    real = engine_mod.create_agent
+
+    async def spy(spec, **kwargs):
+        specs.append(spec)
+        return await real(spec, **kwargs)
+
+    monkeypatch.setattr(engine_mod, "create_agent", spy)
+    return specs
+
+
+def _mcp_file(tmp_path, name):
+    path = tmp_path / name
+    path.write_text('{"mcpServers": {}}', encoding="utf-8")
+    return str(path)
+
+
+@pytest.mark.asyncio
+async def test_engine_wide_mcp_config_path_reaches_the_agent_spec(monkeypatch, tmp_path):
+    """An engine can name the .mcp.json its agents resolve.
+
+    Without this the spec field is left unset and every agent falls through to
+    the user-level ~/.lionagi/.mcp.json — a machine-global file other tools
+    write, so a run depends on a config it never named and an unrelated write
+    to that file breaks every engine on the machine at once.
+    """
+    specs = _capture_specs(monkeypatch)
+    declared = _mcp_file(tmp_path, "declared.mcp.json")
+
+    run = Engine(agent_mcp_config_path=declared).new_run()
+    await run.make_agent("researcher", name="r1")
+
+    assert specs[-1].mcp_config_path == declared
+
+
+@pytest.mark.asyncio
+async def test_per_call_mcp_config_path_outranks_the_engine_wide_default(monkeypatch, tmp_path):
+    """Same precedence as cwd and extra_prompt: explicit call beats engine-wide."""
+    specs = _capture_specs(monkeypatch)
+    engine_wide = _mcp_file(tmp_path, "engine.mcp.json")
+    per_call = _mcp_file(tmp_path, "percall.mcp.json")
+
+    run = Engine(agent_mcp_config_path=engine_wide).new_run()
+    await run.make_agent("researcher", name="r1", mcp_config_path=per_call)
+    await run.make_agent("researcher", name="r2")
+
+    assert specs[-2].mcp_config_path == per_call
+    assert specs[-1].mcp_config_path == engine_wide
+
+
+@pytest.mark.asyncio
+async def test_unset_mcp_config_path_leaves_resolution_untouched(monkeypatch, tmp_path):
+    """Default must not change behaviour for the existing make_agent callers.
+
+    Leaving the field None is what preserves the current discovery order;
+    writing a value in by default here would silently repoint every existing
+    engine at a different config.
+
+    HOME is redirected at a scratch dir on purpose. Unset is exactly the case
+    that falls through to the user-level ~/.lionagi/.mcp.json, so without this
+    the assertion below would load whatever MCP servers the developer happens
+    to have configured, and the outcome would differ between a laptop and CI.
+    That machine dependence is the thing this feature exists to remove, so a
+    test for it must not itself rely on the ambient file.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    specs = _capture_specs(monkeypatch)
+
+    run = Engine().new_run()
+    await run.make_agent("researcher", name="r1")
+
+    assert specs[-1].mcp_config_path is None


### PR DESCRIPTION
## Problem

An engine had no way to say which `.mcp.json` its agents resolve.

`EngineRun.make_agent` composes an `AgentSpec` but never sets `spec.mcp_config_path`, and calls `create_agent(spec, load_settings=False)` without `trust_project_settings`. In `_resolve_mcp_path` (`lionagi/agent/factory.py`) that combination skips both earlier branches — the explicit path and the cwd/parents walk — and lands on the last candidate every time:

```python
candidates.append(Path.home() / ".lionagi" / ".mcp.json")
```

So every agent an engine spawns inherits a **machine-global** file that other tools write.

Three consequences, in order of how hard they are to see:

1. A run depends on a config it never named and cannot observe changing underneath it.
2. Every engine on the machine shares that config, so one unrelated write to it breaks all of them at once.
3. The break surfaces as an MCP transport error at connection time, not as a configuration problem, so the symptom points away from the cause.

## Change

- `Engine(agent_mcp_config_path=...)` — run-wide default for every agent the engine spawns
- `make_agent(mcp_config_path=...)` — per-call override

Precedence is *explicit call > engine-wide*, matching what `cwd` and `agent_extra_prompt` already do, and the field is applied next to the existing `mcp_servers` assignment.

Naming a config also means a wrong path fails loudly at resolution (`_resolve_mcp_path` already raises `ConfigurationError` for a path that does not resolve) instead of silently falling back to the global file. The silent fallback is what made the original problem hard to diagnose.

Placed on `Engine` rather than on `ReviewEngine`, because every engine kind spawns agents through the same `make_agent` and has the same gap; a review-only knob would leave research, coding, hypothesis and planning inheriting the global file.

## Compatibility

Left unset the field stays `None`, so `_resolve_mcp_path` behaves exactly as before and no existing caller moves. A test pins that specifically.

## How visible this already is

On a developer machine that has a `~/.lionagi/.mcp.json` naming a server whose optional extra is not installed, **every one of the 27 failures in `tests/engines/` is that server failing to register** — 27 failures, 27 `Failed to register server` lines. The suite inherits a config no test asked for. CI has no such file, so it passes there and the dependence stays invisible until it bites.

Verified like-for-like: the failure set on this branch and on unmodified `main` are identical, 27 and 27, with an empty set difference. This change introduces none of them and fixes none of them; it makes them fixable, since a caller can now name a config.

## Tests

`tests/engines/test_engine.py`:

- engine-wide `agent_mcp_config_path` reaches the composed spec
- per-call `mcp_config_path` outranks the engine-wide default, and a sibling call without it still gets the default
- unset leaves `spec.mcp_config_path` as `None`

The unset test redirects `HOME` at a scratch directory on purpose: unset is precisely the case that falls through to the user-level file, so without that the assertion would read whatever the developer happens to have configured and would differ between a laptop and CI. Machine dependence is the thing this change exists to remove, so a test for it must not rely on the ambient file.

Verified by mutation rather than by passing: neutralising the assignment reddens the two tests that assert the value arrives and leaves the unset test green, which is the expected split since that test asserts the pre-change behaviour.