### PR TITLE
feat(studio): run the retention prune on a schedule anchored to the last prune

### DIFF
--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -389,6 +389,17 @@ PRUNE_ARCHIVE_DIR: Path | None = (
 # transaction so the write lock is released between chunks and an interrupted
 # prune keeps the chunks that already committed.
 PRUNE_CHUNK_ROWS: int = max(1, int(os.environ.get("LIONAGI_STUDIO_PRUNE_CHUNK_ROWS", "100")))
+# Minimum seconds between automatic retention prunes from the scheduler tick;
+# 0 disables the automatic pass and leaves prune to the admin route. The gap is
+# measured from when a prune last committed, read back from the admin event log,
+# not from when this process started: a daemon restarted more often than the
+# interval would otherwise never reach a pass. A database that has never been
+# pruned starts its clock at process start rather than firing immediately, so
+# adopting this on an installation with a large backlog has a predictable first
+# pass instead of one during startup.
+RETENTION_INTERVAL_SECONDS: int = int(
+    os.environ.get("LIONAGI_STUDIO_RETENTION_INTERVAL_SECONDS", "86400")
+)
 
 # dispatch_outbox retention (ADR-0059 delta 3). Two windows: terminal-success
 # rows (delivered/acked) are low-signal once past the window, so they use a

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -440,6 +440,11 @@ class SchedulerEngine:
         self._fire_tasks: set[asyncio.Task] = set()
         self._last_reaper_run: float = 0.0
         self._last_checkpoint_run: float = 0.0
+        # Unlike the two above, this starts unresolved rather than at 0.0, which
+        # would make a prune due on the first tick. It is resolved once, from
+        # when a prune last committed, so that restarting the daemon neither
+        # triggers a pass nor postpones one that is already overdue.
+        self._last_retention_run: float | None = None
         # max_runs budget reservation (single-process; see _reserve_max_runs_budget).
         self._max_runs_lock = asyncio.Lock()
         self._max_runs_inflight: dict[
@@ -785,6 +790,47 @@ class SchedulerEngine:
             except Exception:
                 _log.exception("Scheduler tick error")
             await asyncio.sleep(_TICK_INTERVAL)
+
+    async def _maybe_prune(self, now: float) -> None:
+        """Run the retention prune when a full interval has passed since one
+        last committed.
+
+        The gap is measured from the recorded prune, not from process start, so
+        a daemon that restarts more often than the interval still reaches a
+        pass. When nothing has ever been pruned the clock starts now, which
+        keeps a first adoption on a large backlog out of daemon startup and
+        puts it one interval later, where it can be expected.
+
+        Only the prune runs here. ``VACUUM`` takes an exclusive lock for as
+        long as it takes to rewrite the file, so it stays on the admin route
+        where a person chooses the moment.
+        """
+        from lionagi.studio.config import RETENTION_INTERVAL_SECONDS
+        from lionagi.studio.services.db_maintenance import get_last_prune_at, prune_old_data
+
+        if RETENTION_INTERVAL_SECONDS <= 0:
+            return
+
+        if self._last_retention_run is None:
+            try:
+                recorded = await get_last_prune_at()
+            except Exception:
+                # Leave it unresolved so the next tick tries again. Anchoring on
+                # a failed read would silence the pass for this process's life.
+                _log.exception("Could not read the last prune time; retrying next tick")
+                return
+            self._last_retention_run = now if recorded is None else recorded
+
+        if now - self._last_retention_run < RETENTION_INTERVAL_SECONDS:
+            return
+
+        try:
+            await prune_old_data(actor="scheduler_tick")
+        except Exception:
+            _log.exception("Periodic retention prune error")
+        # Stamped even on failure, matching the reaper and checkpoint passes: a
+        # prune that keeps failing must not be retried on every tick.
+        self._last_retention_run = now
 
     async def _mark_dispatched(self, run_id: str) -> None:
         """Stamp ``dispatched_at`` the instant spawn_and_wait confirms the
@@ -1199,6 +1245,8 @@ class SchedulerEngine:
             except Exception:
                 _log.exception("Periodic checkpoint error")
             self._last_checkpoint_run = now
+
+        await self._maybe_prune(now)
 
         try:
             await self._deliver_due_dispatches(now)

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -441,10 +441,16 @@ class SchedulerEngine:
         self._last_reaper_run: float = 0.0
         self._last_checkpoint_run: float = 0.0
         # Unlike the two above, this starts unresolved rather than at 0.0, which
-        # would make a prune due on the first tick. It is resolved once, from
-        # when a prune last committed, so that restarting the daemon neither
-        # triggers a pass nor postpones one that is already overdue.
+        # would make a prune due on the first tick. It is resolved from when a
+        # prune last committed, so that restarting the daemon neither triggers
+        # a pass nor postpones one that is already overdue. It is a cheap gate
+        # on the tick, not the decision: see _run_prune.
         self._last_retention_run: float | None = None
+        # Single-flight tracked task for the retention prune, for the same
+        # reason as _worker_task: the sweep's cost scales with whatever has
+        # accumulated, so awaiting it on the tick would hold up dispatch
+        # delivery and schedule evaluation for the whole pass.
+        self._retention_task: asyncio.Task | None = None
         # max_runs budget reservation (single-process; see _reserve_max_runs_budget).
         self._max_runs_lock = asyncio.Lock()
         self._max_runs_inflight: dict[
@@ -711,6 +717,14 @@ class SchedulerEngine:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._worker_task
             self._worker_task = None
+        if self._retention_task is not None:
+            # Cancelling mid-prune keeps whichever chunks already committed and
+            # writes no prune event, so the next process reads the older
+            # recorded prune and is due straight away rather than skipping one.
+            self._retention_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._retention_task
+            self._retention_task = None
         if self._fire_tasks:
             for ft in list(self._fire_tasks):
                 ft.cancel()
@@ -791,46 +805,94 @@ class SchedulerEngine:
                 _log.exception("Scheduler tick error")
             await asyncio.sleep(_TICK_INTERVAL)
 
-    async def _maybe_prune(self, now: float) -> None:
-        """Run the retention prune when a full interval has passed since one
-        last committed.
+    def _maybe_start_prune(self, now: float) -> None:
+        """Kick off the retention prune as a tracked, single-flight background
+        task instead of awaiting it inline.
 
-        The gap is measured from the recorded prune, not from process start, so
-        a daemon that restarts more often than the interval still reaches a
-        pass. When nothing has ever been pruned the clock starts now, which
-        keeps a first adoption on a large backlog out of daemon startup and
-        puts it one interval later, where it can be expected.
+        How much the sweep has to do is set by however much eligible data has
+        accumulated, which nothing here bounds, so awaiting it on the tick
+        would hold dispatch delivery and schedule evaluation for the whole
+        pass. A pass still in flight from an earlier tick starts no second
+        one, so this does not raise the prune rate, only the tick's latency
+        floor for reaching one.
+
+        The check here is only the cheap gate: an unresolved anchor starts a
+        pass because resolving it is a database read, and the decision itself
+        is made in ``_run_prune`` against the recorded prune.
 
         Only the prune runs here. ``VACUUM`` takes an exclusive lock for as
         long as it takes to rewrite the file, so it stays on the admin route
         where a person chooses the moment.
         """
         from lionagi.studio.config import RETENTION_INTERVAL_SECONDS
-        from lionagi.studio.services.db_maintenance import get_last_prune_at, prune_old_data
 
         if RETENTION_INTERVAL_SECONDS <= 0:
             return
+        if self._retention_task is not None and not self._retention_task.done():
+            return
+        if (
+            self._last_retention_run is not None
+            and now - self._last_retention_run < RETENTION_INTERVAL_SECONDS
+        ):
+            return
+        self._retention_task = asyncio.create_task(self._run_prune_guarded(now))
 
-        if self._last_retention_run is None:
-            try:
-                recorded = await get_last_prune_at()
-            except Exception:
-                # Leave it unresolved so the next tick tries again. Anchoring on
-                # a failed read would silence the pass for this process's life.
-                _log.exception("Could not read the last prune time; retrying next tick")
-                return
-            self._last_retention_run = now if recorded is None else recorded
+    async def _run_prune_guarded(self, now: float) -> None:
+        try:
+            await self._run_prune(now)
+        except Exception:
+            _log.exception("Periodic retention prune error")
 
-        if now - self._last_retention_run < RETENTION_INTERVAL_SECONDS:
+    async def _run_prune(self, now: float) -> None:
+        """Prune once, if a full interval has passed since a prune last committed.
+
+        The recorded prune is re-read every time the gate opens rather than
+        resolved once, because a prune from the admin route commits an event
+        this process would otherwise never see: without the re-read an
+        automatic pass could follow a manual one immediately, having measured
+        its interval from a prune two intervals ago.
+
+        The anchor only ever moves forward. The recorded event is written
+        after the prune's transactions commit, so it is a completion time like
+        the stamp below, and taking the later of the two keeps a long prune
+        from leaving the next one due sooner by however long it ran.
+        """
+        from lionagi.studio.config import RETENTION_INTERVAL_SECONDS
+        from lionagi.studio.services.db_maintenance import get_last_prune_at, prune_old_data
+
+        try:
+            recorded = await get_last_prune_at()
+        except Exception:
+            # Leave the anchor as it was so the next tick tries again.
+            # Anchoring on a failed read would either silence the pass or run
+            # it early, depending on which way the failure was read.
+            _log.exception("Could not read the last prune time; retrying next tick")
+            return
+
+        if recorded is None and self._last_retention_run is None:
+            # Nothing has ever been pruned. Start the clock now rather than
+            # firing immediately, so adopting this on an installation with a
+            # large backlog gets a predictable first pass one interval out
+            # instead of one during daemon startup.
+            self._last_retention_run = now
+            return
+
+        # Judged against the tick's own reading, the one the gate used. The
+        # completion stamp below is the only place a fresh reading belongs,
+        # because that is the value the tick cannot know.
+        anchor = max(recorded or 0.0, self._last_retention_run or 0.0)
+        self._last_retention_run = anchor
+        if now - anchor < RETENTION_INTERVAL_SECONDS:
             return
 
         try:
             await prune_old_data(actor="scheduler_tick")
-        except Exception:
-            _log.exception("Periodic retention prune error")
-        # Stamped even on failure, matching the reaper and checkpoint passes: a
-        # prune that keeps failing must not be retried on every tick.
-        self._last_retention_run = now
+        finally:
+            # Stamped from completion rather than from the tick that started
+            # this, and stamped on failure too, matching the reaper and
+            # checkpoint passes: a prune that keeps failing must not be
+            # retried on every tick.
+            self._last_retention_run = time.time()
 
     async def _mark_dispatched(self, run_id: str) -> None:
         """Stamp ``dispatched_at`` the instant spawn_and_wait confirms the
@@ -1246,7 +1308,7 @@ class SchedulerEngine:
                 _log.exception("Periodic checkpoint error")
             self._last_checkpoint_run = now
 
-        await self._maybe_prune(now)
+        self._maybe_start_prune(now)
 
         try:
             await self._deliver_due_dispatches(now)

--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -251,9 +251,36 @@ def get_db_size_alert(size_bytes: int) -> tuple[bool, int]:
     return size_bytes >= threshold, threshold
 
 
-def _row_chunks(ids: Sequence[str], size: int) -> list[list[str]]:
-    """Split *ids* (already sorted) into stable, bounded, non-overlapping chunks."""
-    return [list(ids[i : i + size]) for i in range(0, len(ids), size)]
+async def _candidate_chunks(
+    db: StateDB,
+    *,
+    table: str,
+    where_sql: str,
+    params: Sequence[Any],
+    size: int,
+) -> AsyncIterator[list[str]]:
+    """Yield ids eligible under *where_sql* in bounded, ascending-id chunks.
+
+    The scan reads one chunk at a time instead of every eligible id at once,
+    so a pass holds at most *size* ids however far the aged backlog has grown.
+    Each chunk is read in its own short transaction, which keeps the selection
+    off the write lock the chunk deletes then take.
+
+    The cursor advances by id rather than by "what is still eligible", because
+    a chunk can legitimately delete nothing: `_prune_session_chunk` re-checks
+    each row under the write lock and skips one that stopped being terminal.
+    Re-asking the same question would hand that row back forever.
+    """
+    after = ""
+    while True:
+        sql = f"SELECT id FROM {table} WHERE ({where_sql}) AND id > ? ORDER BY id LIMIT ?"  # noqa: S608
+        async with db.transaction() as conn:
+            rows = (await conn.execute(*_q(sql, (*params, after, size)))).fetchall()
+        ids = sorted({r[0] for r in rows})
+        if not ids:
+            return
+        yield ids
+        after = ids[-1]
 
 
 async def _after_prune_chunk_committed(*, chunk_index: int, chunk_ids: list[str]) -> None:
@@ -626,7 +653,12 @@ async def prune_old_data(
     and deleted in its own short transaction, so an interrupted run keeps
     every chunk that already committed; a failed archive write aborts the
     remainder of the pass. Soft-FK children are nullified before DELETE
-    since they lack CASCADE. See studio.md."""
+    since they lack CASCADE. See studio.md.
+
+    Candidate ids are read one chunk at a time as well, so the pass holds
+    ``PRUNE_CHUNK_ROWS`` ids at a time rather than every id an aged backlog
+    made eligible. Total work still scales with that backlog; what is bounded
+    is the memory a pass occupies and the length of any one lock it takes."""
     from lionagi.studio.config import (
         DISPATCH_RETENTION_DEAD_LETTER_DAYS,
         DISPATCH_RETENTION_SUCCESS_DAYS,
@@ -657,14 +689,17 @@ async def prune_old_data(
     dispatch_archive_ids: list[str] = []
 
     async with StateDB() as db:
-        # ── find session IDs to prune (read-only candidate selection) ──────
-        async with db.transaction() as conn:
-            sql = f"SELECT id FROM sessions WHERE {retention_sql}"  # noqa: S608
-            rows = (await conn.execute(*_q(sql, retention_params))).fetchall()
-            session_ids = sorted({r[0] for r in rows})
-
         # ── archive-then-delete in bounded, independently committed chunks ─
-        for chunk_index, chunk_ids in enumerate(_row_chunks(session_ids, PRUNE_CHUNK_ROWS)):
+        # Candidate ids arrive one chunk at a time; see _candidate_chunks.
+        chunk_index = -1
+        async for chunk_ids in _candidate_chunks(
+            db,
+            table="sessions",
+            where_sql=retention_sql,
+            params=retention_params,
+            size=PRUNE_CHUNK_ROWS,
+        ):
+            chunk_index += 1
             archive_id = archive_chunk_id(cutoff=cutoff, chunk_index=chunk_index)
             async with db.transaction() as conn:
                 chunk_pruned = await _prune_session_chunk(
@@ -693,12 +728,15 @@ async def prune_old_data(
         # ── schedule_run retention: archive-then-delete in bounded, ────────
         # independently committed chunks (ADR-R3 shape, applied to runs).
         run_retention_sql, run_retention_params = _run_retention_predicate(cutoff)
-        async with db.transaction() as conn:
-            sql = f"SELECT id FROM schedule_runs WHERE {run_retention_sql}"  # noqa: S608
-            rows = (await conn.execute(*_q(sql, run_retention_params))).fetchall()
-            run_ids = sorted({r[0] for r in rows})
-
-        for chunk_index, chunk_ids in enumerate(_row_chunks(run_ids, PRUNE_CHUNK_ROWS)):
+        chunk_index = -1
+        async for chunk_ids in _candidate_chunks(
+            db,
+            table="schedule_runs",
+            where_sql=run_retention_sql,
+            params=run_retention_params,
+            size=PRUNE_CHUNK_ROWS,
+        ):
+            chunk_index += 1
             archive_id = archive_chunk_id(cutoff=cutoff, chunk_index=chunk_index, kind="run")
             async with db.transaction() as conn:
                 chunk_pruned = await _prune_run_chunk(
@@ -725,13 +763,16 @@ async def prune_old_data(
         dispatch_retention_sql, dispatch_retention_params = _dispatch_retention_predicate(
             dispatch_success_cutoff, dispatch_dead_letter_cutoff
         )
-        async with db.transaction() as conn:
-            sql = f"SELECT id FROM dispatch_outbox WHERE {dispatch_retention_sql}"  # noqa: S608
-            rows = (await conn.execute(*_q(sql, dispatch_retention_params))).fetchall()
-            dispatch_ids = sorted({r[0] for r in rows})
-
         dispatch_purged = 0
-        for chunk_index, chunk_ids in enumerate(_row_chunks(dispatch_ids, PRUNE_CHUNK_ROWS)):
+        chunk_index = -1
+        async for chunk_ids in _candidate_chunks(
+            db,
+            table="dispatch_outbox",
+            where_sql=dispatch_retention_sql,
+            params=dispatch_retention_params,
+            size=PRUNE_CHUNK_ROWS,
+        ):
+            chunk_index += 1
             archive_id = archive_chunk_id(
                 cutoff=dispatch_success_cutoff, chunk_index=chunk_index, kind="dispatch"
             )

--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -227,6 +227,22 @@ async def get_last_checkpoint_at() -> float | None:
     return None
 
 
+async def get_last_prune_at() -> float | None:
+    """Return the ``created_at`` of the most recent prune event, or None if a
+    prune has never been recorded.
+
+    Unlike ``get_last_checkpoint_at`` this does not swallow read failures. Its
+    caller uses the answer to decide when the next automatic prune is due, and
+    a failed read reported as None is indistinguishable from "never pruned",
+    which would anchor the schedule to the failure instead of retrying.
+    """
+    if state_db_known_absent():
+        return None
+    async with StateDB() as db:
+        events = await db.list_admin_events(action="prune", limit=1)
+    return events[0].get("created_at") if events else None
+
+
 def get_db_size_alert(size_bytes: int) -> tuple[bool, int]:
     """Return ``(size_alert, threshold_bytes)`` given the current DB size."""
     from lionagi.studio.config import DB_SIZE_ALERT_BYTES

--- a/tests/apps_studio_server/test_retention_archive.py
+++ b/tests/apps_studio_server/test_retention_archive.py
@@ -382,6 +382,54 @@ def test_chunk_selection_is_stable_and_bounded(tmp_path, monkeypatch):
     assert len(flat) == len(set(flat))
 
 
+def test_candidate_selection_is_read_one_chunk_at_a_time(tmp_path, monkeypatch):
+    """The pass never asks the DB for more than one chunk of candidate ids.
+
+    Chunking a list of ids bounds the deletes but not the read that produced
+    the list: every eligible id was already in memory by the time the first
+    chunk was archived, so an aged backlog was unbounded exactly where it was
+    largest. The result rows look identical either way, so this reads the SQL
+    the pass issued rather than what it returned.
+    """
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=None, chunk_rows=2)
+
+    old_ts = time.time() - 40 * 86400
+    issued: list[tuple[str, tuple]] = []
+    original_q = maint._q
+
+    def record(sql, params):
+        issued.append((sql, tuple(params)))
+        return original_q(sql, params)
+
+    monkeypatch.setattr(maint, "_q", record)
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            return [
+                await _make_session(db, status="completed", started_at=old_ts) for _ in range(5)
+            ]
+
+    ids = run_async(seed())
+    result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    # The pass still prunes everything; only how it reads changed.
+    assert result["sessions_pruned"] == len(ids) == 5
+
+    candidate_reads = [(s, p) for s, p in issued if s.startswith("SELECT id FROM sessions WHERE")]
+    assert candidate_reads, "the pass issued no candidate selection at all"
+    paged = [(s, p) for s, p in candidate_reads if s.endswith("ORDER BY id LIMIT ?")]
+    # Five candidates at two per read cannot be covered by one read, so this
+    # fails if the selection goes back to fetching every eligible id at once.
+    assert len(paged) >= 3, f"candidate selection was not paged: {candidate_reads}"
+    # Every read carries the chunk size as its bound, so no single read can
+    # return more rows than a chunk holds.
+    assert {p[-1] for _, p in paged} == {2}
+
+
 def test_interrupt_after_n_chunks_keeps_completed_chunks(tmp_path, monkeypatch):
     """An exception after N chunks commit must leave those N chunks' deletions in place."""
     from lionagi.studio.services import db_maintenance as maint

--- a/tests/studio/test_scheduler_retention_tick.py
+++ b/tests/studio/test_scheduler_retention_tick.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The scheduler tick's retention pass.
+
+The pass exists because nothing else calls ``prune_old_data`` on a schedule:
+before this, every prune came from an admin route someone had to invoke, so an
+installation nobody administered grew without bound.
+
+What makes it more than an interval timer is where the interval is measured
+from. Anchoring on process start would mean a daemon restarted more often than
+the interval never prunes at all, and starting the counter at zero, the way the
+reaper and checkpoint passes do, would put a prune in the middle of daemon
+startup on every restart. It reads back when a prune last committed instead.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+DAY = 86400.0
+
+
+def _engine():
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    return SchedulerEngine(svc=AsyncMock())
+
+
+def _patches(*, last_prune, interval=DAY):
+    """Patch the three things `_maybe_prune` reads, and nothing else."""
+    last = (
+        AsyncMock(side_effect=last_prune)
+        if isinstance(last_prune, Exception)
+        else AsyncMock(return_value=last_prune)
+    )
+    prune = AsyncMock(return_value={"sessions_pruned": 0})
+    return (
+        patch("lionagi.studio.config.RETENTION_INTERVAL_SECONDS", int(interval)),
+        patch("lionagi.studio.services.db_maintenance.get_last_prune_at", new=last),
+        patch("lionagi.studio.services.db_maintenance.prune_old_data", new=prune),
+        prune,
+        last,
+    )
+
+
+async def _run(engine, *, last_prune, interval=DAY, now=None):
+    p_interval, p_last, p_prune, prune, last = _patches(last_prune=last_prune, interval=interval)
+    with p_interval, p_last, p_prune:
+        await engine._maybe_prune(time.time() if now is None else now)
+    return prune, last
+
+
+@pytest.mark.asyncio
+async def test_a_prune_older_than_the_interval_is_due():
+    engine = _engine()
+    prune, _ = await _run(engine, last_prune=time.time() - 2 * DAY)
+    assert prune.await_count == 1
+    assert prune.await_args.kwargs["actor"] == "scheduler_tick"
+
+
+@pytest.mark.asyncio
+async def test_a_prune_inside_the_interval_is_not_due():
+    engine = _engine()
+    prune, _ = await _run(engine, last_prune=time.time() - DAY / 2)
+    assert prune.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_a_database_that_has_never_been_pruned_is_not_pruned_at_startup():
+    """The property that keeps a first adoption out of daemon startup.
+
+    An installation carrying a large backlog would otherwise prune during the
+    first tick after the upgrade, which is both the least expected moment and
+    the one competing with everything else startup is doing.
+    """
+    engine = _engine()
+    start = time.time()
+    prune, _ = await _run(engine, last_prune=None, now=start)
+    assert prune.await_count == 0, "a never-pruned database must not prune on the first tick"
+    assert engine._last_retention_run == start, "the clock has to start, or it never becomes due"
+
+
+@pytest.mark.asyncio
+async def test_a_database_that_has_never_been_pruned_is_pruned_one_interval_later():
+    """The other half: not pruning at startup must not mean never pruning."""
+    engine = _engine()
+    start = time.time()
+    prune, last = await _run(engine, last_prune=None, now=start)
+    assert prune.await_count == 0
+
+    prune, last = await _run(engine, last_prune=None, now=start + DAY + 1)
+    assert prune.await_count == 1
+    assert last.await_count == 0, "the anchor is resolved once, not re-read every tick"
+
+
+@pytest.mark.asyncio
+async def test_the_interval_is_measured_from_the_recorded_prune_not_from_startup():
+    """A daemon restarted more often than the interval still reaches a pass.
+
+    This is the case a process-local timer gets wrong: every restart would move
+    the deadline forward, so a daemon bounced daily under a daily interval would
+    never prune once.
+    """
+    engine = _engine()
+    prune, _ = await _run(engine, last_prune=time.time() - 30 * DAY)
+    assert prune.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_zero_interval_disables_the_pass_without_reading_anything():
+    engine = _engine()
+    prune, last = await _run(engine, last_prune=time.time() - 30 * DAY, interval=0)
+    assert prune.await_count == 0
+    assert last.await_count == 0, "a disabled pass must not cost a database read per tick"
+    assert engine._last_retention_run is None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_read_of_the_last_prune_retries_rather_than_anchoring():
+    """A read failure is not an answer.
+
+    Treating it as "never pruned" would anchor the schedule to the moment of the
+    failure and silence the pass for the life of the process. Leaving it
+    unresolved costs one more read on the next tick.
+    """
+    engine = _engine()
+    prune, _ = await _run(engine, last_prune=RuntimeError("database is locked"))
+    assert prune.await_count == 0
+    assert engine._last_retention_run is None, "a failed read must not become the anchor"
+
+    prune, _ = await _run(engine, last_prune=time.time() - 2 * DAY)
+    assert prune.await_count == 1, "the next tick has to try again"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_prune_is_not_retried_on_every_tick():
+    """Matches the reaper and checkpoint passes: the stamp is unconditional."""
+    engine = _engine()
+    now = time.time()
+    p_interval, p_last, _, _, last = _patches(last_prune=now - 2 * DAY)
+    failing = AsyncMock(side_effect=RuntimeError("disk full"))
+    with (
+        p_interval,
+        p_last,
+        patch("lionagi.studio.services.db_maintenance.prune_old_data", new=failing),
+    ):
+        await engine._maybe_prune(now)
+        await engine._maybe_prune(now + 60)
+    assert failing.await_count == 1
+    assert engine._last_retention_run == now
+
+
+@pytest.mark.asyncio
+async def test_the_pass_never_vacuums():
+    """VACUUM holds an exclusive lock for as long as it takes to rewrite the
+    file, so it stays on the admin route where a person picks the moment. A
+    scheduled pass that quietly acquired it would stall every reader."""
+    engine = _engine()
+    p_interval, p_last, p_prune, prune, _ = _patches(last_prune=time.time() - 2 * DAY)
+    vacuum = AsyncMock(return_value={"status": "ok"})
+    with (
+        p_interval,
+        p_last,
+        p_prune,
+        patch("lionagi.studio.services.db_maintenance.vacuum_state_db", new=vacuum),
+    ):
+        await engine._maybe_prune(time.time())
+    assert prune.await_count == 1, "control: the pass did run"
+    assert vacuum.await_count == 0

--- a/tests/studio/test_scheduler_retention_tick.py
+++ b/tests/studio/test_scheduler_retention_tick.py
@@ -11,11 +11,18 @@ What makes it more than an interval timer is where the interval is measured
 from. Anchoring on process start would mean a daemon restarted more often than
 the interval never prunes at all, and starting the counter at zero, the way the
 reaper and checkpoint passes do, would put a prune in the middle of daemon
-startup on every restart. It reads back when a prune last committed instead.
+startup on every restart. It reads back when a prune last committed instead,
+including prunes this process did not run.
+
+The tick starts the pass and moves on. How much the sweep has to do is set by
+however much eligible data has accumulated, and nothing bounds that, so a tick
+that waited for it would stop delivering dispatches and evaluating schedules
+for the duration.
 """
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, patch
 
@@ -30,14 +37,14 @@ def _engine():
     return SchedulerEngine(svc=AsyncMock())
 
 
-def _patches(*, last_prune, interval=DAY):
-    """Patch the three things `_maybe_prune` reads, and nothing else."""
+def _patches(*, last_prune, interval=DAY, prune=None):
+    """Patch the three things the pass reads, and nothing else."""
     last = (
         AsyncMock(side_effect=last_prune)
         if isinstance(last_prune, Exception)
         else AsyncMock(return_value=last_prune)
     )
-    prune = AsyncMock(return_value={"sessions_pruned": 0})
+    prune = prune if prune is not None else AsyncMock(return_value={"sessions_pruned": 0})
     return (
         patch("lionagi.studio.config.RETENTION_INTERVAL_SECONDS", int(interval)),
         patch("lionagi.studio.services.db_maintenance.get_last_prune_at", new=last),
@@ -48,9 +55,16 @@ def _patches(*, last_prune, interval=DAY):
 
 
 async def _run(engine, *, last_prune, interval=DAY, now=None):
+    """Start a pass and wait for it, so a test can assert on what it did.
+
+    Waiting is this helper's job, not the tick's. Everything under test here
+    runs in the background task ``_maybe_start_prune`` spawns.
+    """
     p_interval, p_last, p_prune, prune, last = _patches(last_prune=last_prune, interval=interval)
     with p_interval, p_last, p_prune:
-        await engine._maybe_prune(time.time() if now is None else now)
+        engine._maybe_start_prune(time.time() if now is None else now)
+        if engine._retention_task is not None:
+            await engine._retention_task
     return prune, last
 
 
@@ -81,7 +95,8 @@ async def test_a_database_that_has_never_been_pruned_is_not_pruned_at_startup():
     start = time.time()
     prune, _ = await _run(engine, last_prune=None, now=start)
     assert prune.await_count == 0, "a never-pruned database must not prune on the first tick"
-    assert engine._last_retention_run == start, "the clock has to start, or it never becomes due"
+    assert engine._last_retention_run is not None, "the clock has to start, or it never becomes due"
+    assert engine._last_retention_run >= start
 
 
 @pytest.mark.asyncio
@@ -94,7 +109,6 @@ async def test_a_database_that_has_never_been_pruned_is_pruned_one_interval_late
 
     prune, last = await _run(engine, last_prune=None, now=start + DAY + 1)
     assert prune.await_count == 1
-    assert last.await_count == 0, "the anchor is resolved once, not re-read every tick"
 
 
 @pytest.mark.asyncio
@@ -141,17 +155,21 @@ async def test_a_failing_prune_is_not_retried_on_every_tick():
     """Matches the reaper and checkpoint passes: the stamp is unconditional."""
     engine = _engine()
     now = time.time()
-    p_interval, p_last, _, _, last = _patches(last_prune=now - 2 * DAY)
     failing = AsyncMock(side_effect=RuntimeError("disk full"))
+    p_interval, p_last, _, _, _ = _patches(last_prune=now - 2 * DAY)
+    engine._last_retention_run = now - 2 * DAY
     with (
         p_interval,
         p_last,
         patch("lionagi.studio.services.db_maintenance.prune_old_data", new=failing),
     ):
-        await engine._maybe_prune(now)
-        await engine._maybe_prune(now + 60)
+        engine._maybe_start_prune(now)
+        await engine._retention_task
+        engine._maybe_start_prune(now + 60)
+        if engine._retention_task is not None and not engine._retention_task.done():
+            await engine._retention_task
     assert failing.await_count == 1
-    assert engine._last_retention_run == now
+    assert engine._last_retention_run is not None and engine._last_retention_run >= now
 
 
 @pytest.mark.asyncio
@@ -168,6 +186,120 @@ async def test_the_pass_never_vacuums():
         p_prune,
         patch("lionagi.studio.services.db_maintenance.vacuum_state_db", new=vacuum),
     ):
-        await engine._maybe_prune(time.time())
+        engine._maybe_start_prune(time.time())
+        await engine._retention_task
     assert prune.await_count == 1, "control: the pass did run"
     assert vacuum.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_a_prune_run_from_the_admin_route_delays_the_automatic_one():
+    """The recorded prune decides, not the anchor this process happens to hold.
+
+    Someone pruning by hand commits an event the scheduler never sees any other
+    way. Resolving the anchor once and keeping it would let an automatic pass
+    follow a manual one immediately, having measured its interval from a prune
+    two intervals ago.
+    """
+    engine = _engine()
+    now = time.time()
+    engine._last_retention_run = now - 30 * DAY  # stale: what this process last saw
+
+    prune, last = await _run(engine, last_prune=now - 60, now=now)
+
+    assert last.await_count == 1, "the gate opened, so the recorded prune has to be re-read"
+    assert prune.await_count == 0, "a prune a minute ago means the interval has not elapsed"
+    assert engine._last_retention_run >= now - 60, "the anchor has to adopt the newer prune"
+
+
+@pytest.mark.asyncio
+async def test_a_tick_inside_the_interval_reads_nothing():
+    """The re-read costs one query when the gate opens, not one per tick."""
+    engine = _engine()
+    now = time.time()
+    engine._last_retention_run = now - DAY / 2
+
+    _, last = await _run(engine, last_prune=now - DAY / 2, now=now)
+
+    assert last.await_count == 0
+    assert engine._retention_task is None, "no task should have been started at all"
+
+
+@pytest.mark.asyncio
+async def test_the_next_prune_is_measured_from_when_the_last_one_finished():
+    """A prune that runs for a long time must not leave the next one due sooner.
+
+    Stamping the tick's timestamp meant a sweep that took a third of the
+    interval got its next pass a third of an interval early, and one that ran
+    longer than the interval would have been due again the moment it finished.
+    """
+    engine = _engine()
+    # A tick timestamp far behind the wall clock stands in for a prune that ran
+    # for a long time: the two differ by exactly the sweep's duration, and only
+    # one of them is a sound base for the next interval.
+    tick_time = time.time() - 10 * DAY
+
+    started = time.time()
+    await _run(engine, last_prune=tick_time - 2 * DAY, now=tick_time)
+
+    assert engine._last_retention_run >= started, (
+        "the anchor came from the tick's timestamp, not from when the prune ended"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_tick_does_not_wait_for_the_prune():
+    """The finding this shape exists for: an unbounded sweep held the tick.
+
+    ``_maybe_start_prune`` is a plain function returning None, so a tick cannot
+    await it even by accident. What this pins is the rest of the contract: the
+    call returns while the prune is still running, and a tick arriving during
+    one starts no second sweep.
+    """
+    engine = _engine()
+    release = asyncio.Event()
+    entered = asyncio.Event()
+
+    async def held_prune(**kwargs):
+        entered.set()
+        await release.wait()
+        return {"sessions_pruned": 0}
+
+    p_interval, p_last, p_prune, prune, _ = _patches(
+        last_prune=time.time() - 2 * DAY, prune=AsyncMock(side_effect=held_prune)
+    )
+    with p_interval, p_last, p_prune:
+        engine._maybe_start_prune(time.time())
+        await asyncio.wait_for(entered.wait(), timeout=2)
+        assert not engine._retention_task.done(), "control: the prune is still in flight"
+
+        first_task = engine._retention_task
+        engine._maybe_start_prune(time.time())
+        assert engine._retention_task is first_task, "a second sweep must not start"
+        assert prune.await_count == 1
+
+        release.set()
+        await asyncio.wait_for(engine._retention_task, timeout=2)
+
+    assert prune.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stopping_cancels_a_prune_still_in_flight():
+    """A pass left running past shutdown outlives the engine that owns it."""
+    engine = _engine()
+    entered = asyncio.Event()
+
+    async def held_prune(**kwargs):
+        entered.set()
+        await asyncio.sleep(3600)
+
+    p_interval, p_last, p_prune, _, _ = _patches(
+        last_prune=time.time() - 2 * DAY, prune=AsyncMock(side_effect=held_prune)
+    )
+    with p_interval, p_last, p_prune:
+        engine._maybe_start_prune(time.time())
+        await asyncio.wait_for(entered.wait(), timeout=2)
+        await asyncio.wait_for(engine.stop(), timeout=2)
+
+    assert engine._retention_task is None


### PR DESCRIPTION
## Summary

`prune_old_data` had no automatic caller. Every prune came from an admin route
someone had to invoke, so an installation nobody administered kept every terminal
session, run, and delivered dispatch row indefinitely.

This adds a retention pass to the scheduler tick, alongside the two periodic
maintenance passes already there (the reapers and the WAL checkpoint).

## Where the interval is measured from

That is the part the pass cannot copy from its two neighbours. Both of those count
from process start and initialize their last-run stamp to `0.0`, which is right for
work that is cheap and should happen soon after a restart. Retention is neither:

- counting from process start means a daemon restarted more often than the interval
  never prunes once;
- a `0.0` stamp puts a prune in the middle of daemon startup on every boot, which on
  a large backlog is the least expected moment and the one competing with everything
  else startup is doing.

So the gap is measured from when a prune last committed, read back from the admin
event log `prune_old_data` already writes. A restart neither triggers a pass nor
postpones one that is already overdue. A database that has never been pruned starts
its clock at process start instead, which puts a first adoption one full interval out
rather than during startup.

A failed read of the last prune time is left unresolved rather than read as "never
pruned". Anchoring on the failure would silence the pass for the life of the process;
retrying costs one read on the next tick.

## What it does not do

Only the prune runs here. `VACUUM` holds an exclusive lock for as long as it takes to
rewrite the file, so it stays on the admin route where a person picks the moment. A
test asserts the scheduled pass never reaches it.

`LIONAGI_STUDIO_RETENTION_INTERVAL_SECONDS` defaults to 86400 and 0 disables the pass,
at which point it costs no database read per tick.

## Verification

- `tests/studio/test_scheduler_retention_tick.py`: 9 passed. These are the first tests
  over any of the tick's maintenance passes; the reaper and checkpoint hooks have none.
- Every property is confirmed load-bearing by mutation. Anchoring on process start,
  initializing at `0.0`, treating a failed read as never-pruned, and stamping only on
  success each redden the test named for that behaviour, and the two narrow arms redden
  that test alone.
- Blast radius measured rather than argued: `tests/studio/` plus
  `tests/apps_studio_server/test_db_maintenance.py` run with and without the change give
  identical failure sets (26 pre-existing failures on both sides, zero regressions).
- `ruff check` and `ruff format --check` clean on all four files.
