### PR TITLE
test(lionbench): drop a real home-directory path from a fixture value

### DIFF
--- a/benchmarks/orchestration/suites/lionbench/test_data_hygiene.py
+++ b/benchmarks/orchestration/suites/lionbench/test_data_hygiene.py
@@ -34,7 +34,7 @@ _BANNED_SUBSTRINGS = (
 _UUID_RE = re.compile(
     r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
 )
-# Internal actor identifiers look like "lambda:leo"/"lambda:khive" — no space after
+# Internal actor identifiers are spelled "lambda:<name>" — no space after
 # the colon. A bare "lambda:" substring also matches Python's own zero-arg lambda
 # syntax ("lambda: mock_db"), which is unavoidable in harvested test_patch content
 # (any repo with mocked callables uses it) and is not a leak. ruff-formatted Python

--- a/benchmarks/orchestration/suites/lionbench/test_schema.py
+++ b/benchmarks/orchestration/suites/lionbench/test_schema.py
@@ -93,7 +93,7 @@ def test_save_instance_redacts_validation_output_and_nominated_by_on_disk(tmp_pa
     nomination rationale (can name the fix) must never reach a committed instance
     JSON — the write path redacts them, not a manual step."""
     inst = _make_instance(subject="python-framework")
-    inst.validation.gold_output = "at /Users/lion/.lionagi/swebench-work/repos/_x ok"
+    inst.validation.gold_output = "at /Users/example/.lionagi/swebench-work/repos/_x ok"
     inst.validation.null_output = "some local failure trace"
     path = save_instance(inst, tmp_path)
 


### PR DESCRIPTION
A redaction test supplies a leaky-looking string and asserts the write path empties it. The string it supplied named a real user's home directory.

The test needs *an* absolute path as input. It does not need a real one, and the assertion only checks that the field comes back empty, so any absolute path serves it identically. Swapped for `/Users/example/...`.

Also generalised a comment in the neighbouring leak detector that illustrated the actor-identifier shape with two real internal names. The detector matches on shape (`lambda:` not followed by whitespace, which separates it from Python's own zero-arg lambda syntax), so the examples were carrying no weight.

Both files' tests pass unchanged. The detector itself is untouched — this is fixture data and a comment, not a loosening of what gets caught.