### PR TITLE
fix(dispatch): let the delivery scan record its actual caller

### DIFF
--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -781,7 +781,9 @@ shell), so shell metacharacters are inert.
   each row's `transition()` call are separate transactions, so a concurrent
   `purge_dispatch(es)` can delete a snapshotted row; `transition()` raises `LookupError` in
   that case, caught per-row so one purged row is skipped without aborting the rest of the
-  batch.
+  batch. Every transition the scan writes carries the caller's `actor`, defaulting to the
+  scheduler tick's own identity; a driver other than the scheduler passes its own so the
+  history does not attribute its writes to the scheduler.
 - `purge_dispatch()` / `purge_dispatches()` — `purge_dispatch` accepts any status (naming an
   exact id is already deliberate non-bulk intent) and writes one `admin_events` audit row on
   success. `purge_dispatches` requires `status` and/or `before` (bare call raises

--- a/lionagi/dispatch/outbox.py
+++ b/lionagi/dispatch/outbox.py
@@ -334,17 +334,25 @@ async def deliver_due_dispatches(
     *,
     now: float | None = None,
     notify_template: list[str] | None = None,
+    actor: Actor | None = None,
 ) -> dict[str, int]:
     """Scan due pending/delivering rows and attempt delivery. Called from the scheduler tick.
 
     Ack-required rows loop back to pending until acked/expired/exhausted;
     claims use a time-boxed lease plus a guarded attempt-counter CAS so
     overlapping scans can't double-deliver. See docs/internals/runtime.md.
+
+    ``actor`` is recorded on every transition this scan writes and defaults to
+    the scheduler tick's own identity. A caller driving delivery from anywhere
+    else must pass its own, or the history will attribute its writes to the
+    scheduler.
     """
     if now is None:
         now = time.time()
     if notify_template is None:
         notify_template = resolve_notify_template()
+    if actor is None:
+        actor = Actor(type="scheduler", id="dispatch_delivery_loop")
 
     counts = {"attempted": 0, "delivered": 0, "dead_letter": 0, "expired": 0, "retried": 0}
 
@@ -369,7 +377,7 @@ async def deliver_due_dispatches(
         dispatch_id = row["id"]
         try:
             await _deliver_one_due_row(
-                db, row, now=now, notify_template=notify_template, counts=counts
+                db, row, now=now, notify_template=notify_template, counts=counts, actor=actor
             )
         except LookupError:
             _log.debug(
@@ -388,6 +396,7 @@ async def _deliver_one_due_row(
     now: float,
     notify_template: list[str] | None,
     counts: dict[str, int],
+    actor: Actor,
 ) -> None:
     """Claim-and-deliver one due row; per-row so a mid-scan ``LookupError``
     (row purged concurrently) can be caught without aborting the batch.
@@ -407,7 +416,7 @@ async def _deliver_one_due_row(
                     code=DispatchReasons.EXPIRED_DEADLINE,
                     summary="expires_at reached before delivery",
                 ),
-                actor=Actor(type="scheduler", id="dispatch_delivery_loop"),
+                actor=actor,
                 idempotency_key=f"expire:{dispatch_id}:{row['attempt']}",
             ),
         )
@@ -427,7 +436,7 @@ async def _deliver_one_due_row(
                 code=DispatchReasons.DELIVERING_ATTEMPT,
                 summary=f"attempt {next_attempt}",
             ),
-            actor=Actor(type="scheduler", id="dispatch_delivery_loop"),
+            actor=actor,
             idempotency_key=f"deliver:{dispatch_id}:{row['attempt']}",
         ),
         # Guard on pre-claim attempt (not just status) so a second
@@ -466,7 +475,7 @@ async def _deliver_one_due_row(
                         code=DispatchReasons.DEAD_LETTER_ACK_TIMEOUT,
                         summary=f"{next_attempt} sends without ack (max_attempts exhausted)",
                     ),
-                    actor=Actor(type="scheduler", id="dispatch_delivery_loop"),
+                    actor=actor,
                     idempotency_key=f"ack_timeout:{dispatch_id}:{next_attempt}",
                 ),
             )
@@ -491,7 +500,7 @@ async def _deliver_one_due_row(
                     code=DispatchReasons.DELIVERED_TRANSPORT_OK,
                     summary=("transport command exited 0; consumer acknowledgement not implied"),
                 ),
-                actor=Actor(type="scheduler", id="dispatch_delivery_loop"),
+                actor=actor,
                 idempotency_key=f"delivered:{dispatch_id}:{next_attempt}",
             ),
             patch=patch,
@@ -518,7 +527,7 @@ async def _deliver_one_due_row(
                     code=DispatchReasons.DEAD_LETTER_MAX_ATTEMPTS,
                     summary=f"{next_attempt} attempts exhausted: {err}",
                 ),
-                actor=Actor(type="scheduler", id="dispatch_delivery_loop"),
+                actor=actor,
                 idempotency_key=f"dead_letter:{dispatch_id}:{next_attempt}",
             ),
         )
@@ -538,7 +547,7 @@ async def _deliver_one_due_row(
                 code=DispatchReasons.PENDING_RETRY_BACKOFF,
                 summary=f"retry in {backoff:.0f}s: {err}",
             ),
-            actor=Actor(type="scheduler", id="dispatch_delivery_loop"),
+            actor=actor,
             idempotency_key=f"retry:{dispatch_id}:{next_attempt}",
         ),
     )

--- a/tests/dispatch/test_outbox.py
+++ b/tests/dispatch/test_outbox.py
@@ -936,3 +936,104 @@ async def test_payload_delivered_via_stdin_when_template_has_no_placeholder(tmp_
     assert counts["delivered"] == 1
     captured = out_path.read_text()
     assert '"z": 9' in captured
+
+
+# ── delivery-loop identity (who the history says wrote the row) ──────────────
+
+# Every transition the delivery scan writes: one per write site in the loop.
+_LOOP_REASON_CODES = {
+    "dispatch.delivering.attempt",
+    "dispatch.delivered.transport_ok",
+    "dispatch.pending.retry_backoff",
+    "dispatch.dead_letter.max_attempts",
+    "dispatch.dead_letter.ack_timeout",
+    "dispatch.expired.deadline",
+}
+
+
+async def _loop_identities(db) -> dict[str, set[tuple[str, str]]]:
+    """reason_code -> {(source, actor)} for every delivery-loop history row."""
+    async with db._read() as conn:
+        rows = (
+            (
+                await conn.execute(
+                    text(
+                        "SELECT reason_code, source, actor FROM status_transitions "
+                        "WHERE entity_type = 'dispatch'"
+                    )
+                )
+            )
+            .mappings()
+            .all()
+        )
+    seen: dict[str, set[tuple[str, str]]] = {}
+    for row in rows:
+        if row["reason_code"] in _LOOP_REASON_CODES:
+            seen.setdefault(row["reason_code"], set()).add((row["source"], row["actor"]))
+    return seen
+
+
+async def _drive_every_loop_write_site(db, *, actor=None) -> dict[str, set[tuple[str, str]]]:
+    """Enqueue rows that between them reach all six loop write sites, scan twice
+    (the notify template is per-scan, so success and failure need separate scans),
+    and return the identities the history recorded.
+    """
+    kw = {} if actor is None else {"actor": actor}
+
+    # expired: past deadline, resolved before any transport runs.
+    await enqueue_dispatch(
+        db, kind="terminal_notify", deliver_to="seat-1", expires_at=time.time() - 60
+    )
+    # delivered: transport exits 0, no ack required.
+    await enqueue_dispatch(db, kind="terminal_notify", deliver_to="seat-2")
+    # dead_letter via ack timeout: sends fine, never acked, attempts exhausted.
+    await enqueue_dispatch(
+        db, kind="terminal_notify", deliver_to="seat-3", ack_required=True, max_attempts=1
+    )
+    # now is sampled after enqueue: rows are due at next_attempt_at <= now.
+    await deliver_due_dispatches(db, now=time.time(), notify_template=_SUCCESS_TEMPLATE, **kw)
+
+    # retried: transport fails with attempts left.
+    await enqueue_dispatch(db, kind="terminal_notify", deliver_to="seat-4", max_attempts=3)
+    # dead_letter via max_attempts: transport fails with no attempts left.
+    await enqueue_dispatch(db, kind="terminal_notify", deliver_to="seat-5", max_attempts=1)
+    await deliver_due_dispatches(db, now=time.time(), notify_template=_FAIL_TEMPLATE, **kw)
+
+    return await _loop_identities(db)
+
+
+async def test_delivery_loop_records_the_caller_supplied_actor(tmp_path: Path):
+    """A caller that is not the scheduler tick must be able to say so: the actor
+    it passes is what the history attributes every one of the loop's writes to.
+    """
+    from lionagi.state.transitions import Actor
+
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        seen = await _drive_every_loop_write_site(
+            db, actor=Actor(type="agent", id="fleet-delivery-worker-7")
+        )
+
+    # Non-vacuous: the scenarios really did reach all six write sites.
+    assert set(seen) == _LOOP_REASON_CODES
+
+    for code, identities in seen.items():
+        assert identities == {("agent", "fleet-delivery-worker-7")}, (
+            f"{code} was attributed to {identities}"
+        )
+
+
+async def test_delivery_loop_defaults_to_the_scheduler_identity(tmp_path: Path):
+    """Omitting ``actor`` keeps the scheduler tick's own identity, which is what
+    the only in-tree caller is.
+    """
+    db_path = tmp_path / "state.db"
+    async with StateDB(db_path) as db:
+        seen = await _drive_every_loop_write_site(db)
+
+    assert set(seen) == _LOOP_REASON_CODES
+
+    for code, identities in seen.items():
+        assert identities == {("scheduler", "dispatch_delivery_loop")}, (
+            f"{code} was attributed to {identities}"
+        )


### PR DESCRIPTION
## What

`deliver_due_dispatches()` writes up to six lifecycle transitions per scan (claim, delivered, retry backoff, both dead-letter paths, expiry). Every one of them hard-coded `Actor(type="scheduler", id="dispatch_delivery_loop")`.

The scheduler tick is the only in-tree caller, so today's rows are accurate. But `status_transitions` is a durable history: any other driver of the delivery loop would have had its writes permanently attributed to the scheduler, and that is not correctable after the fact.

## Change

`deliver_due_dispatches()` takes a keyword-only `actor`, threaded to all six write sites, defaulting to the scheduler identity. The scheduler engine's call site and the history it produces are unchanged. This is the convention `purge_dispatch()` / `purge_dispatches()` already follow.

None of the six edges carries an `actor_types` restriction in the lifecycle policy — that applies only to the operator-recovery edges out of `dead_letter` / `expired` — so the injected actor's type is unconstrained.

## Tests

Two tests drive scenarios that between them reach all six write sites and assert the recorded `(source, actor)` pair for each, in the injected case and the default case.

They assert *which* reason codes were observed rather than only checking the rows they happen to find. That is load-bearing: the first version of these tests found zero delivery rows (the scan sampled `now` before the enqueues, so nothing was due) and would have passed green over an empty result without it.

Verified by mutation: reverting a single write site to the hard-coded actor reddens the injected-actor test on exactly that reason code. The defaults test stays green under that mutant, since the mutant is indistinguishable from the default — only the injected-actor test discriminates.

## Scope

`ack_dispatch()` and `retry_dispatch()` still name themselves `li_dispatch_ack` / `li_dispatch_retry`. Those are honest: the CLI is their only caller. They would need the same treatment if a non-CLI caller is ever added.