### PR TITLE
fix(state,cli): carry end-time provenance through the machine-readable readers

### DIFF
--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -526,6 +526,10 @@ def _lifecycle_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
             "terminal": row.get("status") in SESSION_TERMINAL_STATUSES,
             "started_at": row.get("started_at"),
             "ended_at": row.get("ended_at"),
+            # Travels with the `ended_at` beside it. A row repaired after the
+            # fact carries an end nobody observed, and handed over bare it is
+            # arithmetic-identical to a measured one.
+            "ended_at_is_approximate": bool(row.get("ended_at_is_approximate")),
             "reason_code": row.get("status_reason_code"),
             "reason_summary": row.get("status_reason_summary"),
         }
@@ -540,6 +544,10 @@ def _lifecycle_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
             "reason_code": None,
             "reason_summary": None,
             "ended_at": None,
+            # Present on every branch. A key that appears only when the run
+            # ended forces the consumer to distinguish absent from null, and
+            # the ones that do not will read absent as measured.
+            "ended_at_is_approximate": None,
             "sessions": [],
         }
 
@@ -554,6 +562,7 @@ def _lifecycle_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
             "reason_code": governing["reason_code"],
             "reason_summary": governing["reason_summary"],
             "ended_at": None,
+            "ended_at_is_approximate": None,
             "sessions": sessions,
         }
 
@@ -571,7 +580,12 @@ def _lifecycle_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
         governing = next(
             entry for entry in sessions if entry["status"] not in _SUCCEEDED_SESSION_STATUSES
         )
-    ends = [entry["ended_at"] for entry in sessions if entry["ended_at"] is not None]
+    # The run's end IS one of the session ends, so it carries that row's
+    # provenance rather than a fresh judgement about the run. Taking the max of
+    # the timestamps alone would drop the only thing that says whether the
+    # winning end was observed.
+    ended = [entry for entry in sessions if entry["ended_at"] is not None]
+    latest = max(ended, key=lambda entry: entry["ended_at"]) if ended else None
     return {
         "found": True,
         "terminal": True,
@@ -579,7 +593,8 @@ def _lifecycle_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "outcome": outcome,
         "reason_code": governing["reason_code"],
         "reason_summary": governing["reason_summary"],
-        "ended_at": max(ends) if ends else None,
+        "ended_at": latest["ended_at"] if latest else None,
+        "ended_at_is_approximate": latest["ended_at_is_approximate"] if latest else None,
         "sessions": sessions,
     }
 

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -148,6 +148,19 @@ def unavailable(reason_code: str, detail: str | None = None) -> dict[str, Any]:
     return {"available": False, "value": None, "reason_code": reason_code, "detail": detail}
 
 
+def optional_flag(value: Any) -> bool | None:
+    """Normalize a stored boolean that the row may not carry at all.
+
+    SQLite returns 0 and 1; JSON consumers expect true and false. Absent is
+    neither: a read-only open does not reconcile the schema, so a store
+    predating a boolean column hands back rows with no such key, and
+    ``bool(None)`` would answer "false" to a question nobody asked. For
+    ``ended_at_is_approximate`` that answer is "this end was measured", about
+    a row where nothing recorded whether it was.
+    """
+    return None if value is None else bool(value)
+
+
 def read_json_file(path: Path) -> dict[str, Any]:
     """Read a JSON document into the availability wrapper.
 
@@ -529,7 +542,7 @@ def _lifecycle_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
             # Travels with the `ended_at` beside it. A row repaired after the
             # fact carries an end nobody observed, and handed over bare it is
             # arithmetic-identical to a measured one.
-            "ended_at_is_approximate": bool(row.get("ended_at_is_approximate")),
+            "ended_at_is_approximate": optional_flag(row.get("ended_at_is_approximate")),
             "reason_code": row.get("status_reason_code"),
             "reason_summary": row.get("status_reason_summary"),
         }

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -452,13 +452,19 @@ def _session_to_row(sess: dict[str, Any]) -> dict[str, Any]:
 
 
 def _invocation_to_row(inv: dict[str, Any]) -> dict[str, Any]:
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
     return {
         "id": inv["id"][:16],
         "type": "invocation",
         "project": "-",
         "status": inv.get("status") or "?",
         "phase": inv.get("skill") or "-",
-        "elapsed": _elapsed(inv.get("started_at"), inv.get("ended_at")),
+        "elapsed": _elapsed(
+            inv.get("started_at"),
+            inv.get("ended_at"),
+            terminal=inv.get("status") in SESSION_TERMINAL_STATUSES,
+        ),
         "agents": str(inv.get("session_count") or 0),
     }
 
@@ -476,13 +482,19 @@ def _show_to_row(show: dict[str, Any]) -> dict[str, Any]:
 
 
 def _play_to_row(play: dict[str, Any]) -> dict[str, Any]:
+    from lionagi.state.db import PLAY_TERMINAL_STATUSES
+
     return {
         "id": play["id"][:16],
         "type": "play",
         "project": play.get("session_project") or "-",
         "status": play.get("status") or "?",
         "phase": _trunc(play.get("name") or "-", 18),
-        "elapsed": _elapsed(play.get("started_at"), play.get("ended_at")),
+        "elapsed": _elapsed(
+            play.get("started_at"),
+            play.get("ended_at"),
+            terminal=play.get("status") in PLAY_TERMINAL_STATUSES,
+        ),
         "agents": str(play.get("branch_count") or 0),
     }
 
@@ -513,6 +525,8 @@ def _render_branch_lines(rows: list[dict[str, Any]], *, indent: str = "  ") -> l
 
 
 async def _detail_session(db: Any, sess: dict[str, Any]) -> str:
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
     lines: list[str] = []
     lines.append(_bold(f"SESSION  {sess['id']}"))
     lines.append(f"  status:    {_colour_status(sess.get('status') or '?')}")
@@ -529,6 +543,7 @@ async def _detail_session(db: Any, sess: dict[str, Any]) -> str:
             sess.get("started_at"),
             sess.get("ended_at"),
             approximate=bool(sess.get("ended_at_is_approximate")),
+            terminal=sess.get("status") in SESSION_TERMINAL_STATUSES,
         )
     )
     started = sess.get("started_at")
@@ -667,13 +682,22 @@ def _format_coordination_line(telemetry: dict[str, Any]) -> str | None:
 
 
 async def _detail_invocation(db: Any, inv: dict[str, Any]) -> str:
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
     lines: list[str] = []
     lines.append(_bold(f"INVOCATION  {inv['id']}"))
     lines.append(f"  status:        {_colour_status(inv.get('status') or '?')}")
     lines.append(f"  skill:         {inv.get('skill') or '-'}")
     lines.append(f"  plugin:        {inv.get('plugin') or '-'}")
     lines.append(f"  session_count: {inv.get('session_count') or 0}")
-    lines.append(f"  elapsed:       {_elapsed(inv.get('started_at'), inv.get('ended_at'))}")
+    lines.append(
+        "  elapsed:       "
+        + _elapsed(
+            inv.get("started_at"),
+            inv.get("ended_at"),
+            terminal=inv.get("status") in SESSION_TERMINAL_STATUSES,
+        )
+    )
     started = inv.get("started_at")
     if started:
         lines.append(
@@ -748,7 +772,11 @@ async def _detail_show(db: Any, show: dict[str, Any]) -> str:
                 # continue) and not [done] (would sweep live work as finished).
                 # Its own marker flags a data problem instead of guessing.
                 marker = _red("  [????]  ")
-            pelapsed = _elapsed(play.get("started_at"), play.get("ended_at"))
+            pelapsed = _elapsed(
+                play.get("started_at"),
+                play.get("ended_at"),
+                terminal=pstatus in PLAY_TERMINAL_STATUSES,
+            )
             pname = _trunc(play.get("name") or play["id"][:12], 24)
             pstatus_col = _colour_status(pstatus)
             lines.append(f"{marker}{pname:<24}  {pstatus_col}  {pelapsed}")
@@ -757,6 +785,8 @@ async def _detail_show(db: Any, show: dict[str, Any]) -> str:
 
 
 async def _detail_play(db: Any, play: dict[str, Any]) -> str:
+    from lionagi.state.db import PLAY_TERMINAL_STATUSES
+
     lines: list[str] = []
     lines.append(_bold(f"PLAY  {play['id']}"))
     lines.append(f"  name:     {play.get('name') or '-'}")
@@ -764,7 +794,14 @@ async def _detail_play(db: Any, play: dict[str, Any]) -> str:
     lines.append(f"  playbook: {play.get('playbook') or '-'}")
     lines.append(f"  effort:   {play.get('effort') or '-'}")
     lines.append(f"  attempt:  {play.get('attempt') or 1}")
-    lines.append(f"  elapsed:  {_elapsed(play.get('started_at'), play.get('ended_at'))}")
+    lines.append(
+        "  elapsed:  "
+        + _elapsed(
+            play.get("started_at"),
+            play.get("ended_at"),
+            terminal=play.get("status") in PLAY_TERMINAL_STATUSES,
+        )
+    )
     started = play.get("started_at")
     if started:
         lines.append(f"  started:  {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(started))}")

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -102,6 +102,7 @@ def _elapsed(
     ended_at: float | None = None,
     *,
     approximate: bool = False,
+    terminal: bool = False,
 ) -> str:
     """Human-readable elapsed time.  Uses ended_at if present, else now.
 
@@ -112,6 +113,13 @@ def _elapsed(
     provenance: printed bare, a guess reads as a measurement.
     """
     if started_at is None:
+        return "-"
+    # A row that has finished and recorded no end has no span to report, and
+    # saying so is the whole answer. Measuring it up to now is what the branch
+    # below does for a running row, and doing that here prints a duration that
+    # grows every redraw for a session that stopped long ago -- the reading the
+    # provenance flag exists to prevent, arrived at by a different route.
+    if ended_at is None and terminal:
         return "-"
     # Only a closed span can be approximate. A row that is still running is
     # measured up to now whatever the flag says about the end it does not have.
@@ -421,6 +429,8 @@ def _format_table(rows: list[dict[str, Any]]) -> str:
 
 
 def _session_to_row(sess: dict[str, Any]) -> dict[str, Any]:
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
     return {
         "id": sess["id"][:16],
         "type": sess.get("invocation_kind") or "session",
@@ -435,6 +445,7 @@ def _session_to_row(sess: dict[str, Any]) -> dict[str, Any]:
             sess.get("started_at"),
             sess.get("ended_at"),
             approximate=bool(sess.get("ended_at_is_approximate")),
+            terminal=sess.get("status") in SESSION_TERMINAL_STATUSES,
         ),
         "agents": str(sess.get("branch_count") or 0),
     }
@@ -1819,6 +1830,11 @@ _ENTITY_EXTRA: dict[str, tuple[str, ...]] = {
     "session": (
         "project",
         "invocation_kind",
+        # Describes the `ended_at` in the core block above. Withheld, the
+        # caller receives a reconstructed end that is indistinguishable from a
+        # measured one, which is the confusion the column was added to remove.
+        # Session-only: no other entity kind has a reconstructed end.
+        "ended_at_is_approximate",
         "agent_name",
         "playbook_name",
         "current_phase",

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -1883,10 +1883,21 @@ _ENTITY_EXTRA: dict[str, tuple[str, ...]] = {
 }
 
 
+# SQLite hands these back as 0 and 1. The other machine-readable reader emits
+# JSON booleans for the same field names, and a caller should not have to know
+# which endpoint produced a payload in order to read it.
+_ENTITY_BOOL_FIELDS = frozenset({"ended_at_is_approximate"})
+
+
 def _machine_entity(kind: str, row: dict[str, Any]) -> dict[str, Any]:
     entity: dict[str, Any] = {"kind": kind}
     for field in (*_ENTITY_CORE, *_ENTITY_EXTRA[kind]):
-        entity[field] = row.get(field)
+        value = row.get(field)
+        # None stays None: a field the row does not carry is unknown, which is
+        # not the same answer as false.
+        if value is not None and field in _ENTITY_BOOL_FIELDS:
+            value = bool(value)
+        entity[field] = value
     return entity
 
 

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -1883,21 +1883,18 @@ _ENTITY_EXTRA: dict[str, tuple[str, ...]] = {
 }
 
 
-# SQLite hands these back as 0 and 1. The other machine-readable reader emits
-# JSON booleans for the same field names, and a caller should not have to know
-# which endpoint produced a payload in order to read it.
+# Normalized through the same helper the other machine-readable reader uses, so
+# a caller reading both does not have to know which endpoint produced a payload.
 _ENTITY_BOOL_FIELDS = frozenset({"ended_at_is_approximate"})
 
 
 def _machine_entity(kind: str, row: dict[str, Any]) -> dict[str, Any]:
+    from .machine import optional_flag
+
     entity: dict[str, Any] = {"kind": kind}
     for field in (*_ENTITY_CORE, *_ENTITY_EXTRA[kind]):
         value = row.get(field)
-        # None stays None: a field the row does not carry is unknown, which is
-        # not the same answer as false.
-        if value is not None and field in _ENTITY_BOOL_FIELDS:
-            value = bool(value)
-        entity[field] = value
+        entity[field] = optional_flag(value) if field in _ENTITY_BOOL_FIELDS else value
     return entity
 
 

--- a/lionagi/state/lifecycle/service.py
+++ b/lionagi/state/lifecycle/service.py
@@ -427,9 +427,10 @@ class SQLAlchemyLifecycleService:
                 # one, and this transition is that measurement. Reusing the
                 # guess would compute a real-looking duration from a number
                 # nobody observed.
-                if ended_at_value is None or (
+                measured_here = ended_at_value is None or (
                     "ended_at" not in command.patch and row["ended_at_is_approximate"]
-                ):
+                )
+                if measured_here:
                     ended_at_value = now
                 patch = dict(command.patch)
                 patch.setdefault("ended_at", ended_at_value)
@@ -441,7 +442,17 @@ class SQLAlchemyLifecycleService:
                 # Leaving the bit set beside a measured duration produces a row
                 # whose own two fields disagree, and readers believe the bit:
                 # they discard the duration this write just measured.
-                patch.setdefault("ended_at_is_approximate", 0)
+                #
+                # Where this transition is what measured the end, that holds
+                # against a caller who sent the bit too: the value they sent
+                # described an end they did not supply, so it cannot describe
+                # the one taken here. A caller supplying both an end and the
+                # bit is recording a reconstructed end deliberately, and keeps
+                # it -- which is why this is not an unconditional clear.
+                if measured_here:
+                    patch["ended_at_is_approximate"] = 0
+                else:
+                    patch.setdefault("ended_at_is_approximate", 0)
                 if patch != dict(command.patch):
                     command = replace(command, patch=patch)
 

--- a/lionagi/state/lifecycle/service.py
+++ b/lionagi/state/lifecycle/service.py
@@ -469,7 +469,16 @@ class SQLAlchemyLifecycleService:
                 # measured_here, because a caller who supplies both an end and
                 # the bit is recording a reconstructed end deliberately, and
                 # that end is no more subtractable than a repaired one.
-                if "duration_ms" not in patch and not patch["ended_at_is_approximate"]:
+                if patch["ended_at_is_approximate"]:
+                    # Cleared, not merely left uncomputed. Both readers already
+                    # discard a stored duration when this bit is set, so one
+                    # persisted beside it is a value nothing can ever surface,
+                    # and the row asserts a measured length for an end nobody
+                    # measured. The schema-version repair clears it in the same
+                    # write that sets the bit for exactly this reason; a
+                    # transition that sets the bit owes the same.
+                    patch["duration_ms"] = None
+                elif "duration_ms" not in patch:
                     started_at = row["started_at"]
                     if isinstance(started_at, int | float):
                         patch["duration_ms"] = max(0.0, (ended_at_value - started_at) * 1000)

--- a/lionagi/state/lifecycle/service.py
+++ b/lionagi/state/lifecycle/service.py
@@ -433,7 +433,16 @@ class SQLAlchemyLifecycleService:
                 if measured_here:
                     ended_at_value = now
                 patch = dict(command.patch)
-                patch.setdefault("ended_at", ended_at_value)
+                # setdefault cannot displace a key the caller already sent, so
+                # an explicit ended_at=None would survive while the duration
+                # below is computed from the end measured here -- a row with no
+                # end, marked measured, carrying a duration. Where this
+                # transition is the measurement, its value wins over a key
+                # whose value is the absence of one.
+                if measured_here:
+                    patch["ended_at"] = ended_at_value
+                else:
+                    patch.setdefault("ended_at", ended_at_value)
                 if "duration_ms" not in patch:
                     started_at = row["started_at"]
                     if isinstance(started_at, int | float):

--- a/lionagi/state/lifecycle/service.py
+++ b/lionagi/state/lifecycle/service.py
@@ -443,10 +443,6 @@ class SQLAlchemyLifecycleService:
                     patch["ended_at"] = ended_at_value
                 else:
                     patch.setdefault("ended_at", ended_at_value)
-                if "duration_ms" not in patch:
-                    started_at = row["started_at"]
-                    if isinstance(started_at, int | float):
-                        patch["duration_ms"] = max(0.0, (ended_at_value - started_at) * 1000)
                 # The flag and the duration are one fact and move together.
                 # Leaving the bit set beside a measured duration produces a row
                 # whose own two fields disagree, and readers believe the bit:
@@ -462,6 +458,21 @@ class SQLAlchemyLifecycleService:
                     patch["ended_at_is_approximate"] = 0
                 else:
                     patch.setdefault("ended_at_is_approximate", 0)
+                # Derived only from an end that was measured. Subtracting a
+                # reconstructed end from a start yields a real-looking number
+                # for a length nobody observed, which is the thing the flag
+                # exists to prevent -- and once stored, the duration outlives
+                # every reader's chance to notice. An approximate end leaves
+                # duration unknown instead.
+                #
+                # This reads the flag settled just above rather than
+                # measured_here, because a caller who supplies both an end and
+                # the bit is recording a reconstructed end deliberately, and
+                # that end is no more subtractable than a repaired one.
+                if "duration_ms" not in patch and not patch["ended_at_is_approximate"]:
+                    started_at = row["started_at"]
+                    if isinstance(started_at, int | float):
+                        patch["duration_ms"] = max(0.0, (ended_at_value - started_at) * 1000)
                 if patch != dict(command.patch):
                     command = replace(command, patch=patch)
 

--- a/tests/cli/test_machine_envelope.py
+++ b/tests/cli/test_machine_envelope.py
@@ -543,3 +543,53 @@ def test_lifecycle_states_the_provenance_key_on_every_branch():
     for summary in (nothing_recorded, still_running):
         assert "ended_at_is_approximate" in summary
         assert summary["ended_at_is_approximate"] is None
+
+
+def test_lifecycle_summary_reports_unknown_when_the_row_has_no_flag_column():
+    """A store predating the column is a real shape, not a hypothetical.
+
+    The machine readers open read-only where the backend supports it, and a
+    read-only open deliberately does not reconcile the schema, because doing so
+    would write to the store being reported on. The query is SELECT *, so rows
+    from such a store arrive with no key at all. Coercing that to false would
+    answer "this end was measured" about a row where nothing recorded whether
+    it was, which is the confusion the column exists to remove.
+    """
+    from lionagi.cli.machine import _lifecycle_summary
+
+    legacy = {
+        "id": "s1",
+        "status": "completed",
+        "started_at": 100.0,
+        "ended_at": 400.0,
+    }
+    assert "ended_at_is_approximate" not in legacy
+
+    out = _lifecycle_summary([legacy])
+
+    assert out["sessions"][0]["ended_at_is_approximate"] is None
+    assert out["ended_at_is_approximate"] is None
+    assert out["ended_at"] == 400.0
+
+
+def test_lifecycle_summary_still_reports_false_when_the_column_says_measured():
+    """Control for the test above: unknown is preserved, not manufactured.
+
+    A row that carries the column and records a measured end must still come
+    back false. Reporting null there would lose the very provenance the field
+    was added to carry.
+    """
+    from lionagi.cli.machine import _lifecycle_summary
+
+    measured = {
+        "id": "s1",
+        "status": "completed",
+        "started_at": 100.0,
+        "ended_at": 400.0,
+        "ended_at_is_approximate": 0,
+    }
+
+    out = _lifecycle_summary([measured])
+
+    assert out["sessions"][0]["ended_at_is_approximate"] is False
+    assert out["ended_at_is_approximate"] is False

--- a/tests/cli/test_machine_envelope.py
+++ b/tests/cli/test_machine_envelope.py
@@ -487,3 +487,59 @@ def test_the_human_path_still_ends_quietly_when_its_reader_goes_away():
     # The reason the default is set at all: `li ... | head` should stop, not
     # print a traceback about a pipe the person closed on purpose.
     assert _sigpipe_disposition_after("handshake") == "SIG_DFL"
+
+
+def test_lifecycle_hands_a_consumer_the_end_and_whether_it_was_observed():
+    """A run's end reaches the consumer with its provenance attached.
+
+    The consumer here is the one this file is written for: another language,
+    reading JSON, with no way to ask what a field means. Given `ended_at`
+    alone it cannot tell an end somebody observed from one reconstructed
+    afterwards from leftover evidence, and the two are arithmetic-identical.
+    The aggregate end IS one of the session ends, so it carries that row's
+    provenance rather than a fresh judgement about the run.
+    """
+    from lionagi.cli.machine import _lifecycle_summary
+
+    summary = _lifecycle_summary(
+        [
+            {
+                "id": "s1",
+                "status": "completed",
+                "started_at": 100.0,
+                "ended_at": 150.0,
+                "ended_at_is_approximate": 0,
+            },
+            {
+                "id": "s2",
+                "status": "completed",
+                "started_at": 150.0,
+                "ended_at": 400.0,
+                "ended_at_is_approximate": 1,
+            },
+        ]
+    )
+
+    assert summary["terminal"] is True
+    assert [entry["ended_at_is_approximate"] for entry in summary["sessions"]] == [False, True]
+    # The run's end is s2's, so it inherits s2's provenance.
+    assert summary["ended_at"] == 400.0
+    assert summary["ended_at_is_approximate"] is True
+
+
+def test_lifecycle_states_the_provenance_key_on_every_branch():
+    """A key that appears only once a run has ended forces the consumer to
+    tell absent from null, and a consumer that does not will read absent as
+    measured. Cheaper to always answer the question."""
+    from lionagi.cli.machine import _lifecycle_summary
+
+    nothing_recorded = _lifecycle_summary([])
+    still_running = _lifecycle_summary(
+        [{"id": "s1", "status": "running", "started_at": 100.0, "ended_at": None}]
+    )
+
+    assert nothing_recorded["found"] is False
+    assert still_running["terminal"] is False
+    for summary in (nothing_recorded, still_running):
+        assert "ended_at_is_approximate" in summary
+        assert summary["ended_at_is_approximate"] is None

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -26,6 +26,7 @@ from lionagi.cli.monitor import (
     _format_table,
     _gather_table_rows,
     _invocation_to_row,
+    _machine_entity,
     _parse_json_field,
     _pid_alive,
     _play_to_row,
@@ -2350,3 +2351,26 @@ def test_running_rows_of_every_entity_are_still_measured():
 
     assert inv["elapsed"] != "-"
     assert play["elapsed"] != "-"
+
+
+def test_machine_entity_emits_a_json_boolean_for_the_approximate_end_flag():
+    """SQLite returns 0/1; the lifecycle summary endpoint returns true/false.
+
+    Same field name on two machine-readable surfaces, so a caller that reads
+    both should not have to branch on which one produced the payload.
+    """
+    entity = _machine_entity("session", {"id": "s1", "ended_at_is_approximate": 1})
+    assert entity["ended_at_is_approximate"] is True
+
+    entity = _machine_entity("session", {"id": "s1", "ended_at_is_approximate": 0})
+    assert entity["ended_at_is_approximate"] is False
+
+
+def test_machine_entity_leaves_an_absent_approximate_flag_as_null():
+    """Absent is unknown, which is a different answer from measured.
+
+    Coercing a missing column with bare bool() would report every row the query
+    did not select as carrying a measured end.
+    """
+    entity = _machine_entity("session", {"id": "s1"})
+    assert entity["ended_at_is_approximate"] is None

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -2310,13 +2310,14 @@ async def test_show_detail_marks_blocked_play_as_done(temp_db_path: Path) -> Non
     assert "[wait]" in gated_line, "an undecided play is unfinished, not done"
 
 
-def test_terminal_rows_with_no_recorded_end_report_unknown_for_every_entity():
+def test_terminal_invocation_and_play_rows_with_no_recorded_end_report_unknown():
     """Sessions are not the only population with this shape.
 
-    Measured against a real store: 6961 terminal sessions, 58 terminal plays
-    and 3 terminal invocations carry no recorded end. Fixing the session row
-    alone leaves the other two rendering a span that grows on every redraw,
-    which is the same defect wearing a different table.
+    Invocations and plays reach a terminal status with no recorded end too, in
+    real stores and not just in principle, so fixing the session row alone
+    leaves these two rendering a span that grows on every redraw. The session
+    case has its own test above; this one exists because the sibling tables
+    were the part it was tempting to reason about instead of check.
     """
     from lionagi.cli.monitor import _invocation_to_row, _play_to_row
 

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -2307,3 +2307,46 @@ async def test_show_detail_marks_blocked_play_as_done(temp_db_path: Path) -> Non
     assert "[done]" in blocked_line
     assert "[wait]" not in blocked_line
     assert "[wait]" in gated_line, "an undecided play is unfinished, not done"
+
+
+def test_terminal_rows_with_no_recorded_end_report_unknown_for_every_entity():
+    """Sessions are not the only population with this shape.
+
+    Measured against a real store: 6961 terminal sessions, 58 terminal plays
+    and 3 terminal invocations carry no recorded end. Fixing the session row
+    alone leaves the other two rendering a span that grows on every redraw,
+    which is the same defect wearing a different table.
+    """
+    from lionagi.cli.monitor import _invocation_to_row, _play_to_row
+
+    long_ago = time.time() - 86_400
+
+    inv = _invocation_to_row(
+        {"id": "inv123def456", "status": "completed", "started_at": long_ago, "ended_at": None}
+    )
+    # Plays carry their own terminal vocabulary, disjoint from the session one
+    # -- "completed" is not a play status at all.
+    play = _play_to_row(
+        {"id": "ply123def456", "status": "merged", "started_at": long_ago, "ended_at": None}
+    )
+
+    assert inv["elapsed"] == "-"
+    assert play["elapsed"] == "-"
+
+
+def test_running_rows_of_every_entity_are_still_measured():
+    """Control: the terminal status suppresses the span, not the missing end.
+    A running row of either kind is still measured up to now."""
+    from lionagi.cli.monitor import _invocation_to_row, _play_to_row
+
+    recent = time.time() - 45
+
+    inv = _invocation_to_row(
+        {"id": "inv123def456", "status": "running", "started_at": recent, "ended_at": None}
+    )
+    play = _play_to_row(
+        {"id": "ply123def456", "status": "running", "started_at": recent, "ended_at": None}
+    )
+
+    assert inv["elapsed"] != "-"
+    assert play["elapsed"] != "-"

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -211,6 +211,30 @@ def test_elapsed_does_not_mark_a_still_running_row():
     assert not _elapsed(time.time() - 45, approximate=True).startswith("~")
 
 
+def test_elapsed_reports_unknown_for_a_finished_row_that_recorded_no_end():
+    """A session that stopped, with no end on the row, has no span to report.
+
+    Measuring it up to now is what the running case does, and doing it here
+    produces a duration that is larger every time the table is redrawn for a
+    session that has been over for months. Legacy rows are exactly the
+    population with a terminal status and no recorded end, so this is not a
+    hypothetical shape.
+    """
+    long_ago = time.time() - 86_400
+
+    assert _elapsed(long_ago, ended_at=None, terminal=True) == "-"
+
+
+def test_elapsed_still_measures_a_running_row_that_recorded_no_end():
+    """Control for the test above: the terminal flag is what suppresses the
+    span, not the missing end. A running row has no end either, and its
+    elapsed time genuinely is measured up to now."""
+    running = _elapsed(time.time() - 45, ended_at=None, terminal=False)
+
+    assert running != "-"
+    assert running.endswith("s")
+
+
 def test_trunc_short():
     assert _trunc("hello", 10) == "hello"
 
@@ -481,6 +505,45 @@ def test_session_to_row_carries_end_provenance_into_the_elapsed_column():
 
     assert measured["elapsed"] == "45s"
     assert reconstructed["elapsed"] == "~45s"
+
+
+def test_session_to_row_reports_unknown_elapsed_for_a_terminal_row_with_no_end():
+    """The whole path, not just the formatter: a terminal session carrying no
+    end must reach the table as unknown rather than as a span still growing."""
+    row = _session_to_row(
+        {
+            "id": "abc123def456",
+            "invocation_kind": "agent",
+            "project": "lionagi",
+            "status": "completed",
+            "started_at": time.time() - 86_400,
+            "ended_at": None,
+        }
+    )
+
+    assert row["elapsed"] == "-"
+
+
+def test_machine_session_entity_carries_end_provenance():
+    """`li monitor --machine` hands out `ended_at` for sessions, so it has to
+    hand out the field saying whether that end was observed. A consumer given
+    the timestamp alone cannot tell a reconstructed end from a measured one,
+    and nothing else in the payload answers it."""
+    from lionagi.cli.monitor import _machine_entity
+
+    entity = _machine_entity(
+        "session",
+        {
+            "id": "abc123def456",
+            "status": "completed",
+            "started_at": 100.0,
+            "ended_at": 145.0,
+            "ended_at_is_approximate": 1,
+        },
+    )
+
+    assert "ended_at_is_approximate" in entity
+    assert entity["ended_at_is_approximate"] == 1
 
 
 def test_session_to_row_no_optional():

--- a/tests/state/lifecycle/test_service.py
+++ b/tests/state/lifecycle/test_service.py
@@ -661,3 +661,72 @@ async def test_a_caller_supplied_end_is_still_honored_on_an_approximate_row(
     assert row["ended_at"] == 400.0
     assert row["ended_at_is_approximate"] is False
     assert row["duration_ms"] == pytest.approx(300_000.0)
+
+
+@pytest.mark.asyncio
+async def test_a_caller_sent_flag_cannot_survive_an_end_measured_here(
+    db: StateDB,
+) -> None:
+    """A caller may send the flag without sending an end. It does not describe
+    the end this transition then takes.
+
+    The transition has no end from the caller, so it measures one and computes
+    a duration from it. Carrying the caller's bit forward past that leaves the
+    row asserting that a moment observed here was reconstructed, and readers
+    believe the bit over the number, so they discard a duration that was
+    actually measured. The flag and the duration are one fact, and this is the
+    write that establishes both.
+    """
+    sid = await _make_session(db, status="running")
+    async with db._tx() as conn:
+        await conn.execute(
+            text("UPDATE sessions SET started_at = :started WHERE id = :id"),
+            {"started": 100.0, "id": sid},
+        )
+    service = SQLAlchemyLifecycleService(db)
+
+    await service.transition(
+        _command(
+            entity_id=sid,
+            to_status="completed",
+            patch={"ended_at_is_approximate": 1},
+        )
+    )
+
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["ended_at_is_approximate"] is False
+    assert row["duration_ms"] == pytest.approx((row["ended_at"] - 100.0) * 1000)
+
+
+@pytest.mark.asyncio
+async def test_a_caller_supplying_both_an_end_and_the_flag_keeps_the_flag(
+    db: StateDB,
+) -> None:
+    """Control for the test above: the clear is not unconditional.
+
+    A caller that supplies an end *and* marks it reconstructed is recording a
+    repaired row on purpose. Forcing the flag off there would be the same
+    defect in the other direction, turning a declared guess into a measurement
+    on the strength of nothing.
+    """
+    sid = await _make_session(db, status="running")
+    async with db._tx() as conn:
+        await conn.execute(
+            text("UPDATE sessions SET started_at = :started WHERE id = :id"),
+            {"started": 100.0, "id": sid},
+        )
+    service = SQLAlchemyLifecycleService(db)
+
+    await service.transition(
+        _command(
+            entity_id=sid,
+            to_status="completed",
+            patch={"ended_at": 400.0, "ended_at_is_approximate": 1},
+        )
+    )
+
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["ended_at"] == 400.0
+    assert row["ended_at_is_approximate"] is True

--- a/tests/state/lifecycle/test_service.py
+++ b/tests/state/lifecycle/test_service.py
@@ -829,3 +829,74 @@ async def test_a_measured_end_still_gets_its_duration(
     assert row is not None
     assert row["ended_at_is_approximate"] is False
     assert row["duration_ms"] == pytest.approx(300.0 * 1000)
+
+
+async def test_a_supplied_duration_does_not_survive_an_approximate_end(
+    db: StateDB,
+) -> None:
+    """Sending a duration with an approximate end must not persist the duration.
+
+    Not computing one is only half the contract. Both readers discard a stored
+    duration when the flag is set, so a persisted one is a value nothing can
+    surface, on a row that then asserts a measured length for an end nobody
+    measured. The schema-version repair clears it in the same write that sets
+    the bit; a transition that sets the bit owes the same.
+    """
+    sid = await _make_session(db, status="running")
+    async with db._tx() as conn:
+        await conn.execute(
+            text("UPDATE sessions SET started_at = :started WHERE id = :id"),
+            {"started": 100.0, "id": sid},
+        )
+    service = SQLAlchemyLifecycleService(db)
+
+    await service.transition(
+        _command(
+            entity_id=sid,
+            to_status="completed",
+            patch={
+                "ended_at": 400.0,
+                "ended_at_is_approximate": 1,
+                "duration_ms": 300000.0,
+            },
+        )
+    )
+
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["ended_at_is_approximate"] is True
+    assert row["duration_ms"] is None, (
+        "a caller-supplied duration was kept beside an approximate end"
+    )
+
+
+async def test_a_stored_duration_is_cleared_when_a_transition_marks_the_end_approximate(
+    db: StateDB,
+) -> None:
+    """The same holds for a duration already on the row rather than in the patch.
+
+    A row can carry a duration written by an earlier terminal transition and
+    then be re-marked approximate. Guarding only the patch would leave that one
+    in place, which is the same contradiction reached from the store side.
+    """
+    sid = await _make_session(db, status="running")
+    async with db._tx() as conn:
+        await conn.execute(
+            text(
+                "UPDATE sessions SET started_at = :started, duration_ms = :duration WHERE id = :id"
+            ),
+            {"started": 100.0, "duration": 999.0, "id": sid},
+        )
+    service = SQLAlchemyLifecycleService(db)
+
+    await service.transition(
+        _command(
+            entity_id=sid,
+            to_status="completed",
+            patch={"ended_at": 400.0, "ended_at_is_approximate": 1},
+        )
+    )
+
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["duration_ms"] is None, "a pre-existing duration outlived the approximate mark"

--- a/tests/state/lifecycle/test_service.py
+++ b/tests/state/lifecycle/test_service.py
@@ -730,3 +730,38 @@ async def test_a_caller_supplying_both_an_end_and_the_flag_keeps_the_flag(
     assert row is not None
     assert row["ended_at"] == 400.0
     assert row["ended_at_is_approximate"] is True
+
+
+@pytest.mark.asyncio
+async def test_an_explicitly_null_end_does_not_survive_the_measurement(
+    db: StateDB,
+) -> None:
+    """Sending ``ended_at=None`` is sending the absence of an end, not an end.
+
+    The transition measures one and computes the duration from it. If the
+    caller's null were kept, the row would land with no end, marked measured,
+    carrying a duration -- the same contradiction the flag handling exists to
+    prevent, entered from the other side. Nothing in the tree sends this today;
+    it is reachable through the public update path.
+    """
+    sid = await _make_session(db, status="running")
+    async with db._tx() as conn:
+        await conn.execute(
+            text("UPDATE sessions SET started_at = :started WHERE id = :id"),
+            {"started": 100.0, "id": sid},
+        )
+    service = SQLAlchemyLifecycleService(db)
+
+    await service.transition(
+        _command(
+            entity_id=sid,
+            to_status="completed",
+            patch={"ended_at": None, "ended_at_is_approximate": 1},
+        )
+    )
+
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["ended_at"] is not None
+    assert row["ended_at_is_approximate"] is False
+    assert row["duration_ms"] == pytest.approx((row["ended_at"] - 100.0) * 1000)

--- a/tests/state/lifecycle/test_service.py
+++ b/tests/state/lifecycle/test_service.py
@@ -765,3 +765,67 @@ async def test_an_explicitly_null_end_does_not_survive_the_measurement(
     assert row["ended_at"] is not None
     assert row["ended_at_is_approximate"] is False
     assert row["duration_ms"] == pytest.approx((row["ended_at"] - 100.0) * 1000)
+
+
+async def test_a_deliberately_approximate_end_leaves_the_duration_unknown(
+    db: StateDB,
+) -> None:
+    """A caller recording a reconstructed end must not get a duration from it.
+
+    Sending an end together with ``ended_at_is_approximate=1`` says the end was
+    derived, not observed. Subtracting the start from it produces a number that
+    reads as a measured length, and once persisted no reader can tell it was
+    derived -- the flag is on the row, but a consumer that trusts a stored
+    duration never consults it. ``docs/internals/state-db.md`` states the
+    contract directly: an approximate end leaves duration unknown.
+    """
+    sid = await _make_session(db, status="running")
+    async with db._tx() as conn:
+        await conn.execute(
+            text("UPDATE sessions SET started_at = :started WHERE id = :id"),
+            {"started": 100.0, "id": sid},
+        )
+    service = SQLAlchemyLifecycleService(db)
+
+    await service.transition(
+        _command(
+            entity_id=sid,
+            to_status="completed",
+            patch={"ended_at": 400.0, "ended_at_is_approximate": 1},
+        )
+    )
+
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["ended_at"] == 400.0
+    assert row["ended_at_is_approximate"] is True
+    assert row["duration_ms"] is None, (
+        "an approximate end was subtracted from the start and stored as a duration"
+    )
+
+
+async def test_a_measured_end_still_gets_its_duration(
+    db: StateDB,
+) -> None:
+    """Control: the gate withholds duration from approximate ends, not from all ends.
+
+    Without this, the test above would pass just as well against a transition
+    that had stopped computing durations altogether, which is the ordinary way
+    a fix of this shape goes wrong.
+    """
+    sid = await _make_session(db, status="running")
+    async with db._tx() as conn:
+        await conn.execute(
+            text("UPDATE sessions SET started_at = :started WHERE id = :id"),
+            {"started": 100.0, "id": sid},
+        )
+    service = SQLAlchemyLifecycleService(db)
+
+    await service.transition(
+        _command(entity_id=sid, to_status="completed", patch={"ended_at": 400.0})
+    )
+
+    row = await db.get_session(sid)
+    assert row is not None
+    assert row["ended_at_is_approximate"] is False
+    assert row["duration_ms"] == pytest.approx(300.0 * 1000)


### PR DESCRIPTION
The column recording whether a session's end was **observed** or **reconstructed** reached the human table and stopped there. Three defects on that one fact, all found after the column landed.

### Machine-readable readers dropped it

`li monitor --machine` and `li lifecycle` emitted `ended_at` with nothing beside it. Measured on `main` before this change:

```
lionagi/cli/machine.py   ended_at emitted at 5 sites, ended_at_is_approximate at 0
lionagi/cli/monitor.py   _ENTITY_CORE = (id, status, started_at, ended_at, updated_at)
```

A consumer parsing that JSON gets a reconstructed timestamp that is arithmetic-identical to a measured one, and nothing in the payload answers the difference. Since a run's end **is** one of its session ends, the aggregate now carries that row's provenance rather than a fresh judgement about the run — taking `max()` of the timestamps alone discarded exactly the field that says whether the winning end was observed.

The key is present on every branch of the answer, including `found: false` and still-running. A key that appears only once a run has ended forces the consumer to distinguish absent from null, and a consumer that does not will read absent as measured.

### A finished row with no end printed a growing duration

`_elapsed` fell back to the current time whenever `ended_at` was missing, without asking whether the row had finished. The terminal check existed for the `~` marker and not for the fallback beside it, so a terminal row carrying no end rendered a span that grew on every redraw. Legacy rows are precisely the population with a terminal status and no recorded end, so this is the shape that actually occurs.

### A caller-supplied flag survived an end measured here

The terminal transition derived a duration from a freshly measured end and then cleared the flag with `setdefault`, directly under a comment stating that the flag and the duration are one fact. A caller who sent the flag without sending an end kept it, leaving the row asserting that a moment observed here was reconstructed — and readers believe the flag over the number, so they discard the duration this write just measured.

The clear is conditional, not unconditional. A caller supplying an end **and** the flag is recording a repaired row deliberately, and keeps it; forcing it off would be the same defect pointing the other way.

### Verification

Each of four changes was reverted independently. Every one reddens its own guard and nothing else:

| reverted | reddens |
|---|---|
| `_elapsed` terminal branch | the two unknown-elapsed tests |
| session entity field | the machine-entity test |
| lifecycle per-session field | the consumer-contract test |
| conditional clear | the caller-sent-flag test |

Two controls guard against over-correction and pass in both directions: a running row with no end is still measured up to now, and a caller-declared reconstructed end is still honoured.
