### PR TITLE
docs(governance): allow removing an accepted-but-inert option without the wait

### DIFF
--- a/docs/governance/standards/deprecation-policy.md
+++ b/docs/governance/standards/deprecation-policy.md
@@ -85,6 +85,22 @@ These changes may be made without the alias-plus-warning cycle.
 - **Fixing a name that never worked**: if importing or calling the name has always raised an
   exception (e.g., missing dependency, broken wiring), it was never a functional public
   contract. Document this in the commit message.
+- **Removing an option that was accepted and silently ignored**: if a flag or option is parsed
+  and accepted on a surface but its value is never read there, it carried no behavior a caller
+  could depend on, and the wait in section 2 step 3 does not apply. The CHANGELOG `Removed`
+  entry still does. A caller passing an inert flag gets no error and no effect, so nothing in
+  their own logs ever told them it was dead, and the release notes are the only place they can
+  learn it is gone. This is the difference from the bullet above: a name that always raised told
+  its callers immediately, an inert one told them nothing.
+
+  Inertness is a claim about a specific surface and must be verified rather than assumed. Before
+  relying on this clause, confirm at the merge base that the option's value is read nowhere under
+  the module that owns the surface you are removing it from, and state that search scope in the
+  commit message so a reviewer can reproduce the result. Scope matters in both directions: the
+  same option name may be live on one surface and inert on another, so a repo-wide search answers
+  the wrong question. This clause was introduced alongside the removal of `--resume-on-timeout`
+  from `li o fanout` and `li o flow`, where the value was read nowhere under
+  `lionagi/cli/orchestrate/` while the same option remained functional on `li agent` (#3071).
 - **Internal-only changes**: refactoring or renaming anything not in `__all__` and not
   documented. Confirm the name does not appear in any example, cookbook, or docs page first.
 - **Type annotation narrowing that is source-compatible**: adding `| None` or a more specific


### PR DESCRIPTION
## Why

The deprecation policy's "allowed without deprecation" list in section 3 covers a name that
*has always raised an exception*, on the reasoning that it was never a functional public
contract. It does not cover the adjacent and more common case: an option that is parsed and
accepted on a surface but whose value is never read there.

The two are not the same, and the difference matters to a caller. A name that always raised
told its callers immediately. An inert flag tells them nothing: they get no error and no
effect, so nothing in their own logs ever reveals it is dead. That makes the release notes the
only place they can find out it is gone.

Without a clause for it, the case resolves by stretching "always raised an exception" to cover
"accepted and ignored", which is a carve-out being read expansively by the person who needs it.

## What

Adds one bullet to section 3 stating the case and how it resolves:

- The wait in section 2 step 3 does **not** apply. Nobody can depend on behavior that never
  happened, so a deprecation period helps no one.
- The CHANGELOG `Removed` entry **still does**, for the reason above.

It also sets an evidence standard, so the clause cannot be claimed by assertion. Inertness must
be verified as read-nowhere under the module owning the surface, confirmed at the merge base,
with the search scope stated in the commit message so a reviewer can reproduce it.

Scope is load-bearing in both directions, which is why it is written into the clause rather than
left to judgment. The same option name can be live on one surface and inert on another, so a
repo-wide search answers the wrong question and can support either conclusion. The removal this
clause was written alongside has exactly that shape: `--resume-on-timeout` was read nowhere
under `lionagi/cli/orchestrate/` while the same option remained functional on `li agent`
(#3071).

## Scope

Documentation only. No code, no public surface change, so no CHANGELOG entry is owed under
section 4. Section 0's own-use scope already waives the section 2 cycle for this repository
while that directive stands; this clause governs the packages this repository ships to external
callers, and stands on its own terms regardless.