### PR TITLE
perf(cli): journal flow checkpoint deltas instead of rewriting the file

### DIFF
--- a/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
+++ b/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
@@ -41,7 +41,7 @@ This ADR answers five concrete problems:
 | Control addressing and transport | D1: Queue ordered `pause`, `resume`, and `message` rows only for live flow/play sessions. |
 | Cooperative pause semantics | D2: Gate new operation starts at the executor boundary; never preempt an in-flight provider call. |
 | Context-mode steering | D3: Apply messages at most once to shared flow context and render them once into a pending operation instruction. |
-| Checkpoint persistence | D4: Atomically replace a versioned full-state JSON checkpoint after operation outcomes. |
+| Checkpoint persistence | D4: Append fsynced deltas to a generation-scoped journal beside an atomically replaced base snapshot, compacting on a bound. |
 | Resume and reactive-growth bounds | D5: Replay the recorded plan without planning; refuse spawned topology and gate degraded inherited context. |
 
 Out of scope:
@@ -294,6 +294,11 @@ Version 3 replaces the per-completion full rewrite with two run-local files:
   and filesystem work run in a worker thread while one async lock preserves writer order.
 - Context snapshots are reduced to changed and deleted top-level keys. Completed operation responses
   remain individually durable.
+- The baseline for the next delta is captured once, synchronously, before any await. The caller
+  keeps mutating the shared context workspace, so reading it to build the delta and reading it
+  again afterwards to store the baseline would put those reads on opposite sides of an await; a
+  mutation landing between them enters the baseline without entering any delta, and is therefore
+  never journaled at all.
 - After 128 deltas, the writer atomically replaces the base with the recovered current state under a
   new generation and then clears the journal. A journal from an older generation is never replayed
   onto the new base.
@@ -392,8 +397,19 @@ Legacy version 1/2 persistence semantics:
 versioning is recorded.
 
 Why version 3: atomic replacement still protects the compacted base, while fsynced deltas keep
-completion writes proportional to the new data rather than all prior state. Generation ids make the
-two-file compaction boundary recoverable without replaying an obsolete journal.
+completion writes proportional to the changed top-level entries rather than to all prior state.
+Generation ids make the two-file compaction boundary recoverable without replaying an obsolete
+journal.
+
+The ceiling that phrasing carries, stated because it is not "proportional to the new data": a
+delta is computed one top-level key at a time, so a key holding a growing list or dict is
+journaled whole whenever any part of it changes, and the baseline capture deep-copies the whole
+context. Both therefore scale with accumulated context rather than with the increment. That is a
+ceiling, not a regression — the writer this replaces serialized the entire checkpoint state on
+the event loop after every completion, so version 3 is strictly cheaper on both the loop and the
+disk. Lifting it means descending into nested containers on both sides: a structural delta and a
+baseline that shares unchanged subtrees. Those are one decision seen from two ends and are not
+part of this one.
 
 ### D5 — Resume replays the original plan and refuses unfaithful topology
 
@@ -544,6 +560,16 @@ Appending one event per completion would reduce full-file write amplification an
 more exact replay. It lost for the current implementation because it needs log framing,
 compaction, corruption recovery, schema migration, and a deterministic fold. A full JSON snapshot
 is much smaller operational machinery for current flow sizes.
+
+**Reversed in version 3.** That rejection stands for versions 1 and 2 and is kept as written,
+because it records why the full-snapshot writer was the right first shape. Version 3 adopts the
+event log in a bounded form and D4 above is the operative decision. The reversal is not a
+correction of the reasoning: every cost the rejection named is now paid rather than avoided.
+Framing is newline-delimited JSON, compaction is the generation-scoped base rewrite on a
+128-delta bound, corruption recovery is the valid-prefix rule with torn, gapped, malformed and
+stale-generation records disclosed in `_recovery`, and the fold is deterministic because records
+carry a monotonic per-generation sequence. What changed is the price of not paying it: a full
+rewrite per completion costs the serialization of all prior state, which grows with the run.
 
 ### Replan on resume
 

--- a/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
+++ b/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
@@ -283,7 +283,26 @@ Code anchor: `lionagi/operations/flow.py` (`_render_operator_messages`,
 `_render_pending_operator_steers`); `lionagi/cli/orchestrate/flow.py`
 (`_apply_session_control`).
 
-### D4 — Checkpoints are full JSON snapshots replaced atomically
+### D4 — Checkpoints use an atomic base plus a durable delta journal
+
+Version 3 replaces the per-completion full rewrite with two run-local files:
+
+- `checkpoint.json` is an atomic base snapshot carrying a generation id.
+- `checkpoint.json.journal` is newline-delimited, append-only operation, spawn, and top-level
+  context deltas for that generation.
+- A completion is acknowledged only after its journal record is flushed and fsynced. Serialization
+  and filesystem work run in a worker thread while one async lock preserves writer order.
+- Context snapshots are reduced to changed and deleted top-level keys. Completed operation responses
+  remain individually durable.
+- After 128 deltas, the writer atomically replaces the base with the recovered current state under a
+  new generation and then clears the journal. A journal from an older generation is never replayed
+  onto the new base.
+- Recovery applies the valid journal prefix in sequence order. A torn final line is ignored and
+  disclosed in `_recovery`; gaps, malformed records, and stale generations are also reported.
+- Versions 1 and 2 remain readable as single-file checkpoints. `CheckpointWriter` retains version 2
+  as its compatibility default; the flow runtime opts into version 3 explicitly.
+
+The following describes the retired single-file writer retained for compatibility.
 
 The writer is a run-local dataclass:
 
@@ -346,7 +365,7 @@ Wire shape:
 }
 ```
 
-Exact persistence semantics:
+Legacy version 1/2 persistence semantics:
 
 - A writer is created only when checkpoint configuration is provided. Fresh and resumed CLI flows
   construct one; unit seams that omit configuration do not.
@@ -372,9 +391,9 @@ Exact persistence semantics:
 `CHECKPOINT_VERSION = 1` marks the initial shipped shape. No rationale beyond initial format
 versioning is recorded.
 
-Why this way: full snapshots are simple to inspect and avoid a partial event-log replay protocol.
-Atomic replacement protects readers from torn target files. The cost is write amplification after
-every completion and the lack of fsync-level durability or schema migration enforcement.
+Why version 3: atomic replacement still protects the compacted base, while fsynced deltas keep
+completion writes proportional to the new data rather than all prior state. Generation ids make the
+two-file compaction boundary recoverable without replaying an obsolete journal.
 
 ### D5 — Resume replays the original plan and refuses unfaithful topology
 

--- a/docs/cookbook/resumable-background.md
+++ b/docs/cookbook/resumable-background.md
@@ -80,6 +80,7 @@ The highest-severity gaps in the auth module are:
 ```text
 ~/.lionagi/runs/<run_id>/
   checkpoint.json                    # resumable flow plan and operation state
+  checkpoint.json.journal            # ordered deltas since the latest compacted base
   branches/<branch_id>.json          # branch snapshot — restore point for -r
   stream/<branch_id>.buffer.jsonl    # live chunk buffer during stream
 

--- a/docs/guides/durable-operations.md
+++ b/docs/guides/durable-operations.md
@@ -62,14 +62,17 @@ Each CLI run owns a state directory:
 ~/.lionagi/runs/<run-id>/
 ├── run.json
 ├── checkpoint.json
+├── checkpoint.json.journal
 ├── branches/
 └── stream/
 ```
 
 `run.json` records the state and artifact roots. `branches/` contains resumable
-branch snapshots. `checkpoint.json` records flow progress. When `--save DIR`
-is present, worker and synthesis artifacts go to that directory; otherwise
-they live below the run's own `artifacts/` directory.
+branch snapshots. `checkpoint.json` is the flow's atomic base snapshot and
+`checkpoint.json.journal` records ordered completion deltas between bounded
+compactions. Resume reads both through the checkpoint loader. When `--save DIR`
+is present, worker and synthesis artifacts go to that directory; otherwise they
+live below the run's own `artifacts/` directory.
 
 ## Resume after a process stops
 

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -9,7 +9,9 @@ import copy
 import errno
 import json
 import os
+import stat
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -138,20 +140,16 @@ class CheckpointWriter:
         entry = {"agent_id": agent_id, "status": status, "response": response}
         async with self._lock:
             if self.version == CHECKPOINT_VERSION:
-                captured = _capture_context(flow_context)
-                await self._ensure_base_locked()
-                context_delta = await _context_delta_async(self.flow_context, captured)
-                delta = {"kind": "op", "entry": entry}
-                if context_delta is not None:
-                    delta["flow_context"] = context_delta
 
-                def apply() -> None:
+                def store() -> None:
                     self.ops[agent_id] = entry
-                    if captured is not None:
-                        self.flow_context = captured
 
-                await self._append_delta_locked(delta, apply)
-                await self._maybe_compact_locked()
+                await self._journal_locked(
+                    kind="op",
+                    entry=entry,
+                    flow_context=flow_context,
+                    apply_entry=store,
+                )
             else:
                 self.ops[agent_id] = entry
                 if flow_context is not None:
@@ -208,20 +206,12 @@ class CheckpointWriter:
 
         async with self._lock:
             if self.version == CHECKPOINT_VERSION:
-                captured = _capture_context(flow_context)
-                await self._ensure_base_locked()
-                context_delta = await _context_delta_async(self.flow_context, captured)
-                delta = {"kind": "spawned", "entry": entry}
-                if context_delta is not None:
-                    delta["flow_context"] = context_delta
-
-                def apply() -> None:
-                    upsert()
-                    if captured is not None:
-                        self.flow_context = captured
-
-                await self._append_delta_locked(delta, apply)
-                await self._maybe_compact_locked()
+                await self._journal_locked(
+                    kind="spawned",
+                    entry=entry,
+                    flow_context=flow_context,
+                    apply_entry=upsert,
+                )
             else:
                 upsert()
                 if flow_context is not None:
@@ -298,6 +288,37 @@ class CheckpointWriter:
                 if apply_state is not None:
                     apply_state()
 
+    async def _journal_locked(
+        self,
+        *,
+        kind: str,
+        entry: dict[str, Any],
+        flow_context: dict[str, Any] | None,
+        apply_entry: Callable[[], None],
+    ) -> None:
+        """Journal one completion as a delta and advance memory with the file.
+
+        One copy rather than one per record kind. The steps are ordered against
+        each other -- the context is frozen before anything can await, the
+        baseline exists before a delta is taken against it, and memory advances
+        only where the record reached the file -- and two copies of an ordering
+        is an ordering that can be changed in one place.
+        """
+        captured = _capture_context(flow_context)
+        await self._ensure_base_locked()
+        context_delta = await _context_delta_async(self.flow_context, captured)
+        delta: dict[str, Any] = {"kind": kind, "entry": entry}
+        if context_delta is not None:
+            delta["flow_context"] = context_delta
+
+        def apply() -> None:
+            apply_entry()
+            if captured is not None:
+                self.flow_context = captured
+
+        await self._append_delta_locked(delta, apply)
+        await self._maybe_compact_locked()
+
     async def _maybe_compact_locked(self) -> None:
         if self._delta_count >= self.compact_every:
             await self._write_v3_base_locked()
@@ -336,6 +357,18 @@ def _serialize_json(value: Any) -> bytes:
 # quietly depend on which platform this runs on.
 _NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
+# Opening a FIFO for writing waits until someone opens it for reading, which is
+# a wait with no timeout in the middle of a checkpoint write. O_NONBLOCK turns
+# that into an immediate ENXIO, and it has no effect on the regular files this
+# is actually meant to open, so the inode check below gets to run before
+# anything can block on what it is about to refuse.
+_NONBLOCK = getattr(os, "O_NONBLOCK", 0)
+
+# Ownership and permission bits mean what they say on POSIX. On Windows the
+# same fields are synthesized and every file would look world-readable, so the
+# two checks that read them are asked only where the answer is real.
+_POSIX_IDENTITY = hasattr(os, "getuid")
+
 # Checkpoint state and journal records carry raw operation responses and the
 # shared flow context. Every file this module creates is owner-only, and the
 # mode is set on the descriptor rather than left to the process umask, which
@@ -365,18 +398,49 @@ def _refuse_if_symlinked(descriptor: int, path: Path) -> None:
         raise JournalPathError(f"refusing to use a symlinked path: {path}")
 
 
+def _refuse_unsafe_inode(descriptor: int, path: Path) -> None:
+    """Refuse anything at this name but a private regular file of our own.
+
+    O_NOFOLLOW covers a symlink at the final component and nothing else, and
+    0600 describes a file this process created. Neither says anything about an
+    inode that was already there, which is the case that matters: the journal
+    is opened by name on every delta, so whatever is sitting at that name is
+    what the records go into.
+
+    What can be sitting there: a FIFO or device, where the open itself is the
+    attack; a hard link to a file elsewhere, where the creation mode never
+    applies because nothing was created; or a pre-made world-readable file,
+    same reason. Journal records carry raw operation responses and the shared
+    flow context, so each of those is a disclosure of both.
+    """
+    info = os.fstat(descriptor)
+    if not stat.S_ISREG(info.st_mode):
+        raise JournalPathError(f"refusing a path that is not a regular file: {path}")
+    if info.st_nlink != 1:
+        raise JournalPathError(f"refusing a path that is linked from somewhere else: {path}")
+    if _POSIX_IDENTITY:
+        if info.st_uid != os.getuid():
+            raise JournalPathError(f"refusing a path owned by another user: {path}")
+        if info.st_mode & 0o077:
+            raise JournalPathError(f"refusing a path readable beyond its owner: {path}")
+
+
 def _open_no_follow(path: Path, flags: int, mode: int = _PRIVATE_MODE) -> int:
     try:
-        descriptor = os.open(path, flags | _NOFOLLOW, mode)
+        descriptor = os.open(path, flags | _NOFOLLOW | _NONBLOCK, mode)
     except OSError as exc:
         # ELOOP is what O_NOFOLLOW reports for a symlinked final component.
         if exc.errno == errno.ELOOP:
             raise JournalPathError(f"refusing to use a symlinked path: {path}") from exc
+        # ENXIO is a write-side open of a FIFO nobody is reading. Without
+        # O_NONBLOCK this call would still be waiting instead of raising.
+        if exc.errno == errno.ENXIO:
+            raise JournalPathError(f"refusing a path that is not a regular file: {path}") from exc
         raise
-    if _NOFOLLOW:
-        return descriptor
     try:
-        _refuse_if_symlinked(descriptor, path)
+        if not _NOFOLLOW:
+            _refuse_if_symlinked(descriptor, path)
+        _refuse_unsafe_inode(descriptor, path)
     except BaseException:
         os.close(descriptor)
         raise
@@ -489,6 +553,7 @@ def _append_journal_record(path: Path, record: dict[str, Any]) -> int:
     payload = _serialize_json(record) + b"\n"
     path.parent.mkdir(parents=True, exist_ok=True)
     descriptor = _open_no_follow(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+    closed = False
     try:
         written = _write_all(descriptor, payload)
         # Past this point the bytes are in the file. fsync decides whether they
@@ -498,8 +563,27 @@ def _append_journal_record(path: Path, record: dict[str, Any]) -> int:
             os.fsync(descriptor)
         except OSError as exc:
             raise _RecordReachedFileError(written, exc) from exc
+        # Closed here rather than in the `finally` below. A close that fails
+        # from a `finally` replaces whatever the block was returning or
+        # raising, so the byte count goes with it -- and the caller reads a
+        # lost count as a record that never landed, keeps the sequence number,
+        # and spends it again on the next record. Recovery then meets the same
+        # sequence twice and stops there, discarding every completion after it.
+        # The descriptor is gone either way once close returns, error or not.
+        try:
+            os.close(descriptor)
+        except OSError as exc:
+            raise _RecordReachedFileError(written, exc) from exc
+        finally:
+            closed = True
     finally:
-        os.close(descriptor)
+        if not closed:
+            try:
+                os.close(descriptor)
+            except OSError:
+                # Nothing left to salvage: this path is already unwinding a
+                # failure that has the byte count in it.
+                pass
     return written
 
 

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -5,8 +5,10 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import os
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -26,7 +28,9 @@ __all__ = (
     "resolve_checkpoint_target",
 )
 
-CHECKPOINT_VERSION = 2
+LEGACY_CHECKPOINT_VERSION = 2
+CHECKPOINT_VERSION = 3
+_DEFAULT_COMPACT_EVERY = 128
 
 
 class FlowResumeError(LionError):
@@ -35,28 +39,59 @@ class FlowResumeError(LionError):
 
 @dataclass
 class CheckpointWriter:
-    """Serializes checkpoint writes so concurrent op completions never tear the file on disk.
-
-    Every write serializes the FULL current state to a unique temp name and
-    renames it into place, so a reader only ever sees a complete file; a lock
-    held across serialize-write-rename keeps renames in acquisition order.
-    """
+    """Serialize checkpoint updates in completion order without blocking the event loop."""
 
     path: Path
     session_id: str
     prompt: str
     plan: list[dict]
     config: dict[str, Any]
+    version: int = LEGACY_CHECKPOINT_VERSION
+    compact_every: int = _DEFAULT_COMPACT_EVERY
     max_spawn: int | None = None
     flow_context: dict[str, Any] = field(default_factory=dict)
     ops: dict[str, dict[str, Any]] = field(default_factory=dict)
     spawned: list[dict] = field(default_factory=list)
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
     _seq: int = field(default=0, repr=False, compare=False)
+    _generation: str = field(default_factory=lambda: uuid.uuid4().hex, repr=False, compare=False)
+    _journal_seq: int = field(default=0, repr=False, compare=False)
+    _delta_count: int = field(default=0, repr=False, compare=False)
+    _bytes_written: int = field(default=0, repr=False, compare=False)
+    _base_ready: bool = field(default=False, repr=False, compare=False)
+    _journal_reset_required: bool = field(default=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self.version not in (LEGACY_CHECKPOINT_VERSION, CHECKPOINT_VERSION):
+            raise ValueError(f"unsupported checkpoint version: {self.version}")
+        if self.compact_every < 1:
+            raise ValueError("compact_every must be at least 1")
+
+    @property
+    def journal_path(self) -> Path:
+        return self.path.with_name(f"{self.path.name}.journal")
+
+    @property
+    def bytes_written(self) -> int:
+        return self._bytes_written
+
+    def journal_records(self) -> list[dict[str, Any]]:
+        """Read complete records for the active generation, primarily for diagnostics."""
+        if not self.journal_path.exists():
+            return []
+        records: list[dict[str, Any]] = []
+        for line in self.journal_path.read_bytes().splitlines():
+            try:
+                record = json.loads(line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                break
+            if isinstance(record, dict) and record.get("generation") == self._generation:
+                records.append(record)
+        return records
 
     def to_dict(self) -> dict[str, Any]:
-        checkpoint = {
-            "version": CHECKPOINT_VERSION,
+        state: dict[str, Any] = {
+            "version": self.version,
             "session_id": self.session_id,
             "prompt": self.prompt,
             "plan": self.plan,
@@ -66,8 +101,11 @@ class CheckpointWriter:
             "config": self.config,
         }
         if self.max_spawn is not None:
-            checkpoint["max_spawn"] = self.max_spawn
-        return checkpoint
+            state["max_spawn"] = self.max_spawn
+        if self.version == CHECKPOINT_VERSION:
+            state["generation"] = self._generation
+            state["journal_seq"] = 0
+        return state
 
     async def record(
         self,
@@ -83,11 +121,25 @@ class CheckpointWriter:
         shared context workspace — latest wins, since it accumulates rather
         than being per-op data.
         """
+        entry = {"agent_id": agent_id, "status": status, "response": response}
         async with self._lock:
-            self.ops[agent_id] = {"agent_id": agent_id, "status": status, "response": response}
-            if flow_context is not None:
-                self.flow_context = flow_context
-            await self._write_locked()
+            if self.version == CHECKPOINT_VERSION:
+                captured = _capture_context(flow_context)
+                await self._ensure_base_locked()
+                context_delta = await _context_delta_async(self.flow_context, captured)
+                delta = {"kind": "op", "entry": entry}
+                if context_delta is not None:
+                    delta["flow_context"] = context_delta
+                await self._append_delta_locked(delta)
+                self.ops[agent_id] = entry
+                if captured is not None:
+                    self.flow_context = captured
+                await self._maybe_compact_locked()
+            else:
+                self.ops[agent_id] = entry
+                if flow_context is not None:
+                    self.flow_context = flow_context
+                await self._write_locked()
 
     async def record_spawned(
         self,
@@ -117,32 +169,51 @@ class CheckpointWriter:
         distinct from `instruction` (generic boilerplate for a team round);
         `None` when there's no context payload.
         """
+        entry = {
+            "node_id": node_id,
+            "status": status,
+            "response": response,
+            "operation": operation,
+            "assignee": assignee,
+            "instruction": instruction,
+            "parent_id": parent_id,
+            "spawn_id": spawn_id,
+            "context": context,
+        }
         async with self._lock:
-            entry = {
-                "node_id": node_id,
-                "status": status,
-                "response": response,
-                "operation": operation,
-                "assignee": assignee,
-                "instruction": instruction,
-                "parent_id": parent_id,
-                "spawn_id": spawn_id,
-                "context": context,
-            }
+            captured = (
+                _capture_context(flow_context) if self.version == CHECKPOINT_VERSION else None
+            )
+            if self.version == CHECKPOINT_VERSION:
+                await self._ensure_base_locked()
+                context_delta = await _context_delta_async(self.flow_context, captured)
+                delta = {"kind": "spawned", "entry": entry}
+                if context_delta is not None:
+                    delta["flow_context"] = context_delta
+                await self._append_delta_locked(delta)
             for i, existing in enumerate(self.spawned):
                 if existing.get("node_id") == node_id:
                     self.spawned[i] = entry
                     break
             else:
                 self.spawned.append(entry)
-            if flow_context is not None:
+            if self.version == CHECKPOINT_VERSION:
+                if captured is not None:
+                    self.flow_context = captured
+            elif flow_context is not None:
                 self.flow_context = flow_context
-            await self._write_locked()
+            if self.version == CHECKPOINT_VERSION:
+                await self._maybe_compact_locked()
+            else:
+                await self._write_locked()
 
     async def flush(self) -> None:
         """Persist the current state without changing any op entry."""
         async with self._lock:
-            await self._write_locked()
+            if self.version == CHECKPOINT_VERSION:
+                await self._write_v3_base_locked()
+            else:
+                await self._write_locked()
 
     async def _write_locked(self) -> None:
         self._seq += 1
@@ -156,9 +227,286 @@ class CheckpointWriter:
         tmp.write_text(payload)
         os.replace(tmp, self.path)
 
+    async def _ensure_base_locked(self) -> None:
+        if not self._base_ready:
+            await self._write_v3_base_locked()
+        elif self._journal_reset_required:
+            written = await _durable_to_thread(_atomic_write_bytes, self.journal_path, b"")
+            self._bytes_written += written
+            self._journal_reset_required = False
+
+    async def _append_delta_locked(self, delta: dict[str, Any]) -> None:
+        next_seq = self._journal_seq + 1
+        record = {
+            "version": CHECKPOINT_VERSION,
+            "generation": self._generation,
+            "seq": next_seq,
+            **delta,
+        }
+        written = await _durable_to_thread(_append_journal_record, self.journal_path, record)
+        self._bytes_written += written
+        self._journal_seq = next_seq
+        self._delta_count += 1
+        self._seq += 1
+
+    async def _maybe_compact_locked(self) -> None:
+        if self._delta_count >= self.compact_every:
+            await self._write_v3_base_locked()
+
+    async def _write_v3_base_locked(self) -> None:
+        previous_generation = self._generation
+        self._generation = uuid.uuid4().hex
+        state = self.to_dict()
+        try:
+            written = await _durable_to_thread(_atomic_write_json, self.path, state)
+        except BaseException:
+            self._generation = previous_generation
+            raise
+
+        self._bytes_written += written
+        self._journal_seq = 0
+        self._delta_count = 0
+        self._base_ready = True
+        self._journal_reset_required = True
+        written = await _durable_to_thread(_atomic_write_bytes, self.journal_path, b"")
+        self._bytes_written += written
+        self._journal_reset_required = False
+
+
+def _serialize_json(value: Any) -> bytes:
+    raise_if_non_finite(value, default=str)
+    return json.dumps(value, default=str, separators=(",", ":")).encode()
+
+
+async def _durable_to_thread(function: Any, *args: Any) -> Any:
+    """Finish a started durable write even if its bookkeeping task is cancelled."""
+    task = asyncio.create_task(asyncio.to_thread(function, *args))
+    while True:
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            # asyncio cannot stop the worker thread. Returning early would let
+            # the in-memory sequence lag a record that can still reach disk,
+            # so wait through cancellation and advance both states together.
+            if task.done():
+                return task.result()
+
+
+def _fsync_parent(path: Path) -> None:
+    try:
+        descriptor = os.open(path.parent, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_write_bytes(path: Path, payload: bytes) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with tmp.open("wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp, path)
+        _fsync_parent(path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+    return len(payload)
+
+
+def _atomic_write_json(path: Path, value: Any) -> int:
+    return _atomic_write_bytes(path, _serialize_json(value))
+
+
+def _append_journal_record(path: Path, record: dict[str, Any]) -> int:
+    payload = _serialize_json(record) + b"\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("ab") as stream:
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+    return len(payload)
+
+
+def _context_snapshot(current: dict[str, Any]) -> dict[str, Any]:
+    """Baseline for the next delta, insulated from later in-place mutation.
+
+    The caller holds a live reference to the shared context workspace and keeps
+    mutating it between completions. A shallow copy shares every nested value
+    with that workspace, so a nested mutation compares equal against the
+    baseline, journals no delta, and a crash before compaction resumes with
+    context the run had already moved past.
+    """
+    try:
+        return copy.deepcopy(current)
+    except Exception:
+        # Something here refuses to be deep-copied. The journal already
+        # requires this to serialize, so fall back to the serialized form
+        # rather than to a shallow copy that reintroduces the aliasing.
+        return json.loads(_serialize_json(current))
+
+
+def _capture_context(current: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Freeze the caller's live workspace before anything can await on it.
+
+    This has to run synchronously, and that is the whole point of it being a
+    separate call. The caller keeps a reference to the shared context and goes
+    on mutating it between completions, so every ``await`` between reading the
+    context and storing it is a window in which it can change underneath us.
+
+    Deriving the journal delta from the live dict and then snapshotting the
+    live dict again afterwards puts those two reads on opposite sides of that
+    window. A mutation landing inside it enters the new baseline without ever
+    entering a delta, and because the baseline now contains it, the next
+    comparison sees it as unchanged and never journals it either: recovery
+    restores context the run had already moved past, permanently. Capturing
+    once up front and deriving both the delta and the next baseline from that
+    one value is what makes them describe the same state by construction.
+
+    Moving this off the event loop with ``to_thread`` would reintroduce
+    exactly the window it exists to close.
+    """
+    if current is None:
+        return None
+    return _context_snapshot(current)
+
+
+def _context_delta(
+    previous: dict[str, Any], current: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    if current is None:
+        return None
+    changed = {
+        key: value
+        for key, value in current.items()
+        if key not in previous or previous[key] != value
+    }
+    removed = [key for key in previous if key not in current]
+    if not changed and not removed:
+        return None
+    return {"set": changed, "delete": removed}
+
+
+async def _context_delta_async(
+    previous: dict[str, Any], current: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    return await asyncio.to_thread(_context_delta, previous, current)
+
 
 def load_checkpoint(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text())
+    state = json.loads(path.read_text())
+    if state.get("version") != CHECKPOINT_VERSION:
+        return state
+
+    journal_path = path.with_name(f"{path.name}.journal")
+    if not journal_path.exists():
+        return state
+
+    recovery: dict[str, Any] = {}
+    expected_seq = int(state.get("journal_seq") or 0) + 1
+    stale_records = 0
+    raw = journal_path.read_bytes()
+    for line_number, line in enumerate(raw.splitlines(keepends=True), start=1):
+        if not line.endswith(b"\n"):
+            recovery.update({"torn_final_record": True, "line": line_number})
+            break
+        try:
+            record = json.loads(line)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            recovery.update(
+                {
+                    "invalid_record": True,
+                    "line": line_number,
+                    "error": type(exc).__name__,
+                }
+            )
+            break
+        if not isinstance(record, dict):
+            recovery.update({"invalid_record": True, "line": line_number})
+            break
+        if record.get("generation") != state.get("generation"):
+            stale_records += 1
+            continue
+        if record.get("seq") != expected_seq:
+            recovery.update(
+                {
+                    "invalid_sequence": True,
+                    "line": line_number,
+                    "expected": expected_seq,
+                    "actual": record.get("seq"),
+                }
+            )
+            break
+        if not _apply_journal_record(state, record):
+            recovery.update({"invalid_record": True, "line": line_number})
+            break
+        state["journal_seq"] = expected_seq
+        expected_seq += 1
+
+    if stale_records:
+        recovery["stale_generation_records"] = stale_records
+    if recovery:
+        state["_recovery"] = recovery
+    return state
+
+
+def _apply_journal_record(state: dict[str, Any], record: dict[str, Any]) -> bool:
+    entry = record.get("entry")
+    if not isinstance(entry, dict):
+        return False
+    kind = record.get("kind")
+    if kind == "op":
+        entry_id = entry.get("agent_id")
+        if not isinstance(entry_id, str):
+            return False
+    elif kind == "spawned":
+        entry_id = entry.get("node_id")
+        if not isinstance(entry_id, str):
+            return False
+    else:
+        return False
+
+    context_delta = record.get("flow_context")
+    changed: dict[str, Any] = {}
+    removed: list[Any] = []
+    if context_delta is not None:
+        if not isinstance(context_delta, dict):
+            return False
+        changed = context_delta.get("set", {})
+        removed = context_delta.get("delete", [])
+        if not isinstance(changed, dict) or not isinstance(removed, list):
+            return False
+        flow_context = state.setdefault("flow_context", {})
+        if not isinstance(flow_context, dict):
+            return False
+        if any(not isinstance(key, str) for key in removed):
+            return False
+
+    if kind == "op":
+        state.setdefault("ops", {})[entry_id] = entry
+    else:
+        spawned = state.setdefault("spawned", [])
+        for index, existing in enumerate(spawned):
+            if isinstance(existing, dict) and existing.get("node_id") == entry_id:
+                spawned[index] = entry
+                break
+        else:
+            spawned.append(entry)
+
+    if context_delta is not None:
+        flow_context.update(changed)
+        for key in removed:
+            flow_context.pop(key, None)
+    return True
 
 
 def _find_run_dir_by_id(run_id: str) -> RunDir | None:

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -63,6 +63,9 @@ class CheckpointWriter:
     _bytes_written: int = field(default=0, repr=False, compare=False)
     _base_ready: bool = field(default=False, repr=False, compare=False)
     _journal_reset_required: bool = field(default=False, repr=False, compare=False)
+    # Device and inode of the journal this writer created, so an append can
+    # tell "the file I made" from "a file at the name I use".
+    _journal_identity: tuple[int, int] | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         if self.version not in (LEGACY_CHECKPOINT_VERSION, CHECKPOINT_VERSION):
@@ -246,6 +249,9 @@ class CheckpointWriter:
         elif self._journal_reset_required:
             written = await _durable_to_thread(_atomic_write_bytes, self.journal_path, b"")
             self._bytes_written += written
+            self._journal_identity = await _durable_to_thread(
+                _read_inode_identity, self.journal_path
+            )
             self._journal_reset_required = False
 
     async def _append_delta_locked(self, delta: dict[str, Any], apply_state: Any = None) -> None:
@@ -266,7 +272,9 @@ class CheckpointWriter:
         }
         written = 0
         try:
-            written = await _durable_to_thread(_append_journal_record, self.journal_path, record)
+            written = await _durable_to_thread(
+                _append_journal_record, self.journal_path, record, self._journal_identity
+            )
         except _RecordReachedFileError as exc:
             # The record is in the file even though its durability is
             # unconfirmed, so this sequence number is spent. Leaving it unspent
@@ -340,6 +348,7 @@ class CheckpointWriter:
         self._journal_reset_required = True
         written = await _durable_to_thread(_atomic_write_bytes, self.journal_path, b"")
         self._bytes_written += written
+        self._journal_identity = await _durable_to_thread(_read_inode_identity, self.journal_path)
         self._journal_reset_required = False
 
 
@@ -412,6 +421,11 @@ def _refuse_unsafe_inode(descriptor: int, path: Path) -> None:
     applies because nothing was created; or a pre-made world-readable file,
     same reason. Journal records carry raw operation responses and the shared
     flow context, so each of those is a disclosure of both.
+
+    What this cannot see is a private regular file belonging to us, because
+    that is what a healthy journal looks like. `_refuse_replaced_inode` is the
+    other half: it asks whether this is the particular private file we made,
+    which is the question a same-user process substituting one can fail.
     """
     info = os.fstat(descriptor)
     if not stat.S_ISREG(info.st_mode):
@@ -423,6 +437,33 @@ def _refuse_unsafe_inode(descriptor: int, path: Path) -> None:
             raise JournalPathError(f"refusing a path owned by another user: {path}")
         if info.st_mode & 0o077:
             raise JournalPathError(f"refusing a path readable beyond its owner: {path}")
+
+
+def _refuse_replaced_inode(descriptor: int, path: Path, expected: tuple[int, int]) -> None:
+    """Refuse a journal that is not the one this writer created at that name.
+
+    Every kind-and-ownership question `_refuse_unsafe_inode` asks is answered
+    the same way by our own journal and by a private regular file someone else
+    made and still holds open. Identity is the question that separates them,
+    and it is answerable because a journal is only ever created here: the base
+    write replaces it under O_EXCL before the first record, and compaction
+    replaces it again, so between those points the file at that name should not
+    change. If it has, records carrying raw responses and the shared flow
+    context are about to go somewhere other than where the last one went.
+    """
+    info = os.fstat(descriptor)
+    if (info.st_dev, info.st_ino) != expected:
+        raise JournalPathError(f"refusing a journal that was replaced after it was created: {path}")
+
+
+def _read_inode_identity(path: Path) -> tuple[int, int]:
+    """Device and inode of `path`, read through the same refusals a write takes."""
+    descriptor = _open_no_follow(path, os.O_RDONLY)
+    try:
+        info = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    return (info.st_dev, info.st_ino)
 
 
 def _open_no_follow(path: Path, flags: int, mode: int = _PRIVATE_MODE) -> int:
@@ -549,12 +590,20 @@ class _RecordReachedFileError(Exception):
         self.cause = cause
 
 
-def _append_journal_record(path: Path, record: dict[str, Any]) -> int:
+def _append_journal_record(
+    path: Path,
+    record: dict[str, Any],
+    expected_identity: tuple[int, int] | None = None,
+) -> int:
     payload = _serialize_json(record) + b"\n"
     path.parent.mkdir(parents=True, exist_ok=True)
     descriptor = _open_no_follow(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT)
     closed = False
     try:
+        # Before the payload, never after: the point is that these bytes do not
+        # reach a file we did not make.
+        if expected_identity is not None:
+            _refuse_replaced_inode(descriptor, path, expected_identity)
         written = _write_all(descriptor, payload)
         # Past this point the bytes are in the file. fsync decides whether they
         # survive a power loss, not whether they are there, so a failure here

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -247,11 +247,11 @@ class CheckpointWriter:
         if not self._base_ready:
             await self._write_v3_base_locked()
         elif self._journal_reset_required:
-            written = await _durable_to_thread(_atomic_write_bytes, self.journal_path, b"")
-            self._bytes_written += written
-            self._journal_identity = await _durable_to_thread(
-                _read_inode_identity, self.journal_path
+            written, identity = await _durable_to_thread(
+                _atomic_write_bytes, self.journal_path, b""
             )
+            self._bytes_written += written
+            self._journal_identity = identity
             self._journal_reset_required = False
 
     async def _append_delta_locked(self, delta: dict[str, Any], apply_state: Any = None) -> None:
@@ -346,9 +346,9 @@ class CheckpointWriter:
         self._delta_count = 0
         self._base_ready = True
         self._journal_reset_required = True
-        written = await _durable_to_thread(_atomic_write_bytes, self.journal_path, b"")
+        written, identity = await _durable_to_thread(_atomic_write_bytes, self.journal_path, b"")
         self._bytes_written += written
-        self._journal_identity = await _durable_to_thread(_read_inode_identity, self.journal_path)
+        self._journal_identity = identity
         self._journal_reset_required = False
 
 
@@ -450,20 +450,14 @@ def _refuse_replaced_inode(descriptor: int, path: Path, expected: tuple[int, int
     replaces it again, so between those points the file at that name should not
     change. If it has, records carrying raw responses and the shared flow
     context are about to go somewhere other than where the last one went.
+
+    `expected` is taken from the descriptor the replacing write held, never
+    from a later read of the name, so there is no moment at which a substitute
+    could become the file this compares against.
     """
     info = os.fstat(descriptor)
     if (info.st_dev, info.st_ino) != expected:
         raise JournalPathError(f"refusing a journal that was replaced after it was created: {path}")
-
-
-def _read_inode_identity(path: Path) -> tuple[int, int]:
-    """Device and inode of `path`, read through the same refusals a write takes."""
-    descriptor = _open_no_follow(path, os.O_RDONLY)
-    try:
-        info = os.fstat(descriptor)
-    finally:
-        os.close(descriptor)
-    return (info.st_dev, info.st_ino)
 
 
 def _open_no_follow(path: Path, flags: int, mode: int = _PRIVATE_MODE) -> int:
@@ -545,7 +539,13 @@ def _open_private_new(path: Path) -> int:
     return os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, _PRIVATE_MODE)
 
 
-def _write_private_bytes(path: Path, payload: bytes) -> None:
+def _write_private_bytes(path: Path, payload: bytes) -> tuple[int, int]:
+    """Write `payload` into a file this call created, and say which file it is.
+
+    The device and inode come off the descriptor rather than the name. Nobody
+    else can have substituted the file this returns, because the descriptor was
+    never reopened.
+    """
     descriptor = _open_private_new(path)
     try:
         stream = os.fdopen(descriptor, "wb")
@@ -556,13 +556,23 @@ def _write_private_bytes(path: Path, payload: bytes) -> None:
         stream.write(payload)
         stream.flush()
         os.fsync(stream.fileno())
+        info = os.fstat(stream.fileno())
+    return (info.st_dev, info.st_ino)
 
 
-def _atomic_write_bytes(path: Path, payload: bytes) -> int:
+def _atomic_write_bytes(path: Path, payload: bytes) -> tuple[int, tuple[int, int]]:
+    """Replace `path` with `payload`, reporting the bytes and the resulting file.
+
+    A rename moves a directory entry onto an existing inode, so the identity
+    taken from the temporary file before the replace is the identity `path`
+    has after it. Reading it back by name instead would leave a window between
+    the replace and the read where someone can put a different file there and
+    have it be the one that gets pinned.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
     try:
-        _write_private_bytes(tmp, payload)
+        identity = _write_private_bytes(tmp, payload)
         os.replace(tmp, path)
         _fsync_parent(path)
     finally:
@@ -570,11 +580,12 @@ def _atomic_write_bytes(path: Path, payload: bytes) -> int:
             tmp.unlink()
         except FileNotFoundError:
             pass
-    return len(payload)
+    return len(payload), identity
 
 
 def _atomic_write_json(path: Path, value: Any) -> int:
-    return _atomic_write_bytes(path, _serialize_json(value))
+    written, _ = _atomic_write_bytes(path, _serialize_json(value))
+    return written
 
 
 class _RecordReachedFileError(Exception):

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import errno
 import json
 import os
 import uuid
@@ -80,13 +81,18 @@ class CheckpointWriter:
         if not self.journal_path.exists():
             return []
         records: list[dict[str, Any]] = []
-        for line in self.journal_path.read_bytes().splitlines():
+        for line in _read_bytes_no_follow(self.journal_path).splitlines():
             try:
                 record = json.loads(line)
             except (json.JSONDecodeError, UnicodeDecodeError):
                 break
-            if isinstance(record, dict) and record.get("generation") == self._generation:
-                records.append(record)
+            if not isinstance(record, dict) or record.get("generation") != self._generation:
+                continue
+            # Stops where recovery stops. A diagnostic that lists records
+            # recovery would refuse describes a state the run cannot reach.
+            if record.get("version") != CHECKPOINT_VERSION:
+                break
+            records.append(record)
         return records
 
     def to_dict(self) -> dict[str, Any]:
@@ -243,11 +249,27 @@ class CheckpointWriter:
             "seq": next_seq,
             **delta,
         }
-        written = await _durable_to_thread(_append_journal_record, self.journal_path, record)
-        self._bytes_written += written
-        self._journal_seq = next_seq
-        self._delta_count += 1
-        self._seq += 1
+        written = 0
+        try:
+            written = await _durable_to_thread(_append_journal_record, self.journal_path, record)
+        except _RecordReachedFileError as exc:
+            # The record is in the file even though its durability is
+            # unconfirmed, so this sequence number is spent. Leaving it unspent
+            # would let a retry write a second record carrying the same seq;
+            # recovery treats that as corruption, stops at it, and discards
+            # every completed record after it. The error still propagates: the
+            # caller asked for a durable write and did not get one.
+            written = exc.written
+            # Re-raise what actually failed. This wrapper is only how the byte
+            # count travels back from the worker thread; callers still see the
+            # OSError their fsync raised, not a new exception type from here.
+            raise exc.cause from None
+        finally:
+            if written:
+                self._bytes_written += written
+                self._journal_seq = next_seq
+                self._delta_count += 1
+                self._seq += 1
 
     async def _maybe_compact_locked(self) -> None:
         if self._delta_count >= self.compact_every:
@@ -276,6 +298,42 @@ class CheckpointWriter:
 def _serialize_json(value: Any) -> bytes:
     raise_if_non_finite(value, default=str)
     return json.dumps(value, default=str, separators=(",", ":")).encode()
+
+
+# Refuses a final path component that is a symlink. The journal is appended to
+# by name on every delta and read back by name during recovery, so a symlink
+# planted at that name redirects the writer into an arbitrary file and feeds
+# recovery contents this process never wrote. The intermediate directories are
+# not covered, and neither is any platform without the flag, where this degrades
+# to an ordinary open.
+_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+
+class JournalPathError(LionError):
+    """Raised when a journal path is not the regular file it must be."""
+
+
+def _open_no_follow(path: Path, flags: int, mode: int = 0o600) -> int:
+    try:
+        return os.open(path, flags | _NOFOLLOW, mode)
+    except OSError as exc:
+        # ELOOP is what O_NOFOLLOW reports for a symlinked final component.
+        if exc.errno == errno.ELOOP:
+            raise JournalPathError(f"refusing to use a symlinked path: {path}") from exc
+        raise
+
+
+def _read_bytes_no_follow(path: Path) -> bytes:
+    descriptor = _open_no_follow(path, os.O_RDONLY)
+    try:
+        stream = os.fdopen(descriptor, "rb")
+    except BaseException:
+        # fdopen takes ownership only once it returns, so this is the one window
+        # where the descriptor is still ours to close.
+        os.close(descriptor)
+        raise
+    with stream:
+        return stream.read()
 
 
 async def _durable_to_thread(function: Any, *args: Any) -> Any:
@@ -327,13 +385,38 @@ def _atomic_write_json(path: Path, value: Any) -> int:
     return _atomic_write_bytes(path, _serialize_json(value))
 
 
+class _RecordReachedFileError(Exception):
+    """A journal record was written but its durability could not be confirmed.
+
+    Carries the byte count so the caller can settle its bookkeeping against what
+    the file now holds rather than against what the call returned.
+    """
+
+    def __init__(self, written: int, cause: BaseException) -> None:
+        super().__init__(str(cause))
+        self.written = written
+        self.cause = cause
+
+
 def _append_journal_record(path: Path, record: dict[str, Any]) -> int:
     payload = _serialize_json(record) + b"\n"
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("ab") as stream:
+    descriptor = _open_no_follow(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+    try:
+        stream = os.fdopen(descriptor, "ab")
+    except BaseException:
+        os.close(descriptor)
+        raise
+    with stream:
         stream.write(payload)
         stream.flush()
-        os.fsync(stream.fileno())
+        # Past this point the bytes are in the file. fsync decides whether they
+        # survive a power loss, not whether they are there, so a failure here
+        # must not be reported as a write that did not happen.
+        try:
+            os.fsync(stream.fileno())
+        except OSError as exc:
+            raise _RecordReachedFileError(len(payload), exc) from exc
     return len(payload)
 
 
@@ -380,6 +463,33 @@ def _capture_context(current: dict[str, Any] | None) -> dict[str, Any] | None:
     return _context_snapshot(current)
 
 
+def _same_once_serialized(previous: Any, current: Any) -> bool:
+    """Whether two values are the same *as the journal will store them*.
+
+    Python equality is the wrong test here because it is coarser than JSON in
+    exactly the direction that loses data. ``1 == 1.0`` and ``True == 1`` both
+    hold, and ``[1] == [1.0]`` follows, so a context whose value changed from
+    ``1`` to ``1.0`` compared equal, journaled nothing, and left recovery
+    restoring the older value from the base -- permanently, since the next
+    comparison found no difference either.
+
+    Keys are sorted so that a dict rebuilt in a different order is not reported
+    as a change. Where a value cannot be serialized at all, the answer is
+    "different": journaling a delta that turns out to be unnecessary costs a
+    record, and skipping one that was necessary costs the value.
+    """
+    if previous is current:
+        return True
+    try:
+        return _canonical_json(previous) == _canonical_json(current)
+    except (TypeError, ValueError, RecursionError):
+        return False
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(value, default=str, separators=(",", ":"), sort_keys=True).encode()
+
+
 def _context_delta(
     previous: dict[str, Any], current: dict[str, Any] | None
 ) -> dict[str, Any] | None:
@@ -388,7 +498,7 @@ def _context_delta(
     changed = {
         key: value
         for key, value in current.items()
-        if key not in previous or previous[key] != value
+        if key not in previous or not _same_once_serialized(previous[key], value)
     }
     removed = [key for key in previous if key not in current]
     if not changed and not removed:
@@ -414,7 +524,7 @@ def load_checkpoint(path: Path) -> dict[str, Any]:
     recovery: dict[str, Any] = {}
     expected_seq = int(state.get("journal_seq") or 0) + 1
     stale_records = 0
-    raw = journal_path.read_bytes()
+    raw = _read_bytes_no_follow(journal_path)
     for line_number, line in enumerate(raw.splitlines(keepends=True), start=1):
         if not line.endswith(b"\n"):
             recovery.update({"torn_final_record": True, "line": line_number})
@@ -436,6 +546,22 @@ def load_checkpoint(path: Path) -> dict[str, Any]:
         if record.get("generation") != state.get("generation"):
             stale_records += 1
             continue
+        # Checked only for records of the active generation, and before the
+        # record is applied. A version this build does not know is a record
+        # whose meaning it cannot read: applying it anyway would write a
+        # guess into recovered state under the name of a durable record.
+        # Stopping here is the same treatment a torn or malformed record gets,
+        # and it leaves everything already applied intact.
+        if record.get("version") != CHECKPOINT_VERSION:
+            recovery.update(
+                {
+                    "unsupported_record_version": True,
+                    "line": line_number,
+                    "expected": CHECKPOINT_VERSION,
+                    "actual": record.get("version"),
+                }
+            )
+            break
         if record.get("seq") != expected_seq:
             recovery.update(
                 {
@@ -460,6 +586,11 @@ def load_checkpoint(path: Path) -> dict[str, Any]:
 
 
 def _apply_journal_record(state: dict[str, Any], record: dict[str, Any]) -> bool:
+    # Repeated from the recovery loop deliberately. This is the only function
+    # that turns a record into state, so the version test belongs where the
+    # application happens and not only at the one call site that exists today.
+    if record.get("version") != CHECKPOINT_VERSION:
+        return False
     entry = record.get("entry")
     if not isinstance(entry, dict):
         return False

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -67,6 +67,14 @@ class CheckpointWriter:
             raise ValueError(f"unsupported checkpoint version: {self.version}")
         if self.compact_every < 1:
             raise ValueError("compact_every must be at least 1")
+        if self.version == CHECKPOINT_VERSION and self.flow_context:
+            # A resume seeds this from the same dict the executor goes on to use
+            # as its live workspace. Even a shallow copy of it shares every
+            # nested value, so a nested mutation lands in the baseline as well
+            # as in the capture, the two compare equal, no delta is journaled,
+            # and the mutation is lost on the next recovery. Owning the
+            # baseline outright is what makes the comparison meaningful.
+            self.flow_context = _context_snapshot(self.flow_context)
 
     @property
     def journal_path(self) -> Path:
@@ -136,10 +144,13 @@ class CheckpointWriter:
                 delta = {"kind": "op", "entry": entry}
                 if context_delta is not None:
                     delta["flow_context"] = context_delta
-                await self._append_delta_locked(delta)
-                self.ops[agent_id] = entry
-                if captured is not None:
-                    self.flow_context = captured
+
+                def apply() -> None:
+                    self.ops[agent_id] = entry
+                    if captured is not None:
+                        self.flow_context = captured
+
+                await self._append_delta_locked(delta, apply)
                 await self._maybe_compact_locked()
             else:
                 self.ops[agent_id] = entry
@@ -186,31 +197,35 @@ class CheckpointWriter:
             "spawn_id": spawn_id,
             "context": context,
         }
-        async with self._lock:
-            captured = (
-                _capture_context(flow_context) if self.version == CHECKPOINT_VERSION else None
-            )
-            if self.version == CHECKPOINT_VERSION:
-                await self._ensure_base_locked()
-                context_delta = await _context_delta_async(self.flow_context, captured)
-                delta = {"kind": "spawned", "entry": entry}
-                if context_delta is not None:
-                    delta["flow_context"] = context_delta
-                await self._append_delta_locked(delta)
+
+        def upsert() -> None:
             for i, existing in enumerate(self.spawned):
                 if existing.get("node_id") == node_id:
                     self.spawned[i] = entry
                     break
             else:
                 self.spawned.append(entry)
+
+        async with self._lock:
             if self.version == CHECKPOINT_VERSION:
-                if captured is not None:
-                    self.flow_context = captured
-            elif flow_context is not None:
-                self.flow_context = flow_context
-            if self.version == CHECKPOINT_VERSION:
+                captured = _capture_context(flow_context)
+                await self._ensure_base_locked()
+                context_delta = await _context_delta_async(self.flow_context, captured)
+                delta = {"kind": "spawned", "entry": entry}
+                if context_delta is not None:
+                    delta["flow_context"] = context_delta
+
+                def apply() -> None:
+                    upsert()
+                    if captured is not None:
+                        self.flow_context = captured
+
+                await self._append_delta_locked(delta, apply)
                 await self._maybe_compact_locked()
             else:
+                upsert()
+                if flow_context is not None:
+                    self.flow_context = flow_context
                 await self._write_locked()
 
     async def flush(self) -> None:
@@ -230,7 +245,9 @@ class CheckpointWriter:
         # Python reads back and strict readers reject; refuse it at the write.
         raise_if_non_finite(state, default=str)
         payload = json.dumps(state, default=str)
-        tmp.write_text(payload)
+        # Same owner-only creation the journaled path uses: this file holds the
+        # same raw responses and flow context, whichever version wrote it.
+        _write_private_bytes(tmp, payload.encode())
         os.replace(tmp, self.path)
 
     async def _ensure_base_locked(self) -> None:
@@ -241,7 +258,15 @@ class CheckpointWriter:
             self._bytes_written += written
             self._journal_reset_required = False
 
-    async def _append_delta_locked(self, delta: dict[str, Any]) -> None:
+    async def _append_delta_locked(self, delta: dict[str, Any], apply_state: Any = None) -> None:
+        """Append one delta and, if it reached the file, apply it in memory.
+
+        `apply_state` is what this record means for the writer's own state. It
+        runs exactly when the bytes are in the file, durable or not, because
+        the two have to move together: a record that reached disk while memory
+        stayed behind is dropped for good the next time compaction rewrites the
+        base from memory and clears the journal.
+        """
         next_seq = self._journal_seq + 1
         record = {
             "version": CHECKPOINT_VERSION,
@@ -270,6 +295,8 @@ class CheckpointWriter:
                 self._journal_seq = next_seq
                 self._delta_count += 1
                 self._seq += 1
+                if apply_state is not None:
+                    apply_state()
 
     async def _maybe_compact_locked(self) -> None:
         if self._delta_count >= self.compact_every:
@@ -304,23 +331,56 @@ def _serialize_json(value: Any) -> bytes:
 # by name on every delta and read back by name during recovery, so a symlink
 # planted at that name redirects the writer into an arbitrary file and feeds
 # recovery contents this process never wrote. The intermediate directories are
-# not covered, and neither is any platform without the flag, where this degrades
-# to an ordinary open.
+# not covered. Where the flag does not exist -- Windows -- the same refusal is
+# reconstructed from the descriptor after the open, so the protection does not
+# quietly depend on which platform this runs on.
 _NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+# Checkpoint state and journal records carry raw operation responses and the
+# shared flow context. Every file this module creates is owner-only, and the
+# mode is set on the descriptor rather than left to the process umask, which
+# would publish a 0644 file under the default umask of 022.
+_PRIVATE_MODE = 0o600
 
 
 class JournalPathError(LionError):
     """Raised when a journal path is not the regular file it must be."""
 
 
-def _open_no_follow(path: Path, flags: int, mode: int = 0o600) -> int:
+def _refuse_if_symlinked(descriptor: int, path: Path) -> None:
+    """Reconstruct the O_NOFOLLOW refusal from the descriptor we just opened.
+
+    `lstat` describes the name; `fstat` describes what the open actually
+    reached. They disagree exactly when the final component is a symlink, so
+    comparing them says what the flag would have said, on a platform that does
+    not have it. A path that vanished between the two calls is refused for the
+    same reason: this cannot show it opened the file it named.
+    """
     try:
-        return os.open(path, flags | _NOFOLLOW, mode)
+        named = os.lstat(path)
+    except OSError as exc:
+        raise JournalPathError(f"refusing a path that cannot be inspected: {path}") from exc
+    opened = os.fstat(descriptor)
+    if (named.st_dev, named.st_ino) != (opened.st_dev, opened.st_ino):
+        raise JournalPathError(f"refusing to use a symlinked path: {path}")
+
+
+def _open_no_follow(path: Path, flags: int, mode: int = _PRIVATE_MODE) -> int:
+    try:
+        descriptor = os.open(path, flags | _NOFOLLOW, mode)
     except OSError as exc:
         # ELOOP is what O_NOFOLLOW reports for a symlinked final component.
         if exc.errno == errno.ELOOP:
             raise JournalPathError(f"refusing to use a symlinked path: {path}") from exc
         raise
+    if _NOFOLLOW:
+        return descriptor
+    try:
+        _refuse_if_symlinked(descriptor, path)
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor
 
 
 def _read_bytes_no_follow(path: Path) -> bytes:
@@ -363,14 +423,41 @@ def _fsync_parent(path: Path) -> None:
         os.close(descriptor)
 
 
+def _open_private_new(path: Path) -> int:
+    """Open `path` as a file this call created, owner-only.
+
+    Unlinking first and then demanding O_EXCL is what makes the mode
+    meaningful. Writing into a file that was already there keeps whatever
+    permissions it already had, and a symlink left at a temporary name would be
+    followed, so the pair says: nothing here now, and what follows is ours. The
+    umask can only clear bits from the mode, never add them, so 0600 is a
+    ceiling this cannot exceed however the process was configured.
+    """
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+    return os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, _PRIVATE_MODE)
+
+
+def _write_private_bytes(path: Path, payload: bytes) -> None:
+    descriptor = _open_private_new(path)
+    try:
+        stream = os.fdopen(descriptor, "wb")
+    except BaseException:
+        os.close(descriptor)
+        raise
+    with stream:
+        stream.write(payload)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
 def _atomic_write_bytes(path: Path, payload: bytes) -> int:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
     try:
-        with tmp.open("wb") as stream:
-            stream.write(payload)
-            stream.flush()
-            os.fsync(stream.fileno())
+        _write_private_bytes(tmp, payload)
         os.replace(tmp, path)
         _fsync_parent(path)
     finally:
@@ -403,21 +490,51 @@ def _append_journal_record(path: Path, record: dict[str, Any]) -> int:
     path.parent.mkdir(parents=True, exist_ok=True)
     descriptor = _open_no_follow(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT)
     try:
-        stream = os.fdopen(descriptor, "ab")
-    except BaseException:
-        os.close(descriptor)
-        raise
-    with stream:
-        stream.write(payload)
-        stream.flush()
+        written = _write_all(descriptor, payload)
         # Past this point the bytes are in the file. fsync decides whether they
         # survive a power loss, not whether they are there, so a failure here
         # must not be reported as a write that did not happen.
         try:
-            os.fsync(stream.fileno())
+            os.fsync(descriptor)
         except OSError as exc:
-            raise _RecordReachedFileError(len(payload), exc) from exc
-    return len(payload)
+            raise _RecordReachedFileError(written, exc) from exc
+    finally:
+        os.close(descriptor)
+    return written
+
+
+def _write_all(descriptor: int, payload: bytes) -> int:
+    """Write every byte, or report how many got there before it stopped.
+
+    A buffered stream cannot answer that question: a short write inside its
+    flush raises with some of the record already appended, and the caller then
+    treats the whole append as never having happened. It retries under the same
+    sequence number, the retry lands directly behind the fragment, and recovery
+    reads one corrupt line where two records should have been -- discarding
+    every valid completion after it.
+
+    So the count is tracked here, and a stopped write is finished off with a
+    newline where it can be, which leaves the fragment as a line of its own.
+    Recovery still refuses that line, which is the honest answer for a record
+    that is genuinely incomplete, but it refuses only that one.
+    """
+    written = 0
+    try:
+        while written < len(payload):
+            count = os.write(descriptor, payload[written:])
+            if count <= 0:
+                raise OSError(errno.EIO, "journal write made no progress", str(descriptor))
+            written += count
+    except BaseException as exc:
+        if written == 0:
+            raise
+        if not payload[:written].endswith(b"\n"):
+            try:
+                written += os.write(descriptor, b"\n")
+            except OSError:
+                pass
+        raise _RecordReachedFileError(written, exc) from exc
+    return written
 
 
 def _context_snapshot(current: dict[str, Any]) -> dict[str, Any]:
@@ -604,6 +721,15 @@ def _apply_journal_record(state: dict[str, Any], record: dict[str, Any]) -> bool
         if not isinstance(entry_id, str):
             return False
     else:
+        return False
+
+    # An entry is what resume reads to decide whether an op already ran and
+    # what it produced. One carrying an id but no outcome is not a lighter
+    # version of that: applied, it makes resume skip an op whose result it does
+    # not have, silently, under the name of a durable record. Refusing it puts
+    # it on the same footing as a torn line -- recovery reports where it
+    # stopped and keeps what came before.
+    if not isinstance(entry.get("status"), str) or "response" not in entry:
         return False
 
     context_delta = record.get("flow_context")

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -32,7 +32,12 @@ from .._logging import progress
 from .._logging import warn as _warn
 from .._providers import parse_model_spec
 from .._util import classify_exception
-from ._checkpoint import CheckpointWriter, FlowResumeError, resolve_checkpoint_target
+from ._checkpoint import (
+    CHECKPOINT_VERSION,
+    CheckpointWriter,
+    FlowResumeError,
+    resolve_checkpoint_target,
+)
 from ._common import (
     _build_worker_operate_node,
     _create_fanout_team,
@@ -1289,6 +1294,7 @@ async def _execute_dag(
             prompt=checkpoint_prompt,
             plan=checkpoint_plan or [],
             config=checkpoint_config,
+            version=CHECKPOINT_VERSION,
             max_spawn=max_spawn,
             # Seed with prior-checkpoint state (empty on a fresh run) so a
             # resume-of-a-resume can't silently lose context before the next flush.

--- a/tests/cli/orchestrate/test_checkpoint_journal.py
+++ b/tests/cli/orchestrate/test_checkpoint_journal.py
@@ -1,0 +1,355 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Durability and write-amplification contracts for journaled flow checkpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli.orchestrate._checkpoint import (
+    CHECKPOINT_VERSION,
+    CheckpointWriter,
+    load_checkpoint,
+)
+
+
+def _writer(path: Path, *, compact_every: int = 128) -> CheckpointWriter:
+    return CheckpointWriter(
+        path=path,
+        session_id="session-1",
+        prompt="run the plan",
+        plan=[],
+        config={"model_spec": "codex"},
+        version=CHECKPOINT_VERSION,
+        compact_every=compact_every,
+    )
+
+
+async def test_journaled_checkpoint_recovers_concurrent_records_in_writer_order(tmp_path: Path):
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+
+    await asyncio.gather(
+        *(writer.record(f"agent-{i}", status="completed", response=i) for i in range(20))
+    )
+
+    recovered = load_checkpoint(path)
+    assert list(recovered["ops"]) == [f"agent-{i}" for i in range(20)]
+    assert [entry["seq"] for entry in writer.journal_records()] == list(range(1, 21))
+    assert not list(tmp_path.glob("checkpoint.*.tmp"))
+
+
+async def test_journaled_checkpoint_writes_linear_deltas_for_growing_context(tmp_path: Path):
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path, compact_every=128)
+    context: dict[str, str] = {}
+
+    for i in range(200):
+        context = {**context, f"context-{i}": "c" * 8_192}
+        await writer.record(
+            f"agent-{i}",
+            status="completed",
+            response="r" * 8_192,
+            flow_context=context,
+        )
+
+    recovered = load_checkpoint(path)
+    assert len(recovered["ops"]) == 200
+    assert recovered["flow_context"] == context
+    assert writer.bytes_written < 10_000_000
+
+
+async def test_journaled_checkpoint_reports_and_ignores_torn_final_record(tmp_path: Path):
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-1", status="completed", response="durable")
+
+    with writer.journal_path.open("ab") as stream:
+        stream.write(b'{"generation":"torn')
+
+    recovered = load_checkpoint(path)
+    assert recovered["ops"]["agent-1"]["response"] == "durable"
+    assert recovered["_recovery"]["torn_final_record"] is True
+
+
+async def test_journaled_checkpoint_compaction_rebases_generation_atomically(tmp_path: Path):
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path, compact_every=2)
+
+    await writer.record("agent-1", status="completed", response="one")
+    generation_before = json.loads(path.read_text())["generation"]
+    await writer.record("agent-2", status="completed", response="two")
+
+    base = json.loads(path.read_text())
+    assert base["generation"] != generation_before
+    assert base["ops"]["agent-2"]["response"] == "two"
+    assert writer.journal_path.read_bytes() == b""
+    assert load_checkpoint(path)["ops"] == writer.ops
+
+
+async def test_journal_serialization_and_fsync_run_off_the_event_loop(tmp_path: Path, monkeypatch):
+    import lionagi.cli.orchestrate._checkpoint as checkpoint_mod
+
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.flush()
+    started = threading.Event()
+    release = threading.Event()
+    real_append = checkpoint_mod._append_journal_record
+
+    def slow_append(journal_path: Path, record: dict) -> int:
+        started.set()
+        release.wait(timeout=2)
+        return real_append(journal_path, record)
+
+    monkeypatch.setattr(checkpoint_mod, "_append_journal_record", slow_append)
+    task = asyncio.create_task(writer.record("agent", status="completed", response="ok"))
+    assert await asyncio.to_thread(started.wait, 1)
+
+    ticked = False
+
+    def tick() -> None:
+        nonlocal ticked
+        ticked = True
+
+    asyncio.get_running_loop().call_soon(tick)
+    await asyncio.sleep(0)
+    assert ticked is True
+    assert task.done() is False
+    release.set()
+    await task
+
+
+async def test_journal_rejects_non_finite_delta_without_mutating_recovered_state(tmp_path: Path):
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+
+    with pytest.raises(ValueError, match=r"non-finite float.*response.score"):
+        await writer.record(
+            "agent-bad",
+            status="completed",
+            response={"score": float("nan")},
+        )
+
+    assert "agent-bad" not in writer.ops
+    assert "agent-bad" not in load_checkpoint(path)["ops"]
+
+
+async def test_journal_context_delta_applies_deletions_and_none_values(tmp_path: Path):
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+
+    await writer.record(
+        "agent-1",
+        status="completed",
+        response="one",
+        flow_context={"remove": "old", "nullable": "value"},
+    )
+    await writer.record(
+        "agent-2",
+        status="completed",
+        response="two",
+        flow_context={"nullable": None},
+    )
+
+    assert load_checkpoint(path)["flow_context"] == {"nullable": None}
+
+
+async def test_new_base_never_replays_an_old_generation_journal(tmp_path: Path):
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-1", status="completed", response="one")
+    stale_journal = writer.journal_path.read_bytes()
+    await writer.flush()
+    with writer.journal_path.open("ab") as stream:
+        stream.write(stale_journal)
+
+    recovered = load_checkpoint(path)
+    assert recovered["ops"] == writer.ops
+    assert recovered["_recovery"]["stale_generation_records"] == 1
+
+
+async def test_cancellation_during_append_cannot_reuse_a_durable_sequence(
+    tmp_path: Path, monkeypatch
+):
+    import lionagi.cli.orchestrate._checkpoint as checkpoint_mod
+
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.flush()
+    started = threading.Event()
+    release = threading.Event()
+    real_append = checkpoint_mod._append_journal_record
+
+    def paused_append(journal_path: Path, record: dict) -> int:
+        started.set()
+        release.wait(timeout=2)
+        return real_append(journal_path, record)
+
+    monkeypatch.setattr(checkpoint_mod, "_append_journal_record", paused_append)
+    first = asyncio.create_task(writer.record("agent-1", status="completed", response="one"))
+    assert await asyncio.to_thread(started.wait, 1)
+    first.cancel()
+    release.set()
+    with contextlib.suppress(asyncio.CancelledError):
+        await first
+
+    await writer.record("agent-2", status="completed", response="two")
+
+    recovered = load_checkpoint(path)
+    assert set(recovered["ops"]) == {"agent-1", "agent-2"}
+    assert "invalid_sequence" not in recovered.get("_recovery", {})
+
+
+async def test_journal_records_in_place_nested_context_updates(tmp_path: Path):
+    """The caller mutates the shared context workspace in place and passes the
+    same object every time. A snapshot that shared nested values with it would
+    compare equal, journal nothing, and resume with context the run had already
+    moved past.
+    """
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+
+    context: dict = {"shared": {"first": 1}, "top": "a"}
+    await writer.record("agent-1", status="completed", response="one", flow_context=context)
+
+    # In place, on the object the caller still holds — no rebinding.
+    context["shared"]["second"] = 2
+    await writer.record("agent-2", status="completed", response="two", flow_context=context)
+
+    # No compaction has run (compact_every=128), so recovery is journal replay:
+    # exactly the crash window the journal exists to cover.
+    assert writer.journal_path.read_bytes() != b""
+    recovered = load_checkpoint(path)
+    assert recovered["flow_context"] == {"shared": {"first": 1, "second": 2}, "top": "a"}
+
+
+async def test_journal_records_in_place_nested_context_updates_for_spawned_nodes(tmp_path: Path):
+    """Same defect, same fix, on the reactively-spawned path."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+
+    context: dict = {"shared": {"first": 1}}
+    await writer.record_spawned(
+        "node-1", status="completed", response="one", flow_context=context, operation="communicate"
+    )
+
+    context["shared"]["second"] = 2
+    await writer.record_spawned(
+        "node-2", status="completed", response="two", flow_context=context, operation="communicate"
+    )
+
+    recovered = load_checkpoint(path)
+    assert recovered["flow_context"] == {"shared": {"first": 1, "second": 2}}
+
+
+def _inject_after_the_journal_write(monkeypatch, context: dict, mutate) -> list:
+    """Mutate the caller's live workspace after the delta is on disk.
+
+    The journal append runs on a worker thread, and ``record`` is still
+    awaiting it, so mutating once the record has been serialized lands the
+    change in the window between what the journal saw and what the baseline
+    will be.
+
+    Mutating *before* the append instead proves nothing, and it is worth
+    saying why: the delta's ``set`` values are references into the caller's
+    live nested containers, so a change made before serialization is written
+    out with the record and no loss occurs. The window this closes is the one
+    after those bytes exist.
+
+    Returns a list that is non-empty once the injection has run, so a test can
+    assert its own probe fired rather than passing because nothing happened.
+    """
+    from lionagi.cli.orchestrate import _checkpoint as checkpoint_mod
+
+    original = checkpoint_mod._append_journal_record
+    fired: list[bool] = []
+
+    def _append_then_mutate(journal_path, record):
+        written = original(journal_path, record)
+        if not fired:
+            fired.append(True)
+            mutate(context)
+        return written
+
+    monkeypatch.setattr(checkpoint_mod, "_append_journal_record", _append_then_mutate)
+    return fired
+
+
+async def test_a_mutation_during_the_write_cannot_enter_the_baseline_unjournaled(
+    tmp_path: Path, monkeypatch
+):
+    """A value the caller adds while the write is in flight still reaches recovery.
+
+    Deriving the delta from the live context and then snapshotting the live
+    context again reads it twice, on opposite sides of an await. A mutation
+    landing between the two enters the baseline without entering any delta,
+    and the baseline is what the next comparison uses, so the value never gets
+    journaled at all and recovery silently drops it.
+    """
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    context: dict = {"shared": {"first": 1}}
+
+    fired = _inject_after_the_journal_write(
+        monkeypatch, context, lambda c: c["shared"].__setitem__("injected", "during-the-write")
+    )
+    await writer.record("agent-1", status="completed", response="one", flow_context=context)
+    assert fired, "the injection never ran, so this test proves nothing"
+
+    # A later completion is the only remaining chance to journal that value.
+    await writer.record("agent-2", status="completed", response="two", flow_context=context)
+
+    recovered = load_checkpoint(path)
+    assert recovered["flow_context"] == {"shared": {"first": 1, "injected": "during-the-write"}}
+
+
+async def test_a_mutation_during_a_spawned_write_cannot_enter_the_baseline_unjournaled(
+    tmp_path: Path, monkeypatch
+):
+    """Same window, same loss, on the reactively-spawned path."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    context: dict = {"shared": {"first": 1}}
+
+    fired = _inject_after_the_journal_write(
+        monkeypatch, context, lambda c: c["shared"].__setitem__("injected", "during-the-write")
+    )
+    await writer.record_spawned(
+        "node-1", status="completed", response="one", flow_context=context, operation="communicate"
+    )
+    assert fired, "the injection never ran, so this test proves nothing"
+
+    await writer.record_spawned(
+        "node-2", status="completed", response="two", flow_context=context, operation="communicate"
+    )
+
+    recovered = load_checkpoint(path)
+    assert recovered["flow_context"] == {"shared": {"first": 1, "injected": "during-the-write"}}
+
+
+async def test_context_snapshot_falls_back_when_a_value_refuses_deep_copy(tmp_path: Path):
+    """A value that cannot be deep-copied must not turn journaling into a crash;
+    it still has to leave a baseline that is not aliased to the caller's object.
+    """
+    from lionagi.cli.orchestrate._checkpoint import _context_snapshot
+
+    class _NoCopy:
+        def __deepcopy__(self, memo):
+            raise TypeError("cannot deep-copy this")
+
+        def __str__(self) -> str:
+            return "opaque"
+
+    source = {"nested": {"keep": 1}, "opaque": _NoCopy()}
+    snapshot = _context_snapshot(source)
+
+    assert snapshot["nested"] == {"keep": 1}
+    assert snapshot["nested"] is not source["nested"]
+    assert snapshot["opaque"] == "opaque"

--- a/tests/cli/orchestrate/test_checkpoint_journal.py
+++ b/tests/cli/orchestrate/test_checkpoint_journal.py
@@ -107,10 +107,10 @@ async def test_journal_serialization_and_fsync_run_off_the_event_loop(tmp_path: 
     release = threading.Event()
     real_append = checkpoint_mod._append_journal_record
 
-    def slow_append(journal_path: Path, record: dict) -> int:
+    def slow_append(journal_path: Path, record: dict, *rest) -> int:
         started.set()
         release.wait(timeout=2)
-        return real_append(journal_path, record)
+        return real_append(journal_path, record, *rest)
 
     monkeypatch.setattr(checkpoint_mod, "_append_journal_record", slow_append)
     task = asyncio.create_task(writer.record("agent", status="completed", response="ok"))
@@ -191,10 +191,10 @@ async def test_cancellation_during_append_cannot_reuse_a_durable_sequence(
     release = threading.Event()
     real_append = checkpoint_mod._append_journal_record
 
-    def paused_append(journal_path: Path, record: dict) -> int:
+    def paused_append(journal_path: Path, record: dict, *rest) -> int:
         started.set()
         release.wait(timeout=2)
-        return real_append(journal_path, record)
+        return real_append(journal_path, record, *rest)
 
     monkeypatch.setattr(checkpoint_mod, "_append_journal_record", paused_append)
     first = asyncio.create_task(writer.record("agent-1", status="completed", response="one"))
@@ -275,8 +275,8 @@ def _inject_after_the_journal_write(monkeypatch, context: dict, mutate) -> list:
     original = checkpoint_mod._append_journal_record
     fired: list[bool] = []
 
-    def _append_then_mutate(journal_path, record):
-        written = original(journal_path, record)
+    def _append_then_mutate(journal_path, record, *rest):
+        written = original(journal_path, record, *rest)
         if not fired:
             fired.append(True)
             mutate(context)
@@ -941,3 +941,79 @@ async def test_a_failing_close_does_not_hand_back_the_sequence_it_already_spent(
     recovered = load_checkpoint(path)
     assert "invalid_sequence" not in recovered.get("_recovery", {}), recovered.get("_recovery")
     assert "agent-2" in recovered["ops"], recovered["ops"]
+
+
+async def test_the_journal_refuses_a_private_file_that_replaced_the_one_it_created(tmp_path: Path):
+    """A substitute made by a process running as us looks exactly like a healthy
+    journal: regular, one link, our uid, 0600. Only its identity differs, and
+    records carry raw responses and the shared flow context."""
+    from lionagi.cli.orchestrate import _checkpoint as checkpoint_mod
+
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-1", status="completed", response="one")
+
+    journal = writer.journal_path
+    created_inode = journal.stat().st_ino
+    substitute = tmp_path / "substitute"
+    substitute.write_bytes(b"")
+    substitute.chmod(0o600)
+    os.replace(substitute, journal)
+    assert journal.stat().st_ino != created_inode
+
+    # The control that makes this test about identity rather than about the
+    # kind-and-ownership guard: that guard accepts the substitute.
+    descriptor = os.open(journal, os.O_RDONLY)
+    try:
+        checkpoint_mod._refuse_unsafe_inode(descriptor, journal)
+    finally:
+        os.close(descriptor)
+
+    with pytest.raises(JournalPathError):
+        await writer.record("agent-2", status="completed", response="two")
+
+
+async def test_a_journal_this_writer_created_keeps_taking_records(tmp_path: Path):
+    """The control for the refusal above, including across a compaction, which
+    replaces the journal on purpose and has to leave it usable."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path, compact_every=2)
+
+    for i in range(6):
+        await writer.record(f"agent-{i}", status="completed", response=i)
+
+    recovered = load_checkpoint(path)
+    assert list(recovered["ops"]) == [f"agent-{i}" for i in range(6)]
+
+
+async def test_a_journal_reset_deferred_by_a_failure_is_pinned_when_it_finally_happens(
+    tmp_path: Path, monkeypatch
+):
+    """A base write marks the journal for reset before performing it, so a
+    failure there leaves the reset owed to the next record. That reset replaces
+    the journal exactly as the base write would have, and the append after it
+    is measured against whatever the last reset produced."""
+    from lionagi.cli.orchestrate import _checkpoint as checkpoint_mod
+
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path, compact_every=1)
+    real = checkpoint_mod._atomic_write_bytes
+    resets: list[int] = []
+
+    def fail_the_compaction_reset(target: Path, payload: bytes) -> int:
+        if target == writer.journal_path:
+            resets.append(1)
+            if len(resets) == 2:
+                raise OSError(errno.EIO, "journal reset failed")
+        return real(target, payload)
+
+    monkeypatch.setattr(checkpoint_mod, "_atomic_write_bytes", fail_the_compaction_reset)
+
+    with pytest.raises(OSError):
+        await writer.record("agent-1", status="completed", response="one")
+    assert len(resets) == 2
+
+    await writer.record("agent-2", status="completed", response="two")
+
+    recovered = load_checkpoint(path)
+    assert list(recovered["ops"]) == ["agent-1", "agent-2"]

--- a/tests/cli/orchestrate/test_checkpoint_journal.py
+++ b/tests/cli/orchestrate/test_checkpoint_journal.py
@@ -16,6 +16,7 @@ import pytest
 
 from lionagi.cli.orchestrate._checkpoint import (
     CHECKPOINT_VERSION,
+    LEGACY_CHECKPOINT_VERSION,
     CheckpointWriter,
     JournalPathError,
     load_checkpoint,
@@ -559,3 +560,218 @@ async def test_a_record_that_never_reached_the_file_leaves_its_sequence_unspent(
     recovered = load_checkpoint(path)
     assert "_recovery" not in recovered, recovered.get("_recovery")
     assert set(recovered["ops"]) == {"agent-2"}
+
+
+# --- what the files hold is nobody else's business ---------------------------
+
+
+async def test_checkpoint_and_journal_are_created_owner_only(tmp_path: Path):
+    """Both files carry raw operation responses and the shared flow context.
+
+    Creating them through an ordinary open takes the mode from the process
+    umask, which is 022 by default and publishes a world-readable file.
+    """
+    previous_umask = os.umask(0o022)
+    try:
+        path = tmp_path / "checkpoint.json"
+        writer = _writer(path, compact_every=1)
+        await writer.record("agent-1", status="completed", response={"secret": "value"})
+
+        assert path.exists() and writer.journal_path.exists()
+        for created in (path, writer.journal_path):
+            mode = created.stat().st_mode & 0o777
+            assert mode & 0o077 == 0, f"{created.name} is readable by others: {mode:o}"
+    finally:
+        os.umask(previous_umask)
+
+
+async def test_the_legacy_checkpoint_is_created_owner_only_too(tmp_path: Path):
+    """The unjournaled path writes the same responses to the same kind of file."""
+    previous_umask = os.umask(0o022)
+    try:
+        path = tmp_path / "checkpoint.json"
+        writer = CheckpointWriter(
+            path=path,
+            session_id="session-1",
+            prompt="run the plan",
+            plan=[],
+            config={},
+            version=LEGACY_CHECKPOINT_VERSION,
+        )
+        await writer.record("agent-1", status="completed", response={"secret": "value"})
+
+        assert path.stat().st_mode & 0o077 == 0
+    finally:
+        os.umask(previous_umask)
+
+
+async def test_a_symlinked_journal_is_refused_where_the_open_flag_does_not_exist(
+    tmp_path: Path, monkeypatch
+):
+    """O_NOFOLLOW is absent on some platforms this ships to, and the refusal
+    cannot be absent with it: a symlink at the journal name redirects every
+    delta into a file this process never chose and feeds recovery records it
+    never wrote."""
+    import lionagi.cli.orchestrate._checkpoint as checkpoint_mod
+
+    monkeypatch.setattr(checkpoint_mod, "_NOFOLLOW", 0)
+
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.flush()
+
+    elsewhere = tmp_path / "elsewhere.json"
+    elsewhere.write_text("")
+    writer.journal_path.unlink()
+    writer.journal_path.symlink_to(elsewhere)
+
+    with pytest.raises(checkpoint_mod.JournalPathError):
+        await writer.record("agent-1", status="completed", response=1)
+    assert elsewhere.read_text() == "", "the write followed the symlink"
+
+
+# --- the baseline has to be the writer's own copy ----------------------------
+
+
+async def test_a_resumed_writer_does_not_share_nested_context_with_the_executor(
+    tmp_path: Path,
+):
+    """Resume hands the same dict to the writer and to the executor, which goes
+    on mutating it in place. A baseline sharing those nested values moves with
+    every mutation, so the comparison finds nothing to journal and the change is
+    gone at the next recovery."""
+    path = tmp_path / "checkpoint.json"
+    live: dict[str, object] = {"findings": ["first"]}
+    writer = CheckpointWriter(
+        path=path,
+        session_id="session-1",
+        prompt="run the plan",
+        plan=[],
+        config={},
+        version=CHECKPOINT_VERSION,
+        flow_context=dict(live),
+    )
+    await writer.flush()
+
+    live["findings"].append("second")  # type: ignore[attr-defined]
+    await writer.record("agent-1", status="completed", response=1, flow_context=live)
+
+    recovered = load_checkpoint(path)
+    assert "_recovery" not in recovered, recovered.get("_recovery")
+    assert recovered["flow_context"]["findings"] == ["first", "second"]
+
+
+# --- a record on disk that memory forgot is a record compaction deletes ------
+
+
+async def test_an_fsync_failed_record_survives_the_next_compaction(tmp_path: Path, monkeypatch):
+    """Compaction rewrites the base from memory and then clears the journal. An
+    operation whose record reached the file but was never applied in memory is
+    in neither afterwards, so a durable completion is lost for good."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path, compact_every=2)
+    await writer.flush()
+
+    real_fsync = os.fsync
+    armed = {"value": True}
+
+    def flaky_fsync(descriptor):
+        if armed["value"]:
+            armed["value"] = False
+            real_fsync(descriptor)
+            raise OSError(errno.EIO, "injected fsync failure")
+        return real_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", flaky_fsync)
+
+    with pytest.raises(OSError):
+        await writer.record("agent-1", status="completed", response=1)
+    assert armed["value"] is False, "the injected failure never fired"
+
+    # Reaches compact_every and rebases from memory, discarding the journal.
+    await writer.record("agent-2", status="completed", response=2)
+    assert writer.journal_records() == []
+
+    recovered = load_checkpoint(path)
+    assert set(recovered["ops"]) == {"agent-1", "agent-2"}
+    assert recovered["ops"]["agent-1"]["response"] == 1
+
+
+# --- a stopped write must not swallow the record that follows it -------------
+
+
+async def test_a_partial_append_does_not_glue_itself_to_the_next_record(
+    tmp_path: Path, monkeypatch
+):
+    """A write that stops halfway leaves bytes with no newline. Reporting that
+    as a write that never happened leaves the sequence unspent, so the retry
+    lands directly behind the fragment and the two become one unreadable line --
+    which recovery stops at, discarding every valid completion after it."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-0", status="completed", response=0)
+
+    real_write = os.write
+    state = {"phase": "short"}
+
+    def truncating_write(descriptor, payload):
+        # A short write is not an error: it returns a smaller count and the
+        # caller is expected to send the rest. The failure lands on that retry,
+        # which is what leaves a fragment in the file.
+        if state["phase"] == "short" and len(payload) > 8:
+            state["phase"] = "fail"
+            return real_write(descriptor, payload[:8])
+        if state["phase"] == "fail":
+            state["phase"] = "done"
+            raise OSError(errno.EIO, "injected write failure")
+        return real_write(descriptor, payload)
+
+    monkeypatch.setattr(os, "write", truncating_write)
+
+    with pytest.raises(OSError):
+        await writer.record("agent-1", status="completed", response=1)
+    assert state["phase"] == "done", "the injected failure never fired"
+
+    await writer.record("agent-2", status="completed", response=2)
+    monkeypatch.undo()
+
+    lines = writer.journal_path.read_bytes().splitlines()
+    # Three lines: the first record, the fragment on its own, and the next
+    # record intact rather than appended to the fragment.
+    assert len(lines) == 3, lines
+    assert json.loads(lines[0])["entry"]["agent_id"] == "agent-0"
+    assert json.loads(lines[2])["entry"]["agent_id"] == "agent-2"
+
+    recovered = load_checkpoint(path)
+    assert recovered["_recovery"]["invalid_record"] is True
+    assert set(recovered["ops"]) == {"agent-0"}
+
+
+# --- an id with no outcome is not a lighter record ---------------------------
+
+
+async def test_recovery_refuses_a_record_that_carries_an_id_but_no_outcome(tmp_path: Path):
+    """Applied, such a record makes resume skip an operation whose result it
+    does not have, and report success doing it."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-1", status="completed", response=1)
+
+    state = json.loads(path.read_text())
+    with writer.journal_path.open("ab") as journal:
+        journal.write(
+            json.dumps(
+                {
+                    "version": CHECKPOINT_VERSION,
+                    "generation": state["generation"],
+                    "seq": 2,
+                    "kind": "op",
+                    "entry": {"agent_id": "agent-2"},
+                }
+            ).encode()
+            + b"\n"
+        )
+
+    recovered = load_checkpoint(path)
+    assert recovered["_recovery"]["invalid_record"] is True
+    assert set(recovered["ops"]) == {"agent-1"}

--- a/tests/cli/orchestrate/test_checkpoint_journal.py
+++ b/tests/cli/orchestrate/test_checkpoint_journal.py
@@ -775,3 +775,169 @@ async def test_recovery_refuses_a_record_that_carries_an_id_but_no_outcome(tmp_p
     recovered = load_checkpoint(path)
     assert recovered["_recovery"]["invalid_record"] is True
     assert set(recovered["ops"]) == {"agent-1"}
+
+
+# --- what is already sitting at the journal name -----------------------------
+
+
+async def test_the_journal_refuses_an_inode_that_is_linked_from_somewhere_else(tmp_path: Path):
+    """0600 describes a file this process created. A hard link planted at the
+    journal name was created by somebody else, at whatever mode they chose, and
+    every record appended to it lands in their file too -- with the run's raw
+    operation responses and its whole flow context in it."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-0", status="completed", response=0)
+
+    readable = tmp_path / "somebody-elses-file.jsonl"
+    readable.write_bytes(b"")
+    # Owner-only, like a journal we made ourselves. The link is the only thing
+    # wrong with it, so nothing but the link check can be what refuses it --
+    # a 0644 fixture here passes against a writer that has no link check at all.
+    readable.chmod(0o600)
+    writer.journal_path.unlink()
+    os.link(readable, writer.journal_path)
+    assert writer.journal_path.stat().st_nlink == 2, "the fixture did not create a link"
+    assert writer.journal_path.stat().st_mode & 0o077 == 0, "the fixture is not owner-only"
+
+    with pytest.raises(JournalPathError):
+        await writer.record("agent-1", status="completed", response={"token": "sk-secret"})
+
+    assert b"sk-secret" not in readable.read_bytes()
+
+
+async def test_the_journal_refuses_a_file_readable_beyond_its_owner(tmp_path: Path):
+    """The same hole without the link: a file already at the journal name keeps
+    the permissions it was created with, because the creation mode applies to
+    a creation and nothing was created."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-0", status="completed", response=0)
+
+    writer.journal_path.chmod(0o644)
+
+    with pytest.raises(JournalPathError):
+        await writer.record("agent-1", status="completed", response={"token": "sk-secret"})
+
+    assert b"sk-secret" not in writer.journal_path.read_bytes()
+
+
+async def test_a_private_journal_of_our_own_is_still_accepted(tmp_path: Path):
+    """Control for the two refusals above. Both of them pass trivially against
+    a writer that refuses every journal, so the ordinary case has to be shown
+    working under the same checks."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-0", status="completed", response=0)
+    await writer.record("agent-1", status="completed", response={"token": "sk-secret"})
+
+    assert writer.journal_path.stat().st_nlink == 1
+    assert writer.journal_path.stat().st_mode & 0o077 == 0
+    assert b"sk-secret" in writer.journal_path.read_bytes()
+    assert set(load_checkpoint(path)["ops"]) == {"agent-0", "agent-1"}
+
+
+def _fifo_at(path: Path) -> None:
+    """Replace `path` with an owner-only FIFO.
+
+    Owner-only on purpose. A FIFO created at the default umask is 0644, which
+    the permission check refuses on its own -- and a test that trips that check
+    says nothing about whether the file type is examined at all.
+    """
+    path.unlink()
+    os.mkfifo(path, 0o600)
+    path.chmod(0o600)
+    assert path.stat().st_mode & 0o077 == 0, "the fixture is not owner-only"
+
+
+async def test_the_journal_refuses_a_fifo_even_while_one_is_being_read(tmp_path: Path):
+    """A FIFO passes a symlink check, because it is not a symlink. With a
+    reader already attached the write-side open succeeds outright, so nothing
+    about the open refuses it: what the writer does with the descriptor after
+    opening it is the only thing that can."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-0", status="completed", response=0)
+
+    _fifo_at(writer.journal_path)
+    # A non-blocking read-side open returns straight away and leaves a reader
+    # attached, so the writer's open cannot fail for want of one.
+    reader = os.open(writer.journal_path, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        with pytest.raises(JournalPathError):
+            await writer.record("agent-1", status="completed", response=1)
+    finally:
+        os.close(reader)
+
+
+async def test_the_journal_does_not_wait_on_a_fifo_nobody_is_reading(tmp_path: Path):
+    """The same FIFO with no reader. A write-side open of one waits for a
+    reader that is never coming, and the checkpoint write holds the writer's
+    lock, so what stalls is the run.
+
+    The timeout bounds the call rather than the assertion. Without the
+    non-blocking open this does not raise late, it does not return, so a
+    regression here reports as a hang and not as a pass.
+    """
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-0", status="completed", response=0)
+
+    _fifo_at(writer.journal_path)
+
+    with pytest.raises(JournalPathError):
+        await asyncio.wait_for(writer.record("agent-1", status="completed", response=1), timeout=10)
+
+
+async def test_recovery_refuses_a_fifo_at_the_journal_name(tmp_path: Path):
+    """Recovery opens the same name to read it, and gets whatever is there."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-0", status="completed", response=0)
+
+    _fifo_at(writer.journal_path)
+
+    with pytest.raises(JournalPathError):
+        await asyncio.wait_for(asyncio.to_thread(load_checkpoint, path), timeout=10)
+
+
+# --- a close that fails after the bytes are already down ---------------------
+
+
+async def test_a_failing_close_does_not_hand_back_the_sequence_it_already_spent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """close() reports errors the write never surfaced, and it runs after the
+    record is in the file and fsynced. Raised from a `finally`, it replaced the
+    byte count with itself -- so the writer read a landed record as one that
+    never happened, kept the sequence number, and spent it again on the next
+    record. Recovery meets the same sequence twice, stops there, and discards
+    every completion after it."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-0", status="completed", response=0)
+
+    real_close = os.close
+    state = {"fired": False}
+
+    def failing_close(descriptor: int) -> None:
+        if not state["fired"] and os.fstat(descriptor).st_size > 0:
+            state["fired"] = True
+            real_close(descriptor)
+            raise OSError(errno.EIO, "injected close failure")
+        real_close(descriptor)
+
+    monkeypatch.setattr(os, "close", failing_close)
+    with contextlib.suppress(Exception):
+        await writer.record("agent-1", status="completed", response=1)
+    monkeypatch.undo()
+    assert state["fired"], "the injected failure never fired"
+
+    await writer.record("agent-2", status="completed", response=2)
+
+    seqs = [json.loads(line)["seq"] for line in writer.journal_path.read_bytes().splitlines()]
+    assert len(seqs) == len(set(seqs)), f"a sequence number was spent twice: {seqs}"
+
+    recovered = load_checkpoint(path)
+    assert "invalid_sequence" not in recovered.get("_recovery", {}), recovered.get("_recovery")
+    assert "agent-2" in recovered["ops"], recovered["ops"]

--- a/tests/cli/orchestrate/test_checkpoint_journal.py
+++ b/tests/cli/orchestrate/test_checkpoint_journal.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import json
+import os
 import threading
 from pathlib import Path
 
@@ -15,6 +17,7 @@ import pytest
 from lionagi.cli.orchestrate._checkpoint import (
     CHECKPOINT_VERSION,
     CheckpointWriter,
+    JournalPathError,
     load_checkpoint,
 )
 
@@ -353,3 +356,206 @@ async def test_context_snapshot_falls_back_when_a_value_refuses_deep_copy(tmp_pa
     assert snapshot["nested"] == {"keep": 1}
     assert snapshot["nested"] is not source["nested"]
     assert snapshot["opaque"] == "opaque"
+
+
+# --- The journal is a named file, so its name is an attack surface -----------
+
+
+async def test_a_symlinked_journal_is_refused_instead_of_followed(tmp_path: Path):
+    """The journal is appended to and read back by name, never by descriptor
+    held across the run. A symlink planted at that name sends every delta into
+    whatever it points at, so a run's prompts and responses land in a file the
+    run never chose."""
+    path = tmp_path / "checkpoint.json"
+    elsewhere = tmp_path / "elsewhere.txt"
+    elsewhere.write_bytes(b"")
+    writer = _writer(path)
+    await writer.flush()
+
+    journal = writer.journal_path
+    journal.unlink()
+    journal.symlink_to(elsewhere)
+
+    with pytest.raises(JournalPathError):
+        await writer.record("agent-1", status="completed", response=1)
+    # And nothing was appended to the target before the refusal.
+    assert elsewhere.read_bytes() == b""
+
+
+async def test_recovery_refuses_a_symlinked_journal_rather_than_reading_it(tmp_path: Path):
+    """Recovery is the other half: contents arriving through a symlink were
+    written by whoever planted it, and they are applied to state."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-1", status="completed", response=1)
+
+    planted = tmp_path / "planted.journal"
+    planted.write_bytes(writer.journal_path.read_bytes())
+    writer.journal_path.unlink()
+    writer.journal_path.symlink_to(planted)
+
+    with pytest.raises(JournalPathError):
+        load_checkpoint(path)
+
+
+async def test_an_ordinary_journal_is_still_written_and_recovered(tmp_path: Path):
+    """Control: the two refusals above pass if the journal stops working at all."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+
+    await writer.record("agent-1", status="completed", response=1)
+
+    assert not writer.journal_path.is_symlink()
+    assert load_checkpoint(path)["ops"]["agent-1"]["response"] == 1
+
+
+# --- Context deltas are decided by comparison, so the comparison is a contract
+
+
+@pytest.mark.parametrize(
+    ("before", "after"),
+    [
+        (1, 1.0),
+        ([1], [1.0]),
+        (True, 1),
+        ({"n": 1}, {"n": 1.0}),
+    ],
+)
+async def test_a_json_visible_context_change_is_journaled(tmp_path: Path, before, after):
+    """Python equality is coarser than JSON in the direction that loses data:
+    1 == 1.0 and True == 1 both hold. A value that changed compares equal,
+    journals nothing, and recovery restores the older one from the base."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+
+    await writer.record("agent-1", status="completed", response=1, flow_context={"v": before})
+    await writer.record("agent-2", status="completed", response=2, flow_context={"v": after})
+
+    recovered = load_checkpoint(path)
+    assert recovered["flow_context"]["v"] == after
+    assert repr(recovered["flow_context"]["v"]) == repr(after)
+
+
+async def test_an_unchanged_context_still_journals_no_delta(tmp_path: Path):
+    """Control: the parametrized test above passes if every record journals a
+    context delta regardless of whether anything changed, which would give back
+    the write amplification the delta format exists to avoid."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+
+    await writer.record("agent-1", status="completed", response=1, flow_context={"v": 1})
+    await writer.record("agent-2", status="completed", response=2, flow_context={"v": 1})
+
+    records = writer.journal_records()
+    assert "flow_context" in records[0]
+    assert "flow_context" not in records[1]
+
+
+async def test_a_reordered_context_dict_is_not_reported_as_a_change(tmp_path: Path):
+    """Same key set, different insertion order, is the same JSON document."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+
+    await writer.record("a", status="completed", response=1, flow_context={"v": {"x": 1, "y": 2}})
+    await writer.record("b", status="completed", response=2, flow_context={"v": {"y": 2, "x": 1}})
+
+    assert "flow_context" not in writer.journal_records()[1]
+
+
+# --- A record this build cannot read is not a record it may apply ------------
+
+
+async def test_recovery_stops_at_an_unknown_record_version(tmp_path: Path):
+    """An unreadable record applied anyway writes a guess into recovered state
+    under the authority of a durable record."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.record("agent-1", status="completed", response=1)
+
+    state = json.loads(path.read_text())
+    forged = {
+        "version": CHECKPOINT_VERSION + 996,
+        "generation": state["generation"],
+        "seq": 2,
+        "kind": "op",
+        "entry": {"agent_id": "agent-2", "status": "completed", "response": 2},
+    }
+    with writer.journal_path.open("ab") as stream:
+        stream.write(json.dumps(forged).encode() + b"\n")
+
+    recovered = load_checkpoint(path)
+
+    assert recovered["_recovery"]["unsupported_record_version"] is True
+    assert recovered["_recovery"]["actual"] == CHECKPOINT_VERSION + 996
+    # The record was reported, not applied, and the ones before it survive.
+    assert "agent-2" not in recovered["ops"]
+    assert "agent-1" in recovered["ops"]
+
+
+# --- fsync decides durability, not whether the bytes are there ---------------
+
+
+async def test_a_record_that_reached_the_file_does_not_reuse_its_sequence(
+    tmp_path: Path, monkeypatch
+):
+    """A failing fsync leaves the record in the file: the write and the flush
+    already happened, and fsync only says whether it survives a power loss. If
+    the sequence number is treated as unspent, the next record carries the same
+    seq, and recovery reads the duplicate as corruption, stops there, and throws
+    away every completed record after it."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.flush()
+
+    real_fsync = os.fsync
+    armed = {"value": True}
+
+    def flaky_fsync(descriptor):
+        if armed["value"]:
+            armed["value"] = False
+            # Let the data land first, then fail. Failing before the real call
+            # would be a different fault: bytes that never reached the file.
+            real_fsync(descriptor)
+            raise OSError(errno.EIO, "injected fsync failure")
+        return real_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", flaky_fsync)
+
+    with pytest.raises(OSError):
+        await writer.record("agent-1", status="completed", response=1)
+    assert armed["value"] is False, "the injected failure never fired"
+
+    await writer.record("agent-2", status="completed", response=2)
+
+    assert [record["seq"] for record in writer.journal_records()] == [1, 2]
+    recovered = load_checkpoint(path)
+    assert "_recovery" not in recovered, recovered.get("_recovery")
+    assert set(recovered["ops"]) == {"agent-1", "agent-2"}
+
+
+async def test_a_record_that_never_reached_the_file_leaves_its_sequence_unspent(
+    tmp_path: Path, monkeypatch
+):
+    """The other side of the same decision. A write that failed before anything
+    was appended must not consume a number, or the journal gains a gap and
+    recovery stops at it for the mirror-image reason."""
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    await writer.flush()
+
+    import lionagi.cli.orchestrate._checkpoint as checkpoint_mod
+
+    def refuse_open(*args, **kwargs):
+        raise OSError(errno.EACCES, "injected open failure")
+
+    monkeypatch.setattr(checkpoint_mod, "_open_no_follow", refuse_open)
+    with pytest.raises(OSError):
+        await writer.record("agent-1", status="completed", response=1)
+    monkeypatch.undo()
+
+    await writer.record("agent-2", status="completed", response=2)
+
+    assert [record["seq"] for record in writer.journal_records()] == [1]
+    recovered = load_checkpoint(path)
+    assert "_recovery" not in recovered, recovered.get("_recovery")
+    assert set(recovered["ops"]) == {"agent-2"}

--- a/tests/cli/orchestrate/test_checkpoint_journal.py
+++ b/tests/cli/orchestrate/test_checkpoint_journal.py
@@ -986,6 +986,45 @@ async def test_a_journal_this_writer_created_keeps_taking_records(tmp_path: Path
     assert list(recovered["ops"]) == [f"agent-{i}" for i in range(6)]
 
 
+async def test_a_journal_substituted_between_its_replace_and_its_pin_is_refused(
+    tmp_path: Path, monkeypatch
+):
+    """The moment the pin has to be taken before, not after.
+
+    Replacing the journal and then reading its identity back by name leaves a
+    window: whatever is at that name when the read happens becomes the file
+    every later record is measured against, and records carry raw responses and
+    the shared flow context.
+    """
+    from lionagi.cli.orchestrate import _checkpoint as checkpoint_mod
+
+    path = tmp_path / "checkpoint.json"
+    writer = _writer(path)
+    planted_inode: list[int] = []
+    real_fsync_parent = checkpoint_mod._fsync_parent
+
+    def plant_a_substitute_after_the_replace(target: Path) -> None:
+        # Runs after os.replace and before the atomic write returns, which is
+        # exactly the window a pin read back by name would fall into.
+        real_fsync_parent(target)
+        if target == writer.journal_path and not planted_inode:
+            planted = tmp_path / "planted"
+            planted.write_bytes(b"")
+            planted.chmod(0o600)
+            os.replace(planted, target)
+            planted_inode.append(target.stat().st_ino)
+
+    monkeypatch.setattr(checkpoint_mod, "_fsync_parent", plant_a_substitute_after_the_replace)
+
+    with pytest.raises(JournalPathError):
+        await writer.record("agent-1", status="completed", response="one")
+
+    assert planted_inode, "nothing was substituted, so this asserts nothing"
+    journal = writer.journal_path
+    assert journal.stat().st_ino == planted_inode[0]
+    assert journal.read_bytes() == b""
+
+
 async def test_a_journal_reset_deferred_by_a_failure_is_pinned_when_it_finally_happens(
     tmp_path: Path, monkeypatch
 ):
@@ -1000,7 +1039,7 @@ async def test_a_journal_reset_deferred_by_a_failure_is_pinned_when_it_finally_h
     real = checkpoint_mod._atomic_write_bytes
     resets: list[int] = []
 
-    def fail_the_compaction_reset(target: Path, payload: bytes) -> int:
+    def fail_the_compaction_reset(target: Path, payload: bytes) -> tuple[int, tuple[int, int]]:
         if target == writer.journal_path:
             resets.append(1)
             if len(resets) == 2:


### PR DESCRIPTION
## What this replaces

A flow checkpoint was rewritten in full after every completion. Recording one op
cost the serialization of everything already recorded, and that serialization ran
on the event loop.

Version 3 keeps two run-local files:

- `checkpoint.json`, an atomic base snapshot carrying a generation id
- `checkpoint.json.journal`, an append-only log of operation, spawn and top-level
  context deltas for that generation

A completion is acknowledged only once its record is flushed and fsynced.
Serialization and filesystem work run on a worker thread while one async lock
preserves writer order. After 128 deltas the base is replaced atomically under a
new generation and the journal is cleared; a journal from an older generation is
never replayed onto a newer base. Recovery applies the valid prefix in sequence
order and discloses a torn final line, a gap, a malformed record or a stale
generation in `_recovery` rather than failing silently.

Versions 1 and 2 stay readable. `CheckpointWriter` still defaults to version 2;
the flow runtime opts into version 3 explicitly.

## The context baseline is captured once, before any await

The caller holds the shared context workspace and keeps mutating it between
completions. Reading it to build the delta and reading it again afterwards to
store the next baseline puts those two reads on opposite sides of an await. A
mutation landing in between entered the baseline without entering any delta, and
because the next comparison starts from that baseline it was never journaled at
all: recovery restored context the run had already moved past, permanently.

Capturing once up front and deriving both the delta and the next baseline from
that one value makes them describe the same state by construction. It also stops
the journal record from holding live references into a workspace that can still
change before the record is serialized.

Moving that capture off the event loop would reintroduce the window it exists to
close, so it is deliberately synchronous, and the code says so.

## Verification

Reverting the capture to the previous ordering reddens exactly the two new
regression tests and leaves the other twelve green, including the two that cover
in-place nested updates. Those two stay green because they mutate *between*
completions, which is why they never caught this.

The regression tests drive the mutation from inside the journal write, on both
the planned and the spawned paths, and assert their own injection fired.
Injecting *before* the record is serialized proves nothing, because the delta
held references into the caller's containers and the change was written out with
it; the first version of these tests did exactly that and passed against the
unfixed code.

Failure-set diff over 3,276 tests in `tests/cli` plus the checkpoint consumers:
identical before and after, two failures that reproduce unchanged on `main`
(`test_ndjson_from_cli_inherits_stamped_depth`,
`test_schedule_runs_unreachable_studio_reports_diagnostic`). One run also showed
a third failure in a timing-sensitive scheduling test that touches no checkpoint
code; it did not reproduce on a second full run, and a deterministic code change
cannot produce an intermittent failure, so it is recorded as non-deterministic
rather than explained away.

## Known cost, stated rather than left implicit

The per-completion context deep copy and the whole-value delta for a changed
nested container both scale with accumulated context. That is a real remaining
cost and it is filed separately. It is not a regression: the path this replaces
serialized the *entire* checkpoint state on the event loop after every
completion, so version 3 is strictly cheaper on both the loop and the disk. A
delta design that descends into nested containers would be cheaper still and is
a different change.

## Scope

This is the checkpoint half of a change that had grown to cover two unrelated
subsystems. The process-identity and liveness half follows separately, because
the two share no files and no imports.