### PR TITLE
perf(mcp): cut the verb catalog by a third and route unavailable verbs

### DIFF
--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -90,18 +90,32 @@ relative timestamps, formatted durations, or tables.
   "verbs": [
     {
       "verb": "agent.submit",
-      "available": true,
       "summary": "Run one agent on one task as a detached background run.",
-      "required": []
+      "required_unenforced": ["query"],
+      "schema_fingerprint": "ae06438e99123763"
+    },
+    {
+      "verb": "schedule.apply",
+      "available": false,
+      "summary": "Reconcile a whole ScheduleSet file into the store, atomically.",
+      "cli_path": "schedule apply"
     }
   ],
-  "verb_count": 68,
-  "available_count": 40,
+  "verb_count": 70,
+  "available_count": 44,
   "max_ops": 8,
   "help_usage": "help=true returns this catalog; help='<verb>' returns that verb's full parameter schema; ...",
   "synonyms_removed_after": "2026-09-30"
 }
 ```
+
+An entry states only what it cannot be read without. `available` and `required`
+are omitted at their defaults, so a verb with neither key is available and takes
+no required parameters. A verb that is not served here says so and names the
+`cli_path` that does run it, rather than repeating why; `help='<verb>'` returns
+that reason. The one entry that carries a reason inline is a verb whose schema
+failed to build, which reports a defect in this server rather than a deliberate
+exclusion.
 
 `help='<verb>'` returns that one verb's full parameter schema:
 

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -135,13 +135,24 @@ def catalog() -> dict[str, Any]:
     nothing extra). Where the schema depends on an argument, no fingerprint is
     quoted — it would never match — and the entry instead names the parameter
     it varies with.
+
+    Every caller pays for this listing, so an entry states only what it cannot
+    be read without. ``available`` and ``required`` are omitted at their
+    defaults, and an unavailable verb names the ``cli_path`` that does run it
+    rather than repeating the paragraph on why it is not served here — that
+    paragraph is what ``help='<verb>'`` returns. A verb whose schema failed to
+    build is the exception and keeps its reason inline: it reports a defect in
+    this server rather than a deliberate exclusion, and it must not need a
+    second call to be noticed.
     """
     entries: list[dict[str, Any]] = []
     for verb in VERBS.values():
-        entry: dict[str, Any] = {"verb": verb.name, "available": True, "summary": verb.summary}
+        entry: dict[str, Any] = {"verb": verb.name, "summary": verb.summary}
         try:
             schema = verb_schema(verb)
-            entry["required"] = list(schema.get("required", []))
+            required = list(schema.get("required", []))
+            if required:
+                entry["required"] = required
             unenforced = list(schema.get("x-required-unenforced", []))
             if unenforced:
                 entry["required_unenforced"] = unenforced
@@ -157,26 +168,27 @@ def catalog() -> dict[str, Any]:
                 "verb": absent.name,
                 "available": False,
                 "summary": absent.summary,
-                "reason": absent.reason,
+                "cli_path": absent.cli_path,
             }
         )
-    available = [e for e in entries if e["available"]]
+    available = [e for e in entries if e.get("available", True)]
     return {
         "verbs": entries,
         "verb_count": len(entries),
         "available_count": len(available),
         "max_ops": MAX_OPS,
         "help_usage": (
-            "help=true returns this catalog; help='<verb>' returns that verb's full "
-            "parameter schema; help={'verb': '<verb>', 'playbook': '<name>'} resolves a "
-            "playbook's own declared arguments into the schema. An entry carrying a "
-            "schema_fingerprint names a verb whose ops must repeat it: "
-            "{'op': 'agent.submit', 'args': {...}, 'schema_fingerprint': '<from this entry>'}. "
-            "An entry carrying schema_fingerprint_varies_with names the parameters that "
-            "change the schema: pass one of them and the fingerprint to send is the one "
-            "help returns for that spelling, not the one quoted here. "
-            "required_unenforced names parameters the parser will not refuse a call for "
-            "omitting but the command cannot do its work without."
+            "help='<verb>' returns that verb's full parameter schema, and for an "
+            "unavailable one the reason it is not served here. "
+            "help={'verb': '<verb>', 'playbook': '<name>'} resolves a playbook's own "
+            "declared arguments into the schema. An entry omits 'available' and "
+            "'required' when they are true and empty. A schema_fingerprint must be "
+            "repeated on that verb's ops as a sibling of 'args': "
+            "{'op': 'agent.submit', 'args': {...}, 'schema_fingerprint': '<from this entry>'}; "
+            "where the entry carries schema_fingerprint_varies_with instead, pass one of "
+            "the parameters it names to help and send the fingerprint returned for that "
+            "spelling. required_unenforced names parameters the parser will not refuse a "
+            "call for omitting but the command cannot do its work without."
         ),
         "synonyms_removed_after": SYNONYM_REMOVAL_DATE,
     }

--- a/tests/contracts/_capture.py
+++ b/tests/contracts/_capture.py
@@ -21,6 +21,7 @@ import socket
 import subprocess
 import sys
 import time
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -604,7 +605,24 @@ def capture_mcp() -> dict[str, Any]:
             "available_count": catalog["available_count"],
             "max_ops": catalog["max_ops"],
             "verb_names": sorted(v["verb"] for v in catalog["verbs"]),
-            "available_verb_names": sorted(v["verb"] for v in catalog["verbs"] if v["available"]),
+            # the catalog omits `available` at its default, so absence means available
+            "available_verb_names": sorted(
+                v["verb"] for v in catalog["verbs"] if v.get("available", True)
+            ),
+            # Which keys an entry carries is the contract every caller reads, and
+            # names and counts alone are blind to it: fields can be added to or
+            # dropped from all 70 entries without moving anything above. Held as
+            # the distinct key sets with their frequency, so the baseline moves on
+            # a shape change without carrying a row per verb.
+            # lists rather than tuples: this is compared against the JSON
+            # baseline, which has no tuple to round-trip back to
+            "entry_key_sets": [
+                [sorted(shape), count]
+                for shape, count in sorted(
+                    Counter(frozenset(v) for v in catalog["verbs"]).items(),
+                    key=lambda kv: sorted(kv[0]),
+                )
+            ],
         },
         "projections": projections,
         "projection_count": len(projections),

--- a/tests/contracts/data/mcp.json
+++ b/tests/contracts/data/mcp.json
@@ -198,6 +198,61 @@
       "team.receive",
       "team.send",
       "team.show"
+    ],
+    "entry_key_sets": [
+      [
+        [
+          "available",
+          "cli_path",
+          "summary",
+          "verb"
+        ],
+        26
+      ],
+      [
+        [
+          "required",
+          "required_unenforced",
+          "schema_fingerprint_varies_with",
+          "summary",
+          "verb"
+        ],
+        1
+      ],
+      [
+        [
+          "required",
+          "summary",
+          "verb"
+        ],
+        24
+      ],
+      [
+        [
+          "required_unenforced",
+          "schema_fingerprint",
+          "schema_fingerprint_varies_with",
+          "summary",
+          "verb"
+        ],
+        1
+      ],
+      [
+        [
+          "required_unenforced",
+          "schema_fingerprint",
+          "summary",
+          "verb"
+        ],
+        2
+      ],
+      [
+        [
+          "summary",
+          "verb"
+        ],
+        16
+      ]
     ]
   },
   "projections": {

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -314,6 +314,29 @@ def test_mcp_catalog_matches_baseline():
     assert live["catalog"] == expected["catalog"]
 
 
+def test_mcp_catalog_entry_shapes_are_locked_by_hand():
+    """Second, independent lock on the shape of a catalog entry.
+
+    Every caller reads this listing, so a field added to or dropped from all 70
+    entries changes what the whole surface says while leaving verb names and
+    counts identical. Hand-typed rather than derived from the JSON, so the
+    baseline and this test have to be wrong the same way to pass together.
+    """
+    live = _capture.capture_mcp()
+    shapes = {tuple(keys): count for keys, count in live["catalog"]["entry_key_sets"]}
+    assert sum(shapes.values()) == 70
+    # a deliberately unavailable verb says so and routes the caller; its reason
+    # is one targeted help call away rather than in every read of the listing
+    assert shapes[("available", "cli_path", "summary", "verb")] == 26
+    # a runnable verb with no required parameters carries neither key
+    assert shapes[("summary", "verb")] == 16
+    # No shape pairs cli_path with an inline reason. A verb whose schema failed
+    # to build is the one entry that does carry a reason inline, and it has no
+    # cli_path — that path reports a defect in this server and must stay
+    # readable without a second call, so it is not asserted away here.
+    assert not any("cli_path" in keys and "reason" in keys for keys in shapes)
+
+
 def test_mcp_projections_match_baseline():
     expected = _load("mcp")
     live = _capture.capture_mcp()

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -324,12 +324,29 @@ def test_mcp_catalog_entry_shapes_are_locked_by_hand():
     """
     live = _capture.capture_mcp()
     shapes = {tuple(keys): count for keys, count in live["catalog"]["entry_key_sets"]}
+    # The complete mapping, not a sample of it: asserting two shapes leaves the
+    # other four free to change under a refreshed baseline without anything
+    # here noticing.
+    assert shapes == {
+        # a deliberately unavailable verb says so and routes the caller; its
+        # reason is one targeted help call away, not in every read of the listing
+        ("available", "cli_path", "summary", "verb"): 26,
+        # a runnable verb with required parameters names them and nothing else
+        ("required", "summary", "verb"): 24,
+        # a runnable verb with no required parameters carries neither key
+        ("summary", "verb"): 16,
+        # spawn verbs additionally publish what their fingerprint covers
+        ("required_unenforced", "schema_fingerprint", "summary", "verb"): 2,
+        ("required", "required_unenforced", "schema_fingerprint_varies_with", "summary", "verb"): 1,
+        (
+            "required_unenforced",
+            "schema_fingerprint",
+            "schema_fingerprint_varies_with",
+            "summary",
+            "verb",
+        ): 1,
+    }
     assert sum(shapes.values()) == 70
-    # a deliberately unavailable verb says so and routes the caller; its reason
-    # is one targeted help call away rather than in every read of the listing
-    assert shapes[("available", "cli_path", "summary", "verb")] == 26
-    # a runnable verb with no required parameters carries neither key
-    assert shapes[("summary", "verb")] == 16
     # No shape pairs cli_path with an inline reason. A verb whose schema failed
     # to build is the one entry that does carry a reason inline, and it has no
     # cli_path — that path reports a defect in this server and must stay

--- a/tests/mcp/test_catalog_sufficiency.py
+++ b/tests/mcp/test_catalog_sufficiency.py
@@ -156,7 +156,8 @@ def test_a_catalog_built_call_to_an_ordinary_read_verb_succeeds(tmp_path) -> Non
         client.initialize()
         catalog = client.request(help=True)
         entry = _entry(catalog, "job.list")
-        assert entry["required"] == []
+        # no required parameters is spelled by omitting the key
+        assert entry.get("required", []) == []
         assert "schema_fingerprint" not in entry
         result = client.op("job.list", {})
 

--- a/tests/mcp/test_catalog_sufficiency.py
+++ b/tests/mcp/test_catalog_sufficiency.py
@@ -105,8 +105,12 @@ def test_a_positional_the_parser_will_not_enforce_is_still_reported(catalog: dic
 
 def test_the_unenforced_parameters_are_real_parameters(catalog: dict) -> None:
     """A name reported here has to be one the caller may actually pass."""
+    checked = 0
     for entry in catalog["verbs"]:
-        if not entry.get("available"):
+        # An available verb carries no "available" key; only an unavailable one
+        # says so. Reading it without the default skips every entry and leaves
+        # this test asserting nothing at all.
+        if not entry.get("available", True):
             continue
         named = entry.get("required_unenforced")
         if not named:
@@ -114,6 +118,8 @@ def test_the_unenforced_parameters_are_real_parameters(catalog: dict) -> None:
         schema = dispatch.verb_schema(dispatch.VERBS[entry["verb"]])
         for parameter in named:
             assert parameter in schema["properties"]
+            checked += 1
+    assert checked, "no unenforced parameter was checked; this test proved nothing"
 
 
 @pytest.mark.parametrize("verb", ["agent.submit", "flow.submit", "fanout.submit"])

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -70,12 +70,32 @@ def test_catalog_carries_a_signature_not_a_bare_name():
     assert all(e["summary"] for e in entries.values())
 
 
-def test_catalog_names_an_unavailable_verb_with_its_reason():
+def test_catalog_names_an_unavailable_verb_and_routes_it():
     # Hiding it would make "not built" and "cannot be built yet" the same answer.
+    # The catalog states that it cannot run and where it does run; the paragraph
+    # on why is one targeted call away, so every caller does not pay for it.
     entries = {e["verb"]: e for e in call(help=True)["verbs"]}
     absent = entries["schedule.apply"]
     assert absent["available"] is False
-    assert "machine result" in absent["reason"]
+    assert absent["cli_path"] == "schedule apply"
+    assert "reason" not in absent
+    assert "machine result" in call(help="schedule.apply")["reason"]
+
+
+def test_catalog_omits_available_and_required_at_their_defaults():
+    # Both are paid on every entry of a 70-verb listing. Absent means the
+    # default, which the catalog's own help_usage states. Asserted over the
+    # whole listing rather than one entry: the cost is per-entry, so a single
+    # example would not show that the default is omitted everywhere.
+    catalog = call(help=True)
+    entries = catalog["verbs"]
+    assert entries, "an empty catalog would pass every assertion below"
+    assert [e["verb"] for e in entries if e.get("available") is True] == []
+    assert [e["verb"] for e in entries if e.get("required") == []] == []
+    # and the key still carries its non-default value where it applies
+    assert any(e.get("available") is False for e in entries)
+    assert any(e.get("required") for e in entries)
+    assert catalog["available_count"] == sum(1 for e in entries if e.get("available", True))
 
 
 def test_catalog_never_advertises_a_previous_surface_name():

--- a/tests/mcp/test_machine_observability.py
+++ b/tests/mcp/test_machine_observability.py
@@ -344,7 +344,9 @@ def test_a_window_that_cannot_be_parsed_is_refused_inside_the_envelope(home):
 def test_the_plugin_listing_is_named_and_refused_with_why(home):
     entry = next(e for e in call(help=True)["verbs"] if e["verb"] == "plugin.list")
     assert entry["available"] is False
-    assert "trust" in entry["reason"]
+    assert entry["cli_path"]
+    # the why is one targeted call away rather than in every catalog read
+    assert "trust" in call(help="plugin.list")["reason"]
     op = run_op("plugin.list")
     assert op["ok"] is False
     assert op["error"]["kind"] == "unavailable"

--- a/tests/mcp/test_roster.py
+++ b/tests/mcp/test_roster.py
@@ -290,7 +290,8 @@ def test_a_cwd_that_is_not_a_directory_is_refused_by_name(roots, tmp_path: Path)
 
 def test_the_roster_verbs_are_in_the_catalog_with_their_signature():
     entries = {e["verb"]: e for e in call(help=True)["verbs"]}
-    assert entries["profile.list"]["available"] is True
+    # available is omitted at its default; the key appears only to say False
+    assert "available" not in entries["profile.list"]
     assert entries["profile.show"]["required"] == ["name"]
 
 


### PR DESCRIPTION
## What

`help=true` is the listing every MCP caller reads to orient, and a third of it
was spent on prose that does not help anyone make a call.

Each of the 26 deliberately-unavailable verbs carried a paragraph explaining
why it is not served here. Those paragraphs come from 14 distinct strings
repeated across the 26 entries, and they cost ~1,282 tokens on every catalog
read. Meanwhile `cli_path`, the field that names the command which *does* run
the verb, was already on the source dataclass and was never emitted.

So this swaps them. The listing now says a verb is unavailable and where it
runs; the paragraph is what `help='<verb>'` already returned, so nothing became
unreachable. `available` and `required` are omitted at their defaults, which the
catalog's own `help_usage` states.

One case is deliberately left alone: a verb whose schema *fails to build* keeps
its reason inline. That path reports a defect in this server rather than a
design decision, and it must not need a second call to be noticed.

## Measured

| | before | after |
|---|---|---|
| `help=true` | ~4,335 tokens | ~2,960 tokens (**-32%**) |

The catalog also gains a routing field it never had.

## The baseline was blind to this

Worth flagging on its own. `capture_mcp` recorded verb names and counts but not
which keys an entry carries, so changing what all 70 entries tell callers left
**every captured field identical** and the frozen baseline stayed green. The
first run of the changed code against the old baseline reported "Omitting 5
identical items".

The capture now records the distinct entry key sets with their frequency. That
is the entire 55-line addition to `mcp.json`; nothing in the file was removed or
reordered. A second, hand-typed lock on the same shape lives in
`test_public_surfaces.py` and was mutation-probed (26 -> 25 goes red).

Unchanged and re-verified: `verb_count` 70, `available_count` 44,
`available_path_count` 75, `projection_count` 62, `projection_error_count` 13,
`absent_verb_count` 26, and the full absent-verb capture including every reason
string.

## Tests

`tests/mcp` and `tests/contracts` green. Four tests that asserted the old shape
were updated to assert the guarantee where it now lives rather than weakened:
the reason is checked through `help='<verb>'`, and the default-omission is
asserted over the whole listing instead of one entry.