### PR TITLE
docs(changelog): record the notify delivery-state change under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- The notify hook's delivery timeout is derived from the handler budget, so a
+  delivery now fits inside the deadline that would otherwise terminate it.
+- A delivery stopped part way reports `notify_delivery_state` as `unknown`
+  rather than `failed`. Whether the notice already went out is exactly what
+  such a delivery cannot say, and `failed` tells a caller to send it again.
+  The value appears on every job listing row, so callers switching on
+  `failed` should handle `unknown` as well.
+- Delivery descendants are terminated through the shared process-group helper
+  on POSIX. Cross-platform descendant containment remains out of scope and is
+  tracked in #2576.
+
 ## [0.35.0] - 2026-08-12
 
 A broad correctness release across the orchestration engine, the MCP surface,


### PR DESCRIPTION
## Why

The delivery-state change is API-visible and the release notes for this cycle are composed from `git log` at release time. The merge that introduced it describes the timeout half and is silent on the state half, so composing from commit history would have shipped release notes missing a value callers can now receive.

## What changed for a caller

`notify_delivery_state` returns `unknown` instead of `failed` when a delivery is stopped part way. The field is present on every job listing row and documented on the MCP verb, so anyone switching on `failed` sees a value they did not see before. `failed` is the wrong thing to report there: whether the notice already went out is exactly what an interrupted delivery cannot determine, and `failed` tells a caller to send it again.

## Verified at HEAD rather than taken from the merge description

- The branch returning `unknown` sits on the not-ok path and is evaluated after the ok-truthy branch, so it does not shadow `delivered_unverified`.
- The delivery timeout is derived from the handler budget in the notify hook, so a delivery fits inside the deadline that would otherwise terminate it.
- Descendants are terminated with `killpg` against a session started via `start_new_session`.
- #2576 is open and is the tracking issue for the cross-platform half.

Documentation only. No source changes.
