### PR TITLE
docs(state): describe the rebuild order the code actually executes

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1282,7 +1282,14 @@ class StateDB:
 
     async def _rebuild_legacy_sessions_table(self) -> None:
         """Rebuild sessions if it carries either legacy CHECK: the 4-value status
-        vocabulary, or a source_kind that predates the codex-import provenance value."""
+        vocabulary, or a source_kind that predates the codex-import provenance value.
+
+        The rebuild pattern the other legacy-CHECK rebuilds refer back to, in the
+        order it executes: CREATE new → INSERT SELECT → DROP old → RENAME. The
+        table being replaced keeps its own name until the DROP; it is the new
+        table that is built alongside under a temporary name and renamed into
+        place last.
+        """
         if self.dialect != "sqlite":
             return
         async with self._engine.connect() as conn:
@@ -1441,8 +1448,8 @@ class StateDB:
         """Rebuild ``schedules`` if it still carries the legacy action_kind CHECK.
 
         The old CHECK omits ``'flow_yaml'``; SQLite cannot drop a constraint via
-        ALTER TABLE, so we use the rename → CREATE new → INSERT SELECT → DROP
-        old pattern (same as ``_rebuild_legacy_sessions_table``).
+        ALTER TABLE, so we use the CREATE new → INSERT SELECT → DROP old →
+        RENAME pattern (same as ``_rebuild_legacy_sessions_table``).
         """
         if self.dialect != "sqlite":
             return
@@ -1545,7 +1552,7 @@ class StateDB:
         """Rebuild ``schedules`` if its action_kind CHECK still omits 'command'.
 
         SQLite cannot widen a CHECK constraint via ALTER TABLE, so this uses
-        the same rename -> CREATE new -> INSERT SELECT -> DROP old pattern as
+        the same CREATE new -> INSERT SELECT -> DROP old -> RENAME pattern as
         ``_drop_legacy_action_kind_check``. Runs after ``_reconcile_columns``
         (via ``_apply_schema``), so the ADD COLUMN for action_command /
         action_command_args has already landed on the pre-rebuild table.
@@ -1648,7 +1655,7 @@ class StateDB:
     async def _drop_legacy_schedules_trigger_type_check(self) -> None:
         """Rebuild ``schedules`` if its trigger_type CHECK still omits 'at'.
 
-        Same rename -> CREATE new -> INSERT SELECT -> DROP old pattern as
+        Same CREATE new -> INSERT SELECT -> DROP old -> RENAME pattern as
         ``_drop_legacy_schedules_command_check``.
         """
         if self.dialect != "sqlite":
@@ -1737,7 +1744,7 @@ class StateDB:
         """Rebuild ``invocations`` if its status CHECK still omits 'completed_empty'.
 
         SQLite cannot drop a constraint via ALTER TABLE, so we use the same
-        rename → CREATE new → INSERT SELECT → DROP old pattern as
+        CREATE new → INSERT SELECT → DROP old → RENAME pattern as
         ``_rebuild_legacy_sessions_table`` / ``_drop_legacy_action_kind_check``.
         """
         if self.dialect != "sqlite":
@@ -1885,8 +1892,8 @@ class StateDB:
         """Rebuild ``schedule_runs`` if it still carries the legacy status CHECK.
 
         SQLite cannot widen a CHECK constraint nor drop a NOT NULL via ALTER
-        TABLE, so this uses the same rename → CREATE new → INSERT SELECT →
-        DROP old pattern as ``_drop_legacy_action_kind_check`` /
+        TABLE, so this uses the same CREATE new → INSERT SELECT → DROP old →
+        RENAME pattern as ``_drop_legacy_action_kind_check`` /
         ``_drop_legacy_invocations_status_check``. Takes a pre-rebuild backup
         of the database file first (``_backup_before_rebuild``); see its
         docstring for the rollback path.
@@ -2075,7 +2082,7 @@ class StateDB:
         """Rebuild ``definitions`` if it still carries the pre-skill-editor kind CHECK.
 
         SQLite cannot widen a CHECK constraint via ALTER TABLE, so this uses
-        the same rename → CREATE new → INSERT SELECT → DROP old pattern as
+        the same CREATE new → INSERT SELECT → DROP old → RENAME pattern as
         ``_drop_legacy_action_kind_check``. ``definitions`` is not itself an
         FK target, but the foreign_keys-off dance is applied anyway to match
         every other rebuild in this file rather than special-casing this one


### PR DESCRIPTION
Six of the legacy-CHECK table rebuilds in `lionagi/state/db.py` describe themselves as a `rename → CREATE new → INSERT SELECT → DROP old` pattern. None of them renames anything first.

Measured across all seven rebuild sites, by extracting the DDL statements from each closure in source order:

```
_rebuild_legacy_sessions_table            CREATE -> INSERT -> DROP -> RENAME
_drop_legacy_action_kind_check            CREATE -> INSERT -> DROP -> RENAME
_drop_legacy_schedules_command_check      CREATE -> INSERT -> DROP -> RENAME
_drop_legacy_schedules_trigger_type_check CREATE -> INSERT -> DROP -> RENAME
_drop_legacy_invocations_status_check     CREATE -> INSERT -> DROP -> RENAME
_drop_legacy_schedule_runs_check          CREATE -> INSERT -> DROP -> RENAME
_drop_legacy_definitions_kind_check       CREATE -> INSERT -> DROP -> RENAME
```

The replacement is built alongside under a temporary name and renamed into place last; the table being replaced keeps its own name until the `DROP`. That is the opposite of what the docstrings said.

This matters because it is a destructive migration path over five tables, and the described order implies a different recovery shape than the one that exists. The file already contradicted itself on this: a comment further down reasons about "a crash between DROP and RENAME", a window that only exists in the order the code actually runs.

The pattern is now stated once on `_rebuild_legacy_sessions_table` (which the others already cite as the definition, and which described no order at all), and the six references that named the wrong one agree with it.

**Docstrings only.** Verified by parsing both revisions and comparing the syntax trees with docstrings stripped: identical, with a positive control confirming the comparison detects an injected statement. No code lines appear in the diff.
