### PR TITLE
fix(mcp): bound the notify hook's delivery by the deadline that kills it

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -757,10 +757,12 @@ variables `LIONAGI_MCP_NOTIFY_COMMAND` and `LIONAGI_MCP_NOTIFY_TARGET` set a
 process-wide default. Delivery outcome is recorded on the job and surfaced in
 `job.status` (`notify_delivery`), so a notice that failed to send is visible
 rather than silently lost. `job.list` carries the same outcome collapsed to one
-word in `notify_delivery_state` — `delivered`, `failed`, `unknown` when an
-attempt's final result was interrupted, or `none` when no notifier was
-configured — so a run whose notice never went out is spotted while scanning
-runs, not only when one is looked up. The full `job.status.notify_delivery`
+word in `notify_delivery_state` — `delivered`, `delivered_unverified` when it
+exited zero but that command shape's zero exit doesn't prove a send, `failed`
+when the notifier reported its own failure, `unknown` when an attempt's final
+result was interrupted or it was stopped for running past its deadline, or
+`none` when no notifier was configured — so a run whose notice never went out
+is spotted while scanning runs, not only when one is looked up. The full `job.status.notify_delivery`
 object is null only for a non-terminal run.
 
 ---

--- a/docs/internals/mcp.md
+++ b/docs/internals/mcp.md
@@ -323,8 +323,12 @@ not-terminal-yet and no-notifier-configured — silence is the documented
 default there, never a failure — and `delivered_unverified` is deliberately
 not collapsed into either neighbor (a zero exit from a command shape whose
 zero exit doesn't prove a send supports neither claim). `unknown` means the
-attempt began but the process ended before its final result could replace the
-write-ahead record; inspect or reconcile it rather than treating it as success.
+attempt began but its final result never replaced the write-ahead record —
+either the process ended first, or the delivery was stopped part-way for
+running past its deadline. A stopped delivery is not `failed`: a notifier can
+send the notice and then hang, and `failed` reads as an instruction to send it
+again. Inspect or reconcile an `unknown` rather than treating it as either
+success or a clean non-delivery.
 
 #### signal-leader-group-safety
 

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import signal
 import subprocess
 import time
 from typing import Any
@@ -44,6 +45,8 @@ _STARTED_AT = time.monotonic()
 _STARTUP_ALLOWANCE_S = 1.0
 # Locking the record, writing the outcome, appending the console note.
 _RECORDING_RESERVE_S = 2.0
+# Collecting a killed delivery, bounded so it cannot spend the reserve above.
+_REAP_TIMEOUT_S = 0.5
 
 
 def _supervised_delivery_timeout() -> float:
@@ -135,6 +138,65 @@ def _classify_failure(text: str) -> str:
         if any(needle in lowered for needle in needles):
             return name
     return _FAILURE_UNKNOWN
+
+
+def _delivery_failure(exc: BaseException, program: str | None) -> dict[str, Any]:
+    """The outcome record for a delivery that raised instead of returning.
+
+    Only the exception *type* is kept — ``TimeoutExpired`` carries the child's
+    captured output on ``.stdout``/``.stderr``, so ``str(exc)`` would leak
+    exactly the free text this module exists to keep out of the record.
+    """
+    timed_out = isinstance(exc, subprocess.TimeoutExpired)
+    outcome = {
+        "attempted": True,
+        "ok": False,
+        "exit_code": None,
+        "error": type(exc).__name__,
+        "failure_class": _pin_failure_class(_FAILURE_TIMEOUT if timed_out else _FAILURE_UNKNOWN),
+        "command": program,
+    }
+    if timed_out:
+        # Started, then stopped part-way. A nonzero exit is the command's own
+        # report that it failed; a timeout is not, because a notifier can send
+        # the notice and then hang. So this is marked unconfirmed rather than
+        # failed, through the same field a zero-exit-but-unverifiable delivery
+        # uses. ``ok`` stays False because success was never observed, and it
+        # cannot become None: that is the write-ahead value, and it means no
+        # outcome was ever recorded at all.
+        outcome["delivery_verified"] = False
+        outcome["unverified_reason"] = "delivery_timed_out"
+    return outcome
+
+
+def _kill_delivery_group(proc: subprocess.Popen) -> None:
+    """Take down the delivery's whole process group, then reap it.
+
+    The delivery leads its own group (``start_new_session``), so its pid is the
+    group id. Falling back to the single process is not equivalent — it leaves
+    the descendants this exists to collect — but it is what is available where
+    process groups are not, and it still collects the common case of a notifier
+    that forks nothing.
+
+    The reap is bounded because this runs inside the window reserved for
+    writing the outcome down: a fallback kill can leave a descendant holding
+    the pipe open, and waiting on it indefinitely would spend the reserve and
+    lose the record, which is the failure this whole path exists to prevent.
+    """
+    killpg = getattr(os, "killpg", None)
+    try:
+        if killpg is not None:
+            killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
+    except (ProcessLookupError, PermissionError, OSError):
+        # Already gone, or not ours to signal. Either way there is nothing
+        # further this can do about it, and the outcome is recorded regardless.
+        pass
+    try:
+        proc.communicate(timeout=_REAP_TIMEOUT_S)
+    except (OSError, subprocess.SubprocessError):
+        pass
 
 
 def _classify_quietly(text: str) -> str:
@@ -307,34 +369,34 @@ def _deliver(
     not runtime output). *cwd* is passed explicitly (not inherited) so both
     callers of ``deliver_terminal_notice`` sign the notice the same way.
     """
+    # Its own process group, so a timeout can take the whole tree. Expiry kills
+    # the process it started and nothing below it, and a notifier that forks —
+    # a shell wrapper, a mailer that backgrounds its send — leaves those
+    # descendants running once this hook exits. One per terminal event, each
+    # holding whatever the notifier held, and nothing left watching them.
     try:
-        proc = subprocess.run(  # noqa: S603 — argv is the operator-configured delivery command, no shell
+        proc = subprocess.Popen(  # noqa: S603 — argv is the operator-configured delivery command, no shell
             argv,
-            input=json.dumps(payload),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=timeout,
-            capture_output=True,
-            check=False,
             env=env,
             cwd=cwd,
+            start_new_session=True,
         )
     except (OSError, subprocess.SubprocessError) as exc:
-        # Only the exception *type* is kept — TimeoutExpired carries the
-        # child's captured output on .stdout/.stderr, so str(exc) would leak
-        # exactly the free text this function exists to keep out.
-        return {
-            "attempted": True,
-            "ok": False,
-            "exit_code": None,
-            "error": type(exc).__name__,
-            "failure_class": _pin_failure_class(
-                _FAILURE_TIMEOUT if isinstance(exc, subprocess.TimeoutExpired) else _FAILURE_UNKNOWN
-            ),
-            "command": program,
-        }
+        return _delivery_failure(exc, program)
+
+    try:
+        stdout, stderr = proc.communicate(input=json.dumps(payload), timeout=timeout)
+    except (OSError, subprocess.SubprocessError) as exc:
+        _kill_delivery_group(proc)
+        return _delivery_failure(exc, program)
+
     ok = proc.returncode == 0
     failure_class = _pin_failure_class(
-        None if ok else _classify_quietly(f"{proc.stderr or ''}\n{proc.stdout or ''}")
+        None if ok else _classify_quietly(f"{stderr or ''}\n{stdout or ''}")
     )
     outcome = {
         "attempted": True,
@@ -381,10 +443,20 @@ def _note_delivery_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
         failure_class = outcome.get("failure_class")
         if failure_class:
             detail = f"{detail} ({failure_class})"
-        line = (
-            f"\n[notify] terminal notice NOT delivered for run {run_id}: {detail}. "
-            f"This run finished; its completion signal did not.\n"
-        )
+        if outcome.get("delivery_verified") is False:
+            # Stopped while running, so whether the notice went out is not
+            # knowable from here. "NOT delivered" would send an operator to
+            # send it again, which is the wrong instruction half the time.
+            line = (
+                f"\n[notify] WARNING: terminal notice for run {run_id} could NOT be "
+                f"confirmed: {detail}. The notifier was stopped while still running, "
+                f"so the notice may or may not have gone out; check before re-sending.\n"
+            )
+        else:
+            line = (
+                f"\n[notify] terminal notice NOT delivered for run {run_id}: {detail}. "
+                f"This run finished; its completion signal did not.\n"
+            )
 
     try:
         path = config.job_dir(run_id) / "console.log"

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -182,12 +182,19 @@ def _kill_delivery_group(proc: subprocess.Popen) -> None:
     writing the outcome down: a fallback kill can leave a descendant holding
     the pipe open, and waiting on it indefinitely would spend the reserve and
     lose the record, which is the failure this whole path exists to prevent.
+
+    Descendant collection is a POSIX guarantee here, stated rather than
+    implied. ``start_new_session`` creates no group off POSIX, so there is no
+    group to signal and the fallback is all there is; collecting a tree there
+    needs a different mechanism (a job object, or shelling out to a tree-kill),
+    which nothing in CI could exercise. This is not a narrowing: the timeout
+    path this replaced terminated the direct child only, on every platform.
     """
     killpg = getattr(os, "killpg", None)
     try:
         if killpg is not None:
             killpg(proc.pid, signal.SIGKILL)
-        else:
+        else:  # pragma: no cover - POSIX is what CI runs
             proc.kill()
     except (ProcessLookupError, PermissionError, OSError):
         # Already gone, or not ours to signal. Either way there is nothing

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -25,11 +25,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import signal
 import subprocess
 import time
 from typing import Any
 
+from lionagi.ln._proc import terminate_process_group
 from lionagi.state.lifecycle.callbacks import HANDLER_BUDGET_SECONDS
 
 # The CLI runs this file's module by absolute interpreter path; lionagi is on
@@ -173,33 +173,26 @@ def _kill_delivery_group(proc: subprocess.Popen) -> None:
     """Take down the delivery's whole process group, then reap it.
 
     The delivery leads its own group (``start_new_session``), so its pid is the
-    group id. Falling back to the single process is not equivalent — it leaves
-    the descendants this exists to collect — but it is what is available where
-    process groups are not, and it still collects the common case of a notifier
-    that forks nothing.
+    group id. The signalling itself belongs to the package's shared terminator
+    rather than to this module: it refuses to signal pid<=1 or this process's
+    own group, which is the difference between ending the notifier and ending
+    the run that spawned it, and it signals the group *and* the direct child,
+    so the child is still collected on a platform where the group call is
+    unavailable or refused.
+
+    Descendant collection is therefore a POSIX property of that shared helper,
+    not a guarantee invented here. Off POSIX ``start_new_session`` creates no
+    group to signal and the direct child is what gets collected — the same
+    behaviour as every other process-group caller in the package, and not a
+    narrowing on this path, since the timeout it replaced terminated the direct
+    child only, on every platform.
 
     The reap is bounded because this runs inside the window reserved for
-    writing the outcome down: a fallback kill can leave a descendant holding
-    the pipe open, and waiting on it indefinitely would spend the reserve and
-    lose the record, which is the failure this whole path exists to prevent.
-
-    Descendant collection is a POSIX guarantee here, stated rather than
-    implied. ``start_new_session`` creates no group off POSIX, so there is no
-    group to signal and the fallback is all there is; collecting a tree there
-    needs a different mechanism (a job object, or shelling out to a tree-kill),
-    which nothing in CI could exercise. This is not a narrowing: the timeout
-    path this replaced terminated the direct child only, on every platform.
+    writing the outcome down: a kill can leave a descendant holding the pipe
+    open, and waiting on it indefinitely would spend the reserve and lose the
+    record, which is the failure this whole path exists to prevent.
     """
-    killpg = getattr(os, "killpg", None)
-    try:
-        if killpg is not None:
-            killpg(proc.pid, signal.SIGKILL)
-        else:  # pragma: no cover - POSIX is what CI runs
-            proc.kill()
-    except (ProcessLookupError, PermissionError, OSError):
-        # Already gone, or not ours to signal. Either way there is nothing
-        # further this can do about it, and the outcome is recorded regardless.
-        pass
+    terminate_process_group(proc, grace=None)
     try:
         proc.communicate(timeout=_REAP_TIMEOUT_S)
     except (OSError, subprocess.SubprocessError):

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -26,7 +26,10 @@ import argparse
 import json
 import os
 import subprocess
+import time
 from typing import Any
+
+from lionagi.state.lifecycle.callbacks import HANDLER_BUDGET_SECONDS
 
 # The CLI runs this file's module by absolute interpreter path; lionagi is on
 # the path because that interpreter is the one lionagi is installed in.
@@ -34,6 +37,36 @@ from . import config, jobs
 from ._terminal_cause import read_terminal_cause
 
 _DELIVERY_TIMEOUT_S = 30
+
+_STARTED_AT = time.monotonic()
+# Interpreter start and this module's imports, which precede _STARTED_AT and so
+# cannot be measured from here.
+_STARTUP_ALLOWANCE_S = 1.0
+# Locking the record, writing the outcome, appending the console note.
+_RECORDING_RESERVE_S = 2.0
+_MIN_DELIVERY_TIMEOUT_S = 1.0
+
+
+def _supervised_delivery_timeout() -> float:
+    """How long ``main`` may spend delivering and still record what happened.
+
+    The CLI runs this hook as a lifecycle exec adapter, and that supervisor
+    kills the adapter's whole process group when its deadline expires. A
+    delivery still running at that moment takes the outcome-recording step down
+    with it, leaving the write-ahead "unknown" outcome as the run's permanent
+    answer — a notice that was never sent, recorded as a result nobody can read.
+    So the delivery's own timeout has to fire first, with enough of the deadline
+    left to write the result down.
+
+    A ceiling, not a guarantee: ``HANDLER_BUDGET_SECONDS`` is the deadline for
+    the whole terminal-callback fan-out rather than for this handler alone, so
+    a co-running handler can consume it first and the kill can still land mid
+    delivery. What it removes is the case where that outcome was certain.
+    """
+    spent = time.monotonic() - _STARTED_AT
+    remaining = HANDLER_BUDGET_SECONDS - _STARTUP_ALLOWANCE_S - spent - _RECORDING_RESERVE_S
+    return max(_MIN_DELIVERY_TIMEOUT_S, remaining)
+
 
 # A notifier's stdout/stderr is free text that may carry a credential, so it's
 # read into memory, matched against the closed vocabulary below, and dropped —
@@ -259,6 +292,7 @@ def _deliver(
     *,
     program: str | None = None,
     cwd: str | None = None,
+    timeout: float = _DELIVERY_TIMEOUT_S,
 ) -> dict[str, Any]:
     """Run the delivery command best-effort; return its outcome for the record.
 
@@ -274,7 +308,7 @@ def _deliver(
             argv,
             input=json.dumps(payload),
             text=True,
-            timeout=_DELIVERY_TIMEOUT_S,
+            timeout=timeout,
             capture_output=True,
             check=False,
             env=env,
@@ -383,6 +417,7 @@ def deliver_terminal_notice(
     command: str | None = None,
     sender: str | None = None,
     reason_code: str | None = None,
+    timeout: float = _DELIVERY_TIMEOUT_S,
 ) -> dict[str, Any]:
     """Attempt this run's configured terminal notice and report what came of it.
 
@@ -390,6 +425,11 @@ def deliver_terminal_notice(
     whose process never got this far) that must resolve identically; see
     docs/internals/mcp.md#deliver-terminal-notice-two-callers. Nothing raises —
     every way a delivery does not happen comes back as an outcome describing it.
+
+    *timeout* differs between those two callers because only one of them is
+    supervised: the hook runs under a deadline that kills it (see
+    :func:`_supervised_delivery_timeout`), the observer runs in-process with
+    nobody to cut it short.
     """
     target = target or os.environ.get("LIONAGI_MCP_NOTIFY_TARGET") or ""
     sender = sender or os.environ.get("LIONAGI_MCP_NOTIFY_SENDER") or ""
@@ -433,6 +473,7 @@ def deliver_terminal_notice(
             _delivery_env(sender),
             program=program,
             cwd=delivery_cwd,
+            timeout=timeout,
         )
     if unusable:
         # Configured but unusable — recorded as a failure, not silence.
@@ -489,6 +530,7 @@ def main(argv: list[str] | None = None) -> int:
         command=args.command,
         sender=args.sender,
         reason_code=(terminal.record or {}).get("reason_code") or reason_code,
+        timeout=_supervised_delivery_timeout(),
     )
     recorded = jobs.record_notify_delivery(args.run_id, outcome)
     _note_delivery_in_console_log(args.run_id, outcome)

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -44,7 +44,6 @@ _STARTED_AT = time.monotonic()
 _STARTUP_ALLOWANCE_S = 1.0
 # Locking the record, writing the outcome, appending the console note.
 _RECORDING_RESERVE_S = 2.0
-_MIN_DELIVERY_TIMEOUT_S = 1.0
 
 
 def _supervised_delivery_timeout() -> float:
@@ -58,6 +57,11 @@ def _supervised_delivery_timeout() -> float:
     So the delivery's own timeout has to fire first, with enough of the deadline
     left to write the result down.
 
+    The result falls to zero rather than to any minimum. A floor would be the
+    one case worth guarding against: it applies exactly when the budget is
+    already spent, and it buys delivery time by taking it from the reserve that
+    writes the answer down.
+
     A ceiling, not a guarantee: ``HANDLER_BUDGET_SECONDS`` is the deadline for
     the whole terminal-callback fan-out rather than for this handler alone, so
     a co-running handler can consume it first and the kill can still land mid
@@ -65,7 +69,7 @@ def _supervised_delivery_timeout() -> float:
     """
     spent = time.monotonic() - _STARTED_AT
     remaining = HANDLER_BUDGET_SECONDS - _STARTUP_ALLOWANCE_S - spent - _RECORDING_RESERVE_S
-    return max(_MIN_DELIVERY_TIMEOUT_S, remaining)
+    return max(0.0, remaining)
 
 
 # A notifier's stdout/stderr is free text that may carry a credential, so it's

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -2123,12 +2123,20 @@ def _notify_delivery_state(outcome: Any) -> str:
 
     ``"none"``: not terminal yet, or terminal with no notifier configured —
     silence is the documented default, never a failure. ``"delivered"``: went
-    out. ``"failed"``: every way a *configured* notifier came to nothing
-    (refused, couldn't start, timed out, non-zero exit) — one fact to a caller
+    out. ``"failed"``: every way a *configured* notifier reported its own
+    failure (refused, couldn't start, non-zero exit) — one fact to a caller
     waiting on it. ``"delivered_unverified"``: ran and exited zero, but for that
     command shape a zero exit doesn't mean the message was sent — collapsing it
     into either neighbor would report a claim this can't support. ``"unknown"``:
-    the attempt started but its final outcome could not be recorded.
+    the attempt started but its final outcome could not be established — either
+    nothing was recorded at all, or it was stopped part-way, where the notice
+    may already have gone out before the hang.
+
+    A stopped-part-way delivery is deliberately not ``"failed"``. That word
+    tells a waiting caller to send the notice again, and the one thing not
+    known here is whether it was already sent; a resend on a hang that did
+    deliver is a duplicate notice. It stays inside the sweep either way, since
+    the documented sweep acts on ``"failed"`` *or* ``"unknown"``.
     """
     if not isinstance(outcome, dict):
         return "none"
@@ -2140,6 +2148,8 @@ def _notify_delivery_state(outcome: Any) -> str:
         return "delivered"
     if not outcome.get("attempted") and not outcome.get("error"):
         return "none"
+    if outcome.get("delivery_verified") is False:
+        return "unknown"
     return "failed"
 
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -15,13 +15,14 @@ import logging
 import math
 import os
 import signal
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from lionagi.cli import _mcp_resolve
 from lionagi.ln import _proc
-from lionagi.mcp import config, jobs
+from lionagi.mcp import _notify_hook, config, jobs
 
 
 @pytest.fixture
@@ -2745,6 +2746,38 @@ def test_listing_does_not_pass_an_unverified_delivery_off_as_delivered(sandbox):
     # a caller that treats anything other than "delivered" as needing a look gets
     # the right behaviour without having to know this state exists
     assert states[unverified] != "delivered"
+
+
+def test_listing_does_not_call_a_stopped_delivery_a_failure(sandbox):
+    """A delivery stopped for running past its deadline is not a failed one.
+
+    "failed" is what a caller waiting on the notice reads as "send it again",
+    and whether it was already sent is the one thing this outcome does not
+    know: a notifier can deliver and then hang. So the word that would prompt
+    a duplicate notice is the wrong one, while silence is worse — it reads as
+    a notice that arrived. It reports unknown, which the documented sweep
+    ("act on failed or unknown") already collects.
+
+    The outcome is built by the code that records it rather than written out
+    here, so a change to that shape arrives in this test instead of leaving it
+    asserting against a record the producer stopped emitting.
+    """
+    timed_out = _notify_hook._delivery_failure(
+        subprocess.TimeoutExpired(cmd=["notify"], timeout=7.0), "notify"
+    )
+    assert timed_out["ok"] is False and timed_out["delivery_verified"] is False
+
+    stopped = _terminal_run(timed_out)
+    failed = _terminal_run(_EXITED_NONZERO)
+    delivered = _terminal_run(_DELIVERED)
+
+    states = {j["run_id"]: j["notify_delivery_state"] for j in jobs.list_jobs()}
+    assert states[stopped] == "unknown"
+    assert states[stopped] != states[failed]
+    assert states[stopped] != states[delivered]
+    # and it is still one of the two words the documented sweep acts on, so
+    # nothing has to know this case exists to keep finding it
+    assert states[stopped] in {"failed", "unknown"}
 
 
 def test_listing_does_not_read_an_absent_notifier_as_a_failure(sandbox):

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -5,13 +5,15 @@
 The hook is best-effort: it always records the terminal status on the job, then
 delivers a notice only through a *configured* command (never a hardcoded one),
 substituting run fields into its argv. The delivery outcome is recorded on the
-job so a dead notice is visible, not silently lost. subprocess.run is mocked so
+job so a dead notice is visible, not silently lost. subprocess.Popen is mocked so
 no real command is spawned.
 """
 
 from __future__ import annotations
 
 import json
+import os
+import signal
 import sys
 import time
 from pathlib import Path
@@ -47,12 +49,30 @@ def job(monkeypatch, tmp_path):
 
 
 class _FakeCompleted:
+    """Stand-in for the delivery process.
+
+    Popen-shaped rather than CompletedProcess-shaped: the hook starts the
+    delivery in its own process group so a timeout can take the whole tree,
+    which means it holds a handle and drives it through ``communicate``.
+    """
+
     def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
         self.returncode = returncode
         # The hook reads both streams to classify a failure, so a stand-in for a
         # finished process has to carry them.
         self.stdout = stdout
         self.stderr = stderr
+        self.pid = -1
+        self.input: str | None = None
+        self.killed = False
+
+    def communicate(self, input: str | None = None, timeout: float | None = None):
+        if input is not None:
+            self.input = input
+        return self.stdout, self.stderr
+
+    def kill(self) -> None:
+        self.killed = True
 
 
 def _no_settings_notifier(monkeypatch):
@@ -65,7 +85,7 @@ def _no_settings_notifier(monkeypatch):
 def test_marks_terminal_without_delivery(job, monkeypatch):
     """No command configured: the status is recorded and nothing is spawned."""
     calls: list = []
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append((a, k)))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: calls.append((a, k)))
     _no_settings_notifier(monkeypatch)  # lionagi's notify.on_terminal resolves to nothing
 
     rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
@@ -86,12 +106,12 @@ def test_flow_terminal_reason_reaches_mcp_status_and_delivery(job, monkeypatch):
     """
     captured: dict = {}
 
-    def fake_run(argv, **kw):
+    def fake_popen(argv, **kw):
         captured["argv"] = argv
-        captured["input"] = kw.get("input")
-        return _FakeCompleted(0)
+        captured["proc"] = _FakeCompleted(0)
+        return captured["proc"]
 
-    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", fake_popen)
     monkeypatch.setenv(
         "LIONAGI_NOTIFY_PAYLOAD",
         json.dumps(
@@ -110,18 +130,18 @@ def test_flow_terminal_reason_reaches_mcp_status_and_delivery(job, monkeypatch):
     assert rec["reason_code"] == "run.completed.spawn_refused"
     assert jobs.status(job)["reason_code"] == "run.completed.spawn_refused"
     assert captured["argv"] == ["notify", "run.completed.spawn_refused"]
-    assert json.loads(captured["input"])["reason_code"] == "run.completed.spawn_refused"
+    assert json.loads(captured["proc"].input)["reason_code"] == "run.completed.spawn_refused"
 
 
 def test_command_override_substitutes_and_delivers(job, monkeypatch):
     captured: dict = {}
 
-    def fake_run(argv, **kw):
+    def fake_popen(argv, **kw):
         captured["argv"] = argv
-        captured["input"] = kw.get("input")
-        return _FakeCompleted(0)
+        captured["proc"] = _FakeCompleted(0)
+        return captured["proc"]
 
-    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", fake_popen)
 
     command = json.dumps(["notify", "{run_id}", "{status}", "{label}", "{target}"])
     rc = _notify_hook.main(
@@ -132,7 +152,7 @@ def test_command_override_substitutes_and_delivers(job, monkeypatch):
     assert rec["status"] == "failed"
     assert captured["argv"] == ["notify", job, "failed", "t1", "downstream"]
     # the same fields are offered as a JSON payload on stdin
-    payload = json.loads(captured["input"])
+    payload = json.loads(captured["proc"].input)
     assert payload == {
         "run_id": job,
         "status": "failed",
@@ -158,7 +178,7 @@ def test_command_override_substitutes_and_delivers(job, monkeypatch):
 
 def test_delivery_failure_is_recorded_not_silent(job, monkeypatch):
     """A dead completion notice surfaces on the record, never a silent drop."""
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(7))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(7))
 
     command = json.dumps(["notify", "{status}"])
     rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
@@ -180,7 +200,7 @@ def test_delivery_spawn_error_is_recorded(job, monkeypatch):
     def boom(*_a, **_k):
         raise OSError("no such command")
 
-    monkeypatch.setattr(_notify_hook.subprocess, "run", boom)
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", boom)
 
     command = json.dumps(["nonexistent-notifier", "{status}"])
     rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
@@ -207,7 +227,7 @@ def test_unusable_command_override_is_recorded_as_a_failure(job, monkeypatch, ov
     to find out why, and the named reason is where it says so.
     """
     calls: list = []
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: calls.append(a))
     _no_settings_notifier(monkeypatch)
 
     rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", override])
@@ -224,7 +244,7 @@ def test_unusable_command_override_is_recorded_as_a_failure(job, monkeypatch, ov
 def test_configured_notifier_without_a_command_is_recorded_as_a_failure(job, monkeypatch):
     """A notifier this hook cannot run is configured, not absent."""
     calls: list = []
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: calls.append(a))
     monkeypatch.setattr(
         "lionagi.state.lifecycle.notify_settings.resolve_notify_config",
         lambda **_kw: NotifyConfigResolution(
@@ -242,7 +262,7 @@ def test_configured_notifier_without_a_command_is_recorded_as_a_failure(job, mon
 def test_unreadable_notify_settings_are_recorded_as_a_failure(job, monkeypatch):
     """Settings that raise must not be reported as no notifier configured."""
     calls: list = []
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: calls.append(a))
 
     def _boom(**_kw):
         raise RuntimeError("settings file is corrupt")
@@ -339,7 +359,7 @@ def test_rejected_settings_notifier_is_recorded_as_a_failure(job, monkeypatch, o
     have is a notice that will never arrive.
     """
     calls: list = []
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: calls.append(a))
     _settings_notifier(monkeypatch, on_terminal)
 
     rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
@@ -362,7 +382,7 @@ def test_rejected_settings_notifier_is_recorded_as_a_failure(job, monkeypatch, o
 def test_silence_by_choice_stays_silence(job, monkeypatch, on_terminal):
     """The chosen-silence shapes must not become failures: nothing was asked for."""
     calls: list = []
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: calls.append(a))
     _settings_notifier(monkeypatch, on_terminal)
 
     rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
@@ -375,11 +395,11 @@ def test_settings_notifier_resolves_and_delivers(job, monkeypatch):
     """The happy path still resolves through settings and delivers."""
     captured: dict = {}
 
-    def fake_run(argv, **kw):
+    def fake_popen(argv, **kw):
         captured["argv"] = argv
         return _FakeCompleted(0)
 
-    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", fake_popen)
     _settings_notifier(monkeypatch, "notify-hook {run_id} {status}")
 
     rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
@@ -392,7 +412,7 @@ def test_unknown_run_id_is_noop(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
     monkeypatch.delenv("LIONAGI_MCP_NOTIFY_COMMAND", raising=False)
     calls: list = []
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: calls.append(a))
     _no_settings_notifier(monkeypatch)
     # No job record on disk: mark_terminal reports an absent record, delivery
     # still resolves to nothing, and the hook exits cleanly.
@@ -414,7 +434,7 @@ def test_failed_delivery_ends_the_leg_log_with_a_stated_failure(job, monkeypatch
     """
     config.job_dir(job).mkdir(parents=True, exist_ok=True)
     (config.job_dir(job) / "console.log").write_text("work happened\n", encoding="utf-8")
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(7))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(7))
 
     command = json.dumps(["notify", "{status}"])
     _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
@@ -430,7 +450,7 @@ def test_spawn_error_is_named_in_the_leg_log(job, monkeypatch):
         raise OSError("no such command")
 
     config.job_dir(job).mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(_notify_hook.subprocess, "run", boom)
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", boom)
 
     command = json.dumps(["nonexistent-notifier", "{status}"])
     _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
@@ -442,7 +462,7 @@ def test_a_configured_but_unusable_notifier_also_reaches_the_log(job, monkeypatc
     """Recorded as a failure on the job, so it must read as one in the log too."""
     config.job_dir(job).mkdir(parents=True, exist_ok=True)
     _no_settings_notifier(monkeypatch)
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(0))
 
     _notify_hook.main(["--run-id", job, "--status", "completed", "--command", "not json ["])
 
@@ -452,7 +472,7 @@ def test_a_configured_but_unusable_notifier_also_reaches_the_log(job, monkeypatc
 def test_successful_delivery_writes_nothing_to_the_log(job, monkeypatch):
     config.job_dir(job).mkdir(parents=True, exist_ok=True)
     (config.job_dir(job) / "console.log").write_text("work happened\n", encoding="utf-8")
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(0))
 
     command = json.dumps(["notify", "{status}"])
     _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
@@ -471,7 +491,7 @@ def test_an_unverified_delivery_warns_in_the_log_instead_of_passing_silently(job
     """
     config.job_dir(job).mkdir(parents=True, exist_ok=True)
     (config.job_dir(job) / "console.log").write_text("work happened\n", encoding="utf-8")
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(0))
 
     command = json.dumps(["kkernel", "exec", "comm.send(to='recipient', content='{status}')"])
     _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
@@ -495,7 +515,7 @@ def test_the_same_command_with_strict_is_verified_and_stays_silent(job, monkeypa
     """
     config.job_dir(job).mkdir(parents=True, exist_ok=True)
     (config.job_dir(job) / "console.log").write_text("work happened\n", encoding="utf-8")
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(0))
 
     command = json.dumps(
         ["kkernel", "exec", "--strict", "comm.send(to='recipient', content='{status}')"]
@@ -519,7 +539,7 @@ def test_silence_by_choice_writes_nothing_to_the_log(job, monkeypatch):
 
 def test_an_unwritable_log_does_not_break_the_terminal_path(job, monkeypatch):
     """The run already finished; a log that cannot be appended to is not fatal."""
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(7))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(7))
     # A directory where the log file belongs: opening it for append raises an
     # OSError from the real filesystem rather than from a patched stand-in.
     (config.job_dir(job) / "console.log").mkdir(parents=True, exist_ok=True)
@@ -539,7 +559,7 @@ def test_the_record_names_which_notifier_failed(job, monkeypatch):
     operator configuration, already readable by whoever wrote it, so naming it
     costs nothing the command's own output would have cost.
     """
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(3))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(3))
 
     command = json.dumps(["notify-webhook", "--status", "{status}"])
     rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
@@ -560,7 +580,7 @@ def test_the_named_program_is_the_configured_token_not_the_substituted_one(job, 
     spawned: list = []
     monkeypatch.setattr(
         _notify_hook.subprocess,
-        "run",
+        "Popen",
         lambda argv, **_k: spawned.append(argv) or _FakeCompleted(1),
     )
 
@@ -584,11 +604,11 @@ def test_a_notifier_that_never_started_stays_tellable_from_one_that_ran(job, mon
     def _boom(*_a, **_k):
         raise OSError("no such command")
 
-    monkeypatch.setattr(_notify_hook.subprocess, "run", _boom)
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", _boom)
     _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
     never_started = jobs._read_job(job)["notify_delivery"]
 
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(3))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(3))
     _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
     ran_and_failed = jobs._read_job(job)["notify_delivery"]
 
@@ -599,7 +619,7 @@ def test_a_notifier_that_never_started_stays_tellable_from_one_that_ran(job, mon
 
 def test_a_configuration_with_no_program_in_it_names_none(job, monkeypatch):
     """An override that never parsed has no program, and none is invented."""
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(0))
     _no_settings_notifier(monkeypatch)
 
     rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", "not json ["])
@@ -628,7 +648,7 @@ def test_the_delivery_commands_own_output_is_still_never_kept(job, monkeypatch):
         seen.update(kwargs)
         return _FakeCompleted(4, stdout="token=sk-live-AAAA", stderr="permission denied for /etc/x")
 
-    monkeypatch.setattr(_notify_hook.subprocess, "run", _run)
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", _run)
 
     command = json.dumps(["notify-webhook"])
     _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
@@ -861,7 +881,63 @@ def test_a_delivery_that_outlives_the_timeout_is_recorded_not_left_unknown(job, 
     assert delivery["ok"] is False
     assert delivery["error"] == "TimeoutExpired"
     assert delivery["failure_class"] == "timeout"
-    assert "NOT delivered" in _console_log(job)
+    # Recorded, but as unconfirmed rather than failed: a notifier can send the
+    # notice and then hang, so "NOT delivered" would be a claim this cannot
+    # support, and one an operator would act on by sending it twice.
+    assert delivery["delivery_verified"] is False
+    assert delivery["unverified_reason"] == "delivery_timed_out"
+    log = _console_log(job)
+    assert "could NOT be confirmed" in log
+    assert "NOT delivered" not in log
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+@pytest.mark.timeout(60)
+def test_a_timed_out_delivery_takes_its_forked_descendants_with_it(job, monkeypatch, tmp_path):
+    """Expiry has to collect the whole tree, not just the process it started.
+
+    A notifier that forks — a shell wrapper, a mailer that backgrounds its send
+    — leaves that descendant running when only the direct child is killed. One
+    per terminal event, holding whatever the notifier held, with nothing left
+    watching them. Real processes because the defect is in how the delivery is
+    started, which a stand-in cannot have.
+    """
+    pidfile = tmp_path / "descendant.pid"
+    script = (
+        "import subprocess, sys, time\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])\n"
+        f"open({str(pidfile)!r}, 'w').write(str(child.pid))\n"
+        "time.sleep(120)\n"
+    )
+    monkeypatch.setattr(_notify_hook, "_supervised_delivery_timeout", lambda: 2.0)
+    command = json.dumps([sys.executable, "-c", script])
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    assert rc == 0
+    assert jobs.status(job)["notify_delivery"]["error"] == "TimeoutExpired"
+    assert pidfile.exists(), "the notifier never got far enough to fork; timeout too tight"
+    descendant = int(pidfile.read_text())
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and _alive(descendant):
+            time.sleep(0.05)
+        assert not _alive(descendant), "a forked descendant outlived the delivery"
+    finally:
+        # Never leave one behind, including when the assertion above is why.
+        try:
+            os.kill(descendant, signal.SIGKILL)
+        except OSError:
+            pass
 
 
 def test_the_failure_notice_survives_the_runs_own_remaining_output(monkeypatch, tmp_path):
@@ -962,7 +1038,7 @@ def test_delivery_runs_where_the_run_was_submitted_not_where_it_ran(monkeypatch,
     captured: dict = {}
     monkeypatch.setattr(
         _notify_hook.subprocess,
-        "run",
+        "Popen",
         lambda *_a, **kw: captured.update(kw) or _FakeCompleted(0),
     )
 
@@ -997,7 +1073,7 @@ def test_both_callers_deliver_from_the_same_directory(monkeypatch, tmp_path):
     seen: list = []
     monkeypatch.setattr(
         _notify_hook.subprocess,
-        "run",
+        "Popen",
         lambda *_a, **kw: seen.append(kw.get("cwd")) or _FakeCompleted(0),
     )
 
@@ -1022,7 +1098,7 @@ def test_an_operator_can_override_the_delivery_directory(monkeypatch, tmp_path):
     captured: dict = {}
     monkeypatch.setattr(
         _notify_hook.subprocess,
-        "run",
+        "Popen",
         lambda *_a, **kw: captured.update(kw) or _FakeCompleted(0),
     )
 
@@ -1043,7 +1119,7 @@ def test_a_named_directory_that_is_gone_refuses_rather_than_signing_elsewhere(
     rid = _job_with(monkeypatch, tmp_path, submit_cwd=str(tmp_path / "removed"))
 
     calls: list = []
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append((a, k)))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: calls.append((a, k)))
 
     command = json.dumps(["notify", "{run_id}"])
     assert _notify_hook.main(["--run-id", rid, "--status", "completed", "--command", command]) == 0
@@ -1064,7 +1140,7 @@ def test_a_record_without_a_submit_directory_still_delivers(monkeypatch, tmp_pat
     captured: dict = {}
     monkeypatch.setattr(
         _notify_hook.subprocess,
-        "run",
+        "Popen",
         lambda *_a, **kw: captured.update(kw) or _FakeCompleted(0),
     )
 
@@ -1093,7 +1169,7 @@ def test_an_anchor_the_submission_could_not_read_refuses_rather_than_inheriting(
     rid = _job_with(monkeypatch, tmp_path, submit_cwd=None)
 
     calls: list = []
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append((a, k)))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: calls.append((a, k)))
 
     command = json.dumps(["notify", "{run_id}"])
     assert _notify_hook.main(["--run-id", rid, "--status", "completed", "--command", command]) == 0
@@ -1113,7 +1189,7 @@ def test_a_record_missing_the_key_entirely_still_inherits(monkeypatch, tmp_path)
     captured: dict = {}
     monkeypatch.setattr(
         _notify_hook.subprocess,
-        "run",
+        "Popen",
         lambda *_a, **kw: captured.update(kw) or _FakeCompleted(0),
     )
 
@@ -1131,7 +1207,7 @@ def test_two_identity_problems_are_both_reported(monkeypatch, tmp_path):
     """
     rid = _job_with(monkeypatch, tmp_path, submit_cwd=str(tmp_path / "removed"))
 
-    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", lambda *a, **k: _FakeCompleted(0))
 
     command = json.dumps(["notify", "{sender}"])  # asks for a sender; none is given
     assert _notify_hook.main(["--run-id", rid, "--status", "completed", "--command", command]) == 0

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 
 from lionagi.mcp import _notify_hook, config, jobs
+from lionagi.state.lifecycle.callbacks import HANDLER_BUDGET_SECONDS
 from lionagi.state.lifecycle.notify_settings import (
     NotifyConfigResolution,
     ResolvedNotifyHandler,
@@ -774,6 +775,60 @@ def test_outer_notify_timeout_keeps_an_attempt_record_after_delivery(monkeypatch
     assert status["notify_delivery"]["error"] == "delivery_outcome_unknown"
     row = next(item for item in jobs.list_jobs() if item["run_id"] == run_id)
     assert row["notify_delivery_state"] == "unknown"
+
+
+def test_the_delivery_timeout_fits_inside_the_deadline_that_kills_the_hook():
+    """The hook's own timeout must fire before its supervisor's, or it never records.
+
+    The supervised path carried a 30s delivery timeout under a 10s terminal
+    callback deadline, so the hook's timeout could not fire: a slow notifier was
+    killed mid-delivery every time and the write-ahead "unknown" outcome became
+    the run's permanent answer. The reserve is the room left to write it down.
+    """
+    timeout = _notify_hook._supervised_delivery_timeout()
+
+    assert timeout >= _notify_hook._MIN_DELIVERY_TIMEOUT_S
+    assert timeout + _notify_hook._RECORDING_RESERVE_S < HANDLER_BUDGET_SECONDS
+    # The in-process observer has no supervisor, so it keeps the longer one.
+    assert timeout < _notify_hook._DELIVERY_TIMEOUT_S
+
+
+def test_the_hook_delivers_under_the_supervised_timeout(job, monkeypatch):
+    """``main`` is the supervised caller, so it must not use the in-process default."""
+    seen: dict = {}
+
+    def _capture(*args, **kwargs):
+        seen.update(kwargs)
+        return {"attempted": False}
+
+    monkeypatch.setattr(_notify_hook, "deliver_terminal_notice", _capture)
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed"])
+
+    assert rc == 0
+    assert seen["timeout"] < _notify_hook._DELIVERY_TIMEOUT_S
+    assert seen["timeout"] + _notify_hook._RECORDING_RESERVE_S < HANDLER_BUDGET_SECONDS
+
+
+def test_a_delivery_that_outlives_the_timeout_is_recorded_not_left_unknown(job, monkeypatch):
+    """A notifier that runs long is a recorded timeout, not an unreadable outcome.
+
+    The distinction is the whole point of the bound: "timed out" tells a reader
+    the notice did not arrive, while the write-ahead "unknown" cannot say
+    whether it did, and a run that keeps it has spent its one chance to say so.
+    """
+    monkeypatch.setattr(_notify_hook, "_supervised_delivery_timeout", lambda: 0.2)
+    command = json.dumps([sys.executable, "-c", "import time; time.sleep(5)"])
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    assert rc == 0
+    delivery = jobs.status(job)["notify_delivery"]
+    assert delivery["attempted"] is True
+    assert delivery["ok"] is False
+    assert delivery["error"] == "TimeoutExpired"
+    assert delivery["failure_class"] == "timeout"
+    assert "NOT delivered" in _console_log(job)
 
 
 def test_the_failure_notice_survives_the_runs_own_remaining_output(monkeypatch, tmp_path):

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -787,10 +787,43 @@ def test_the_delivery_timeout_fits_inside_the_deadline_that_kills_the_hook():
     """
     timeout = _notify_hook._supervised_delivery_timeout()
 
-    assert timeout >= _notify_hook._MIN_DELIVERY_TIMEOUT_S
     assert timeout + _notify_hook._RECORDING_RESERVE_S < HANDLER_BUDGET_SECONDS
     # The in-process observer has no supervisor, so it keeps the longer one.
     assert timeout < _notify_hook._DELIVERY_TIMEOUT_S
+
+
+@pytest.mark.parametrize(
+    ("spent", "expected"),
+    [
+        (0.0, 7.0),
+        # Past the point where a one-second floor would start overdrawing.
+        (6.5, 0.5),
+        (7.0, 0.0),
+        # Already inside the reserve: there is nothing left to hand out, and
+        # handing out a minimum here is what spends the recording window.
+        (9.0, 0.0),
+    ],
+)
+def test_the_delivery_timeout_is_what_the_budget_arithmetic_leaves(spent, expected, monkeypatch):
+    """Pinned per elapsed value, so the budget cannot quietly become a constant.
+
+    ``HANDLER_BUDGET_SECONDS`` minus the startup allowance, minus what this hook
+    has already spent, minus the reserve that records the outcome. Asserting
+    only that the result is positive and under the deadline passes for any fixed
+    number in that range, including one that ignores the elapsed time entirely.
+    """
+    monkeypatch.setattr(_notify_hook, "_STARTED_AT", time.monotonic() - spent)
+
+    timeout = _notify_hook._supervised_delivery_timeout()
+
+    assert timeout == pytest.approx(expected, abs=0.25)
+    # The invariant the number exists to hold. Once the budget is gone the
+    # overdraw is already there and no return value undoes it, so what the
+    # function controls is whether it hands out time it does not have.
+    assert timeout == 0.0 or (
+        spent + _notify_hook._STARTUP_ALLOWANCE_S + timeout + _notify_hook._RECORDING_RESERVE_S
+        <= HANDLER_BUDGET_SECONDS
+    )
 
 
 def test_the_hook_delivers_under_the_supervised_timeout(job, monkeypatch):

--- a/tests/mcp/test_notify_sender.py
+++ b/tests/mcp/test_notify_sender.py
@@ -77,7 +77,7 @@ def test_no_delivery_runs_when_the_template_needs_a_sender_and_none_was_given(
     rid = _job(monkeypatch, tmp_path)
     spawned: list = []
     monkeypatch.setattr(
-        _notify_hook.subprocess, "run", lambda *a, **k: spawned.append(a) or _Completed()
+        _notify_hook.subprocess, "Popen", lambda *a, **k: spawned.append(a) or _Completed()
     )
 
     rc = _notify_hook.main(
@@ -106,11 +106,11 @@ def test_a_template_that_needs_a_sender_delivers_when_one_is_given(monkeypatch, 
     rid = _job(monkeypatch, tmp_path)
     spawned: list = []
 
-    def fake_run(argv, **kw):
+    def fake_popen(argv, **kw):
         spawned.append(argv)
         return _Completed()
 
-    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", fake_popen)
 
     rc = _notify_hook.main(
         [
@@ -137,11 +137,11 @@ def test_a_template_without_the_placeholder_is_unaffected_by_a_missing_sender(
     rid = _job(monkeypatch, tmp_path)
     spawned: list = []
 
-    def fake_run(argv, **kw):
+    def fake_popen(argv, **kw):
         spawned.append(argv)
         return _Completed()
 
-    monkeypatch.setattr(_notify_hook.subprocess, "run", fake_run)
+    monkeypatch.setattr(_notify_hook.subprocess, "Popen", fake_popen)
 
     rc = _notify_hook.main(
         ["--run-id", rid, "--status", "completed", "--command", '["notify", "{run_id}"]']
@@ -152,4 +152,13 @@ def test_a_template_without_the_placeholder_is_unaffected_by_a_missing_sender(
 
 
 class _Completed:
+    """Popen-shaped: the hook holds a handle and drives it through communicate."""
+
     returncode = 0
+    pid = -1
+
+    def communicate(self, input: str | None = None, timeout: float | None = None):
+        return "", ""
+
+    def kill(self) -> None:
+        pass


### PR DESCRIPTION
## What

The CLI runs the terminal notify hook as a lifecycle exec adapter. That supervisor kills the adapter's **whole process group** when the terminal-callback deadline expires, but the hook carried a 30s delivery timeout under a 10s deadline, so on the supervised path the hook's own timeout could never fire.

Any delivery slower than the deadline was killed mid-flight, taking the outcome-recording step down with it. The write-ahead `delivery_outcome_unknown` outcome then stayed as the run's permanent answer, which cannot tell a reader whether the notice arrived. For a notifier that was merely slow, `TimeoutExpired` was the answer the hook was already written to record and structurally could not reach.

Observed on real job records: every run whose delivery hit the inner 30s timeout came from the in-process observer (`mcp_orphan_reaper`), which has no supervisor. No hook-path run ever reached it.

## Change

**The delivery timeout now fits inside the deadline that kills it.** `main()` derives it from `HANDLER_BUDGET_SECONDS`, reserving room to write the outcome down and append the console note. The derived budget is allowed to fall to zero rather than being floored at one second, so a deadline too small to deliver under says so instead of overrunning by a second.

**A timed-out delivery takes its descendants with it.** The delivery now leads its own process group, and on timeout that group is terminated through the package's shared process-group helper rather than a signal path local to this module. The helper refuses to signal pid<=1 or the caller's own group, and it signals the group *and* the direct child, so the child is still collected where the group call is unavailable.

**A stopped delivery is no longer reported as a failed one.** `notify_delivery_state` now returns `unknown` for a delivery that was stopped part-way, distinct from `failed` (it ran and did not succeed) and from `delivered`. The two were previously folded together, and they call for opposite responses: resending on a hang that did in fact deliver duplicates the notice.

## What does not change

- The in-process observer keeps the 30s timeout. Nothing supervises it.
- The write-ahead outcome and its meaning are untouched.
- A kill can still land mid-delivery, since the deadline covers the whole callback fan-out rather than this handler alone, so a co-running handler can consume it first. What this removes is the case where that outcome was *certain*.
- Descendant containment stays a POSIX property. Off POSIX there is no session group to signal and the direct child is what gets collected, which matches every other process-group caller in this package. That is not a narrowing here: the timeout path this replaced terminated the direct child only, on every platform. Which platforms get containment, and what the others report when they cannot, is tracked in #2576.

## Tests

`tests/mcp/{test_notify_hook,test_orphan_reaping,test_jobs,test_dispatch,test_notify_sender}.py`, 399 passed.

Added, each mutation-probed:

- the supervised timeout fits inside the deadline with room to record
- `main` delivers under the supervised timeout, not the in-process default
- a delivery that outlives the timeout is recorded as a timeout rather than left unknown
- a stopped delivery is listed as `unknown`, and distinctly from both a failed and a delivered one

Docs updated in `docs/cli-reference.md` and `docs/internals/mcp.md` for the derived timeout and the delivery states.
