### PR TITLE
fix(state): refuse a pre-rebuild backup when the checkpoint is incomplete

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2019,16 +2019,27 @@ class StateDB:
         # would then be a rollback artifact predating them. So the result is
         # read rather than discarded, and a partial checkpoint refuses.
         result = await self.checkpoint("TRUNCATE")
-        if result is not None:
-            busy, log_pages, checkpointed = result
-            if busy or log_pages != checkpointed:
-                raise BackupNotTrustworthyError(
-                    f"cannot back up {mask_credentials(str(p))} before the {label} rebuild: "
-                    f"wal_checkpoint(TRUNCATE) reported busy={busy}, "
-                    f"{checkpointed} of {log_pages} WAL pages checkpointed. Committed data "
-                    "may still be in the write-ahead log, so a file copy would not be a "
-                    "complete backup. Stop other writers to this database and retry."
-                )
+        if result is None:
+            # checkpoint() returns None for a non-sqlite dialect or for a pragma
+            # read that produced no row. The dialect was ruled out above, so
+            # only the failed read is left, and it says nothing about whether
+            # the WAL was folded in. Reading that silence as permission would
+            # be the same mistake as discarding the result outright.
+            raise BackupNotTrustworthyError(
+                f"cannot back up {mask_credentials(str(p))} before the {label} rebuild: "
+                "wal_checkpoint(TRUNCATE) returned no row, so whether the write-ahead "
+                "log was folded into the database file is unknown. A file copy would "
+                "not be a verifiable backup. Retry, and check the database is readable."
+            )
+        busy, log_pages, checkpointed = result
+        if busy or log_pages != checkpointed:
+            raise BackupNotTrustworthyError(
+                f"cannot back up {mask_credentials(str(p))} before the {label} rebuild: "
+                f"wal_checkpoint(TRUNCATE) reported busy={busy}, "
+                f"{checkpointed} of {log_pages} WAL pages checkpointed. Committed data "
+                "may still be in the write-ahead log, so a file copy would not be a "
+                "complete backup. Stop other writers to this database and retry."
+            )
         backup_path = p.with_name(f"{p.name}.pre-{label}.{int(time.time())}.bak")
         shutil.copy2(p, backup_path)
         # Not a snapshot: a writer committing between the checkpoint above and

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -147,6 +147,16 @@ class SchemaTooNewError(RuntimeError):
     """
 
 
+class BackupNotTrustworthyError(RuntimeError):
+    """A pre-rebuild backup could not be taken from a fully checkpointed store.
+
+    Raised instead of copying, and it aborts the rebuild that asked for the
+    backup. A rebuild replaces a table in place, so the backup is the only way
+    back; a copy that is missing committed data restores cleanly and silently
+    returns a database to an earlier state, which is worse than not migrating.
+    """
+
+
 def state_db_file() -> Path | None:
     """The local file a default ``StateDB()`` would open, or None.
 
@@ -2001,11 +2011,31 @@ class StateDB:
         # In WAL mode, recently committed transactions can live only in the
         # `-wal` sidecar file until a checkpoint occurs. A raw file copy taken
         # without checkpointing first can silently omit that data, defeating
-        # the rollback guarantee this backup exists to provide. TRUNCATE forces
-        # a full checkpoint and truncates the WAL file back to zero length.
-        await self.checkpoint("TRUNCATE")
+        # the rollback guarantee this backup exists to provide.
+        #
+        # TRUNCATE *asks* for a full checkpoint; it does not promise one. When
+        # it cannot get the locks within the busy timeout it falls back and
+        # reports busy, leaving committed frames in the WAL, and the copy below
+        # would then be a rollback artifact predating them. So the result is
+        # read rather than discarded, and a partial checkpoint refuses.
+        result = await self.checkpoint("TRUNCATE")
+        if result is not None:
+            busy, log_pages, checkpointed = result
+            if busy or log_pages != checkpointed:
+                raise BackupNotTrustworthyError(
+                    f"cannot back up {mask_credentials(str(p))} before the {label} rebuild: "
+                    f"wal_checkpoint(TRUNCATE) reported busy={busy}, "
+                    f"{checkpointed} of {log_pages} WAL pages checkpointed. Committed data "
+                    "may still be in the write-ahead log, so a file copy would not be a "
+                    "complete backup. Stop other writers to this database and retry."
+                )
         backup_path = p.with_name(f"{p.name}.pre-{label}.{int(time.time())}.bak")
         shutil.copy2(p, backup_path)
+        # Not a snapshot: a writer committing between the checkpoint above and
+        # this copy lands in the WAL again, and those frames are not in the
+        # file just written. The check above bounds what was missed to writes
+        # concurrent with the backup itself rather than to the whole unflushed
+        # WAL, which is a narrower window, not no window.
 
     # Substring present only in the current schedule_runs CREATE SQL
     # (the widened status CHECK); its absence indicates a legacy DB whose

--- a/tests/state/test_backup_checkpoint_gate.py
+++ b/tests/state/test_backup_checkpoint_gate.py
@@ -103,3 +103,29 @@ async def test_backup_proceeds_on_a_real_checkpoint(tmp_path):
         assert len(_backups(tmp_path)) == 1
     finally:
         await db.close()
+
+
+async def test_backup_refuses_when_the_checkpoint_read_returns_no_row(tmp_path, monkeypatch):
+    """A checkpoint that cannot be read is not a checkpoint that passed.
+
+    ``checkpoint()`` returns None for a non-sqlite dialect or for a pragma read
+    that produced no row. ``_backup_before_rebuild`` returns before this point
+    on any non-sqlite dialect, so None can only be the failed read -- an absent
+    value, which says nothing about whether the WAL was folded in. Spending it
+    as permission is the same defect as discarding the result, one branch over.
+    """
+    db = await _seeded_db(tmp_path)
+    try:
+
+        async def _no_row(mode: str = "PASSIVE"):
+            return None
+
+        monkeypatch.setattr(db, "checkpoint", _no_row)
+
+        with pytest.raises(BackupNotTrustworthyError) as excinfo:
+            await db._backup_before_rebuild("probe")
+
+        assert "no row" in str(excinfo.value)
+        assert _backups(tmp_path) == [], "a backup file was written despite the refusal"
+    finally:
+        await db.close()

--- a/tests/state/test_backup_checkpoint_gate.py
+++ b/tests/state/test_backup_checkpoint_gate.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""A pre-rebuild backup must refuse rather than copy a partially checkpointed store.
+
+`PRAGMA wal_checkpoint(TRUNCATE)` asks for a full checkpoint and reports whether
+it got one. Where it does not, committed transactions are still in the `-wal`
+sidecar, and the main database file on its own is a rollback artifact predating
+them. Copying anyway produces a backup that restores cleanly while silently
+missing data, on the one path whose entire purpose is being able to go back.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from lionagi.state.db import BackupNotTrustworthyError, StateDB
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seeded_db(tmp_path: Path) -> StateDB:
+    db = StateDB(path=tmp_path / "state.db")
+    await db.open()
+    return db
+
+
+def _backups(tmp_path: Path) -> list[Path]:
+    return sorted(tmp_path.glob("state.db.pre-*.bak"))
+
+
+async def test_backup_refuses_when_the_checkpoint_reports_busy(tmp_path, monkeypatch):
+    db = await _seeded_db(tmp_path)
+    try:
+        # busy=1 with pages left behind: SQLite falls back from TRUNCATE when it
+        # cannot get the locks in time, and says so in the value nobody read.
+        async def _busy(mode: str = "PASSIVE"):
+            return (1, 7, 3)
+
+        monkeypatch.setattr(db, "checkpoint", _busy)
+
+        with pytest.raises(BackupNotTrustworthyError) as excinfo:
+            await db._backup_before_rebuild("probe")
+
+        assert "busy=1" in str(excinfo.value)
+        assert _backups(tmp_path) == [], "a backup file was written despite the refusal"
+    finally:
+        await db.close()
+
+
+async def test_backup_refuses_when_pages_are_left_uncheckpointed(tmp_path, monkeypatch):
+    """busy=0 is not on its own a complete checkpoint.
+
+    A checkpoint can report that it did not block and still leave frames behind,
+    so the page counts are the check and the busy flag alone is not.
+    """
+    db = await _seeded_db(tmp_path)
+    try:
+
+        async def _partial(mode: str = "PASSIVE"):
+            return (0, 9, 4)
+
+        monkeypatch.setattr(db, "checkpoint", _partial)
+
+        with pytest.raises(BackupNotTrustworthyError):
+            await db._backup_before_rebuild("probe")
+
+        assert _backups(tmp_path) == []
+    finally:
+        await db.close()
+
+
+async def test_backup_proceeds_on_a_complete_checkpoint(tmp_path, monkeypatch):
+    """Control: the gate refuses partial checkpoints, not every checkpoint.
+
+    Without this the two tests above would pass against a backup path that had
+    simply been broken outright.
+    """
+    db = await _seeded_db(tmp_path)
+    try:
+
+        async def _complete(mode: str = "PASSIVE"):
+            return (0, 5, 5)
+
+        monkeypatch.setattr(db, "checkpoint", _complete)
+
+        await db._backup_before_rebuild("probe")
+
+        assert len(_backups(tmp_path)) == 1, "a complete checkpoint must still back up"
+    finally:
+        await db.close()
+
+
+async def test_backup_proceeds_on_a_real_checkpoint(tmp_path):
+    """Second control, unmocked: the real pragma against a real store passes.
+
+    The three tests above all replace `checkpoint`, so together they cannot say
+    whether a genuine checkpoint satisfies the predicate. If real sqlite
+    returned something the gate rejects, every rebuild would refuse.
+    """
+    db = await _seeded_db(tmp_path)
+    try:
+        await db._backup_before_rebuild("probe")
+        assert len(_backups(tmp_path)) == 1
+    finally:
+        await db.close()


### PR DESCRIPTION
## The defect

`StateDB._backup_before_rebuild` is the only backup taken before a destructive schema
rebuild. It ran:

```python
# TRUNCATE forces a full checkpoint, so the WAL is folded into the main file
await self.checkpoint("TRUNCATE")
backup_path = ...
shutil.copy2(p, backup_path)
```

The comment is wrong and the discarded return value is what says so. `PRAGMA
wal_checkpoint(TRUNCATE)` *asks* for a full checkpoint. When it cannot acquire the
locks within the busy timeout it falls back and reports `busy=1`, and it can also
return without blocking having left frames behind. In both cases committed
transactions are still in the `-wal` sidecar, and a `copy2` of the main database file
alone is a rollback artifact predating them.

That produces a backup which restores **cleanly while silently missing data**, on the
one path whose entire purpose is being able to go back from a destructive migration.

`checkpoint()` has documented its `(busy, log_pages, checkpointed)` return the whole
time. It has exactly one caller in this file, and that caller did not read it.

## The fix

Read the result and refuse unless the checkpoint both did not block and left no pages
behind:

```python
result = await self.checkpoint("TRUNCATE")
if result is not None:
    busy, log_pages, checkpointed = result
    if busy or log_pages != checkpointed:
        raise BackupNotTrustworthyError(...)
```

Refusing *before* the rebuild starts leaves the store untouched, which is the
recoverable outcome. The alternative — proceeding with a rebuild whose rollback path
is quietly incomplete — is the one that loses data.

## What this does not fix

A writer committing between the checkpoint returning and the `copy2` finishing lands
frames in the WAL again, outside the copy. This bounds what can be missed to writes
concurrent with the backup itself rather than to the entire unflushed WAL. That is a
narrower window, not no window, and the code now says so instead of asserting a
snapshot it does not take. Closing it properly means the SQLite Online Backup API or
`VACUUM INTO` under a held `BEGIN IMMEDIATE`; that is a larger change than this one.

## Tests

`tests/state/test_backup_checkpoint_gate.py`, four cases:

- refuses when the checkpoint reports `busy`
- refuses when pages are left uncheckpointed with `busy=0` — the page counts are the
  check, the busy flag alone is not
- **control**: a mocked complete checkpoint still backs up, so the two refusal tests
  cannot be passing against a backup path that was simply broken outright
- **second control, unmocked**: a real checkpoint against a real store satisfies the
  predicate. The other three all replace `checkpoint`, so together they cannot say
  whether genuine SQLite passes the gate. Without this, a predicate that rejected
  reality would make every rebuild refuse and no test would notice.

Full suite: no regressions. Same-tree, same-venv, three repeats each with and without
the change — 6 failures both ways, all pre-existing `ModuleNotFoundError: fastapi` in
a file lacking the `importorskip` guard used elsewhere in the suite.
