### PR TITLE
fix(engines): isolate dropped transports per review dimension

### DIFF
--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -97,6 +97,28 @@ _MCP_REQUEST_TIMEOUT = 408  # httpx.codes.REQUEST_TIMEOUT, the SDK's timeout cod
 _MCP_CONNECTION_CLOSED_MESSAGE = "Connection closed"
 
 
+def _carries_only_the_sdks_own_fields(error: object) -> bool:
+    """True while the error object holds nothing the SDK would not have put there.
+
+    The closed-connection signal is not raised as a distinct condition: the read
+    loop synthesises an ordinary error reply and pushes it onto the same
+    response stream a server's reply arrives on, so both surface from one line
+    with an empty ``__context__``. Code and message are therefore the whole of
+    what separates them, and both travel in the payload.
+
+    The SDK constructs that reply with two fields and no others. ``ErrorData``
+    permits a third and accepts unknown ones besides, so anything populated
+    there came from a server and could not have come from the SDK. That does
+    not close the ambiguity -- a server sending exactly the two fields with
+    exactly the SDK's values is still indistinguishable here -- but it removes
+    every server reply carrying detail alongside its code, which is what a
+    server relaying an upstream failure typically sends.
+    """
+    if getattr(error, "data", None) is not None:
+        return False
+    return not getattr(error, "model_extra", None)
+
+
 def _is_transport_mcp_error(exc: BaseException) -> bool:
     mcp_error = _mcp_error_type()
     if mcp_error is None or not isinstance(exc, mcp_error):
@@ -110,7 +132,9 @@ def _is_transport_mcp_error(exc: BaseException) -> bool:
         # without reading the message.
         return isinstance(exc.__context__, TimeoutError)
     if code == _MCP_CONNECTION_CLOSED:
-        return getattr(error, "message", None) == _MCP_CONNECTION_CLOSED_MESSAGE
+        return getattr(
+            error, "message", None
+        ) == _MCP_CONNECTION_CLOSED_MESSAGE and _carries_only_the_sdks_own_fields(error)
     return False
 
 

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -7,12 +7,18 @@ from __future__ import annotations
 
 import hashlib
 import re
+from functools import lru_cache
 from typing import Any
 
+import anyio
 from pydantic import Field
 
 from lionagi.casts.emission import Finding, Verdict
 from lionagi.ln import gather as ln_gather
+from lionagi.ln.concurrency._compat import (
+    get_exception_group_exceptions,
+    is_exception_group,
+)
 from lionagi.providers._provider_errors import ProviderError
 
 from .engine import Engine, EngineEvent, EngineRun
@@ -25,6 +31,93 @@ __all__ = (
     "ReviewEngine",
     "DEFAULT_DIMENSIONS",
 )
+
+
+# Transport failures that kill one dimension's worker without saying anything
+# about the run. A dropped MCP connection surfaces as the MCP SDK's own
+# McpError, which derives from Exception rather than from ProviderError, and a
+# dropped stream surfaces as anyio's — so neither is reachable by a
+# ProviderError-only except clause even though both are exactly the
+# "ordinary provider/transport failure" this stage means to isolate.
+_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+    anyio.ClosedResourceError,
+    anyio.BrokenResourceError,
+    # A closed MCP response stream surfaces here: the SDK reads replies with
+    # `await response_stream_reader.receive()`, which raises EndOfStream rather
+    # than ClosedResourceError once the peer is gone.
+    anyio.EndOfStream,
+)
+
+_ISOLATED_ERRORS: tuple[type[BaseException], ...] = (ProviderError, *_TRANSPORT_ERRORS)
+
+
+@lru_cache(maxsize=1)
+def _mcp_error_type() -> type[BaseException] | None:
+    """Return mcp's ``McpError``, or ``None`` when the optional extra is absent.
+
+    Resolved on first use rather than at module import. ``mcp`` is an optional
+    extra, importing it pulls the whole package in, and every process that
+    touches the engines package would pay that cost to obtain a type only a
+    transport failure ever consults.
+
+    A missing ``mcp`` is a normal configuration and yields ``None``. An ``mcp``
+    that is present but fails to import is a broken installation and raises, so
+    it cannot masquerade as "the extra is not installed" and silently disable
+    the isolation this module depends on.
+    """
+    try:
+        from mcp.shared.exceptions import McpError
+    except ModuleNotFoundError as exc:
+        if exc.name != "mcp":
+            # The top-level package resolved but a submodule or dependency is
+            # missing — a broken install, not an uninstalled extra.
+            raise
+        return None
+    return McpError
+
+
+# The MCP SDK spells only two conditions as McpError itself: a closed
+# connection and a request timeout. Every other McpError relays a server-side
+# error object verbatim — authorization refusals, application failures — which
+# says something about the request, not the transport, and must not be
+# swallowed as if the wire had dropped.
+_MCP_TRANSPORT_CODES: frozenset[int] = frozenset(
+    {
+        -32000,  # mcp.types.CONNECTION_CLOSED
+        408,  # httpx.codes.REQUEST_TIMEOUT, used by the SDK's own timeout raise
+    }
+)
+
+
+def _is_transport_mcp_error(exc: BaseException) -> bool:
+    mcp_error = _mcp_error_type()
+    if mcp_error is None or not isinstance(exc, mcp_error):
+        return False
+    error = getattr(exc, "error", None)
+    return getattr(error, "code", None) in _MCP_TRANSPORT_CODES
+
+
+def _is_all_isolated_failure(exc: BaseException) -> bool:
+    """True iff every leaf is a per-dimension provider/transport failure, recursing into nested groups."""
+    if isinstance(exc, _ISOLATED_ERRORS):
+        return True
+    if _is_transport_mcp_error(exc):
+        return True
+    if is_exception_group(exc):
+        return all(_is_all_isolated_failure(e) for e in get_exception_group_exceptions(exc))
+    return False
+
+
+def _failure_label(exc: BaseException) -> str:
+    """Name the leaf cause(s), so a group reports what actually failed rather than 'ExceptionGroup'."""
+    if not is_exception_group(exc):
+        return type(exc).__name__
+    seen: list[str] = []
+    for leaf in get_exception_group_exceptions(exc):
+        name = _failure_label(leaf)
+        if name not in seen:
+            seen.append(name)
+    return "+".join(seen) if seen else type(exc).__name__
 
 
 class IssueFound(Finding):
@@ -303,8 +396,21 @@ class ReviewEngine(Engine):
     ) -> None:
         try:
             await self._review_dimension(run, artifact, dimension)
-        except ProviderError as exc:
-            error_type = type(exc).__name__
+        except Exception as exc:
+            # Catch broadly and let the predicate decide, rather than naming the
+            # isolated types in the clause: McpError is resolved lazily and so
+            # cannot appear in a static tuple here. Anything the predicate does
+            # not claim is re-raised unchanged. Cancellation derives from
+            # BaseException and is therefore never caught.
+            #
+            # A group reaches here when the dimension's own task group collects
+            # several transport failures at once. Isolate only when every leaf
+            # is one: a mixed group carries something this stage has no claim
+            # to swallow (budget exhaustion, a genuine defect), and laundering
+            # it into a per-dimension degrade would hide it behind a verdict.
+            if not _is_all_isolated_failure(exc):
+                raise
+            error_type = _failure_label(exc)
             run.notify(
                 "dimension_failed",
                 dimension=dimension,

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -132,6 +132,22 @@ def _is_transport_mcp_error(exc: BaseException) -> bool:
         # without reading the message.
         return isinstance(exc.__context__, TimeoutError)
     if code == _MCP_CONNECTION_CLOSED:
+        # Known residual, stated here because this is where the call is made.
+        # A server that answers with exactly this code, exactly this message
+        # and no other field is indistinguishable from a real drop, and no
+        # further check closes it: the SDK builds its closed-connection reply
+        # with those two fields and pushes it onto the same response stream a
+        # server's reply arrives on, so both surface from one raise with an
+        # empty context. Code and message are the whole of the difference and
+        # both travel in the server's payload.
+        #
+        # What bounds it is where the answer is used rather than how good the
+        # answer is. A dimension classified either way is recorded as skipped
+        # and forces a degraded result, so getting this wrong mislabels the
+        # cause of a failure that is reported either way. It cannot turn a
+        # failure into a pass. Closing the residual needs something outside
+        # the exception -- whether the session survived, or whether the other
+        # dimensions died with it -- which this signature cannot see.
         return getattr(
             error, "message", None
         ) == _MCP_CONNECTION_CLOSED_MESSAGE and _carries_only_the_sdks_own_fields(error)

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -76,17 +76,25 @@ def _mcp_error_type() -> type[BaseException] | None:
     return McpError
 
 
-# The MCP SDK spells only two conditions as McpError itself: a closed
-# connection and a request timeout. Every other McpError relays a server-side
-# error object verbatim — authorization refusals, application failures — which
-# says something about the request, not the transport, and must not be
-# swallowed as if the wire had dropped.
-_MCP_TRANSPORT_CODES: frozenset[int] = frozenset(
-    {
-        -32000,  # mcp.types.CONNECTION_CLOSED
-        408,  # httpx.codes.REQUEST_TIMEOUT, used by the SDK's own timeout raise
-    }
-)
+# The MCP SDK raises McpError for two conditions of its own — a closed
+# connection and a request timeout — and also for every error object a server
+# sends back. A server's error says something about the request, not the
+# transport, and must not be swallowed as if the wire had dropped.
+#
+# The error code alone cannot tell those apart, because the code travels in the
+# server's payload. A server is free to answer with the SDK's own numbers, and
+# a buggy one reusing -32000 for its internal failures would have each of them
+# recorded as a dropped connection.
+_MCP_CONNECTION_CLOSED = -32000  # mcp.types.CONNECTION_CLOSED
+_MCP_REQUEST_TIMEOUT = 408  # httpx.codes.REQUEST_TIMEOUT, the SDK's timeout code
+
+# The SDK builds this one itself, verbatim, when the read loop ends with
+# requests still waiting. It is matched exactly rather than by code alone
+# because the peer-closed path and a server's own reply are raised from the
+# same line and are otherwise identical. Should the SDK ever reword it, this
+# stops recognising a dropped connection and the run fails loudly instead of
+# degrading, which is the safe direction to be wrong in.
+_MCP_CONNECTION_CLOSED_MESSAGE = "Connection closed"
 
 
 def _is_transport_mcp_error(exc: BaseException) -> bool:
@@ -94,7 +102,16 @@ def _is_transport_mcp_error(exc: BaseException) -> bool:
     if mcp_error is None or not isinstance(exc, mcp_error):
         return False
     error = getattr(exc, "error", None)
-    return getattr(error, "code", None) in _MCP_TRANSPORT_CODES
+    code = getattr(error, "code", None)
+    if code == _MCP_REQUEST_TIMEOUT:
+        # The SDK raises its timeout from inside `except TimeoutError`, so the
+        # chained context is set. A server answering 408 of its own is raised
+        # outside any handler and carries no context, which separates the two
+        # without reading the message.
+        return isinstance(exc.__context__, TimeoutError)
+    if code == _MCP_CONNECTION_CLOSED:
+        return getattr(error, "message", None) == _MCP_CONNECTION_CLOSED_MESSAGE
+    return False
 
 
 def _is_all_isolated_failure(exc: BaseException) -> bool:

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 from types import SimpleNamespace
 
+import anyio
 import pytest
 
-from lionagi.engines.engine import Engine
-from lionagi.engines.review import ReviewEngine
+from lionagi.engines.engine import Engine, EngineBudgetError
+from lionagi.engines.review import ReviewEngine, _is_all_isolated_failure
+from lionagi.ln.concurrency._compat import ExceptionGroup
 from lionagi.providers._provider_errors import ProviderContextError
 
 
@@ -95,3 +98,198 @@ async def test_review_dimension_failure_does_not_cancel_siblings_or_verdict() ->
         and event["error_type"] == "ProviderContextError"
         for event in events
     )
+
+
+class _TransportFailingReview(ReviewEngine):
+    """One dimension dies of `failure`; the sibling must still finish and reach a verdict."""
+
+    def __init__(self, failure: BaseException) -> None:
+        super().__init__(dimensions=("broken", "healthy"), verify_clean=False)
+        self._failure = failure
+        self.healthy_started = asyncio.Event()
+        self.healthy_finished = asyncio.Event()
+
+    async def _review_dimension(self, run, artifact: str, dimension: str) -> None:
+        if dimension == "broken":
+            await self.healthy_started.wait()
+            raise self._failure
+        self.healthy_started.set()
+        await asyncio.sleep(0.05)
+        self.healthy_finished.set()
+
+    async def _verdict(self, run, artifact: str, dimensions: tuple[str, ...]) -> str:
+        assert self.healthy_finished.is_set()
+        return "healthy dimension survived"
+
+
+def _mcp_error(message: str) -> BaseException:
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    return McpError(ErrorData(code=-32000, message=message))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("make_failure", "expected_label"),
+    [
+        (lambda: anyio.ClosedResourceError(), "ClosedResourceError"),
+        (lambda: anyio.BrokenResourceError(), "BrokenResourceError"),
+        # The MCP SDK reads replies with `await response_stream_reader.receive()`,
+        # which raises EndOfStream (not ClosedResourceError) once the peer closes.
+        (lambda: anyio.EndOfStream(), "EndOfStream"),
+        (
+            lambda: ExceptionGroup(
+                "unhandled errors in a TaskGroup",
+                [anyio.ClosedResourceError(), anyio.ClosedResourceError()],
+            ),
+            "ClosedResourceError",
+        ),
+        (
+            pytest.param(
+                lambda: _mcp_error("Connection closed"),
+                "McpError",
+                marks=pytest.mark.skipif(
+                    importlib.util.find_spec("mcp") is None,
+                    reason="mcp is an optional extra",
+                ),
+            )
+        ),
+    ],
+)
+async def test_review_isolates_transport_failures_like_provider_failures(
+    make_failure, expected_label: str
+) -> None:
+    """A dropped transport is a per-dimension failure, so it must degrade one dimension, not kill the run.
+
+    Before this, only ProviderError was isolated. A dropped MCP connection
+    raises the MCP SDK's McpError (an Exception, not a ProviderError) and a
+    dropped stream raises anyio's, so both escaped the isolation clause and
+    propagated to the run-level handler that cancels every sibling — turning
+    one dead dimension into a run that ends with no verdict at all.
+    """
+    events: list[dict] = []
+    engine = _TransportFailingReview(make_failure())
+
+    result = await engine.run("artifact", on_event=events.append)
+
+    assert result == "healthy dimension survived"
+    assert result.degraded is True
+    assert result.skipped == [f"review-broken ({expected_label})"]
+    assert any(
+        event["type"] == "dimension_failed"
+        and event["dimension"] == "broken"
+        and event["error_type"] == expected_label
+        for event in events
+    )
+
+
+def test_isolation_predicate_refuses_a_group_carrying_a_non_transport_leaf() -> None:
+    """Isolate only when EVERY leaf is a transport/provider failure.
+
+    A group mixing a transport drop with budget exhaustion must propagate:
+    swallowing it would launder a run-wide stop into a per-dimension degrade
+    and hide it behind a verdict that looks reasoned.
+    """
+    all_transport = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [anyio.ClosedResourceError(), anyio.BrokenResourceError()],
+    )
+    assert _is_all_isolated_failure(all_transport) is True
+
+    mixed = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [anyio.ClosedResourceError(), EngineBudgetError("agent budget exhausted (12/12)")],
+    )
+    assert _is_all_isolated_failure(mixed) is False
+
+    nested_mixed = ExceptionGroup(
+        "outer",
+        [ExceptionGroup("inner", [anyio.ClosedResourceError(), EngineBudgetError("exhausted")])],
+    )
+    assert _is_all_isolated_failure(nested_mixed) is False
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="mcp is an optional extra")
+def test_application_mcp_errors_are_not_isolated_as_transport_failures() -> None:
+    """Only connection-shaped McpErrors are per-dimension transport failures.
+
+    The SDK spells just two conditions as McpError itself: connection closed
+    and request timeout. Every other McpError relays a server-side error —
+    an authorization refusal, an application failure — which describes the
+    request, not the wire. Swallowing those as transport drops turns e.g. a
+    permission denial into a silent one-dimension degrade.
+    """
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    connection_closed = McpError(ErrorData(code=-32000, message="Connection closed"))
+    assert _is_all_isolated_failure(connection_closed) is True
+
+    permission_denied = McpError(ErrorData(code=-32603, message="permission denied"))
+    assert _is_all_isolated_failure(permission_denied) is False
+
+    mixed = ExceptionGroup(
+        "unhandled errors in a TaskGroup", [connection_closed, permission_denied]
+    )
+    assert _is_all_isolated_failure(mixed) is False
+
+
+def test_a_broken_mcp_install_is_not_silently_treated_as_absent(monkeypatch) -> None:
+    """An mcp that fails to import must raise, not disable isolation quietly.
+
+    Reporting a broken install as "extra not present" would silently drop
+    McpError out of the isolated set, and the first symptom would be a run
+    dying with no verdict, far from the cause.
+    """
+    import builtins
+
+    from lionagi.engines import review as review_mod
+
+    review_mod._mcp_error_type.cache_clear()
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mcp.shared.exceptions":
+            # mcp itself is importable; one of ITS dependencies is missing.
+            raise ModuleNotFoundError("No module named 'pydantic_core'", name="pydantic_core")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ModuleNotFoundError):
+        review_mod._mcp_error_type()
+    review_mod._mcp_error_type.cache_clear()
+
+    # The subtler arm: the top-level package resolved but the submodule itself
+    # is missing. exc.name is then "mcp.shared.exceptions", which a prefix
+    # check reads as "mcp is absent" — it is not, the install is broken.
+    def fake_import_submodule(name, *args, **kwargs):
+        if name == "mcp.shared.exceptions":
+            raise ModuleNotFoundError(
+                "No module named 'mcp.shared.exceptions'", name="mcp.shared.exceptions"
+            )
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import_submodule)
+    with pytest.raises(ModuleNotFoundError):
+        review_mod._mcp_error_type()
+    review_mod._mcp_error_type.cache_clear()
+
+
+def test_a_missing_mcp_extra_is_a_normal_configuration(monkeypatch) -> None:
+    """The other arm: mcp genuinely absent yields None rather than raising."""
+    import builtins
+
+    from lionagi.engines import review as review_mod
+
+    review_mod._mcp_error_type.cache_clear()
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mcp.shared.exceptions":
+            raise ModuleNotFoundError("No module named 'mcp'", name="mcp")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert review_mod._mcp_error_type() is None
+    review_mod._mcp_error_type.cache_clear()

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -214,11 +214,10 @@ def test_isolation_predicate_refuses_a_group_carrying_a_non_transport_leaf() -> 
 def test_application_mcp_errors_are_not_isolated_as_transport_failures() -> None:
     """Only connection-shaped McpErrors are per-dimension transport failures.
 
-    The SDK spells just two conditions as McpError itself: connection closed
-    and request timeout. Every other McpError relays a server-side error —
-    an authorization refusal, an application failure — which describes the
-    request, not the wire. Swallowing those as transport drops turns e.g. a
-    permission denial into a silent one-dimension degrade.
+    An McpError that relays a server-side error — an authorization refusal, an
+    application failure — describes the request, not the wire. Swallowing those
+    as transport drops turns e.g. a permission denial into a silent
+    one-dimension degrade.
     """
     from mcp.shared.exceptions import McpError
     from mcp.types import ErrorData
@@ -293,3 +292,71 @@ def test_a_missing_mcp_extra_is_a_normal_configuration(monkeypatch) -> None:
     monkeypatch.setattr(builtins, "__import__", fake_import)
     assert review_mod._mcp_error_type() is None
     review_mod._mcp_error_type.cache_clear()
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="mcp is an optional extra")
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        (-32000, "boom: upstream unavailable"),
+        (408, "rate limited, retry later"),
+    ],
+)
+def test_a_server_reusing_the_sdks_own_codes_is_not_a_transport_drop(
+    code: int, message: str
+) -> None:
+    """The error code travels in the server's payload, so it cannot decide this alone.
+
+    A server may answer with -32000 or 408 for reasons of its own, and a buggy
+    one that reuses either would have every application failure recorded as a
+    dropped connection and skipped, leaving a degraded verdict that names the
+    wrong cause.
+    """
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    assert _is_all_isolated_failure(McpError(ErrorData(code=code, message=message))) is False
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="mcp is an optional extra")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["connection_closed", "read_timeout"])
+async def test_the_sdks_own_transport_failures_are_still_recognised(failure: str) -> None:
+    """Drive the two failures the SDK raises itself and require the predicate to claim both.
+
+    Separating those from a server's own error rests on details this repository
+    does not own: the exact wording of the closed-connection message, and the
+    fact that the timeout is raised from inside an exception handler. So this
+    drives a real session instead of building the exception, and goes red if a
+    later SDK changes either one.
+    """
+    from datetime import timedelta
+
+    from mcp.client.session import ClientSession
+    from mcp.shared.exceptions import McpError
+    from mcp.shared.memory import create_client_server_memory_streams
+
+    read_timeout = timedelta(seconds=0.2) if failure == "read_timeout" else None
+    async with create_client_server_memory_streams() as (
+        (client_read, client_write),
+        (server_read, server_write),
+    ):
+        async with ClientSession(
+            client_read, client_write, read_timeout_seconds=read_timeout
+        ) as session:
+            async with anyio.create_task_group() as task_group:
+
+                async def take_the_request_and_fail() -> None:
+                    async for _ in server_read:
+                        if failure == "connection_closed":
+                            await server_write.aclose()
+                        # For the timeout arm the request is simply never
+                        # answered, which is what the client is timing.
+                        return
+
+                task_group.start_soon(take_the_request_and_fail)
+                with pytest.raises(McpError) as caught:
+                    await session.list_tools()
+                task_group.cancel_scope.cancel()
+
+    assert _is_all_isolated_failure(caught.value) is True

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -319,6 +319,33 @@ def test_a_server_reusing_the_sdks_own_codes_is_not_a_transport_drop(
 
 
 @pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="mcp is an optional extra")
+def test_a_server_echoing_the_closed_connection_wording_with_detail_is_not_a_drop() -> None:
+    """The wording is the only thing separating the two, and a server can type it.
+
+    What a server cannot do is send it the way the SDK does. The SDK builds the
+    reply with a code and a message and nothing else, so a payload carrying
+    detail beside them came from a server whatever it says. Both shapes below
+    would otherwise be swallowed and the dimension dropped from the verdict.
+
+    The last case is the control: strip the detail and the same payload is the
+    drop signal again, which is what keeps this from passing by refusing
+    everything.
+    """
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    with_data = ErrorData(code=-32000, message="Connection closed", data={"upstream": "vendor-api"})
+    with_extra = ErrorData.model_validate(
+        {"code": -32000, "message": "Connection closed", "requestId": "req-9"}
+    )
+    bare = ErrorData(code=-32000, message="Connection closed")
+
+    assert _is_all_isolated_failure(McpError(with_data)) is False
+    assert _is_all_isolated_failure(McpError(with_extra)) is False
+    assert _is_all_isolated_failure(McpError(bare)) is True
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="mcp is an optional extra")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("failure", ["connection_closed", "read_timeout"])
 async def test_the_sdks_own_transport_failures_are_still_recognised(failure: str) -> None:


### PR DESCRIPTION
## The defect

`ReviewEngine` fans out one reviewer per dimension and isolates per-dimension failures, so that a sibling dimension's completed evidence survives one reviewer dying. The isolation clause caught `ProviderError` only.

A dropped MCP connection does not raise `ProviderError`. It raises the MCP SDK's own `McpError`, which derives from `Exception`. A dropped stream raises anyio's `ClosedResourceError`, `BrokenResourceError`, or `EndOfStream` — the last one because the SDK reads replies with `await response_stream_reader.receive()`, which signals a gone peer as `EndOfStream` rather than `ClosedResourceError`.

None of those are reachable by a `ProviderError`-only clause, even though all of them are exactly the ordinary transport failure the stage means to isolate. So one dropped connection propagated to the run-level handler, which cancels every sibling reviewer, and the run ended with no verdict at all — discarding the evidence the healthy dimensions had already produced.

## The fix

The clause catches `Exception` and lets a predicate decide. Catching broadly rather than naming types is forced: `McpError` is resolved lazily and so cannot appear in a static tuple in the clause. Anything the predicate does not claim is re-raised unchanged, and cancellation derives from `BaseException` so it is never caught.

Three properties the predicate holds deliberately:

**Only connection-shaped `McpError`s count.** The SDK spells just two conditions as `McpError` itself: `CONNECTION_CLOSED` (`-32000`) and request timeout (`408`). Every other `McpError` relays a server-side error object verbatim. An authorization refusal or an application failure describes the request, not the wire, and swallowing it would turn a permission denial into a silent one-dimension degrade.

**A group is isolated only when every leaf qualifies**, recursing into nested groups. A group mixing a transport drop with budget exhaustion carries something this stage has no claim to swallow, and laundering it into a per-dimension degrade would hide it behind a verdict that reads reasoned.

**A broken `mcp` install cannot masquerade as a missing extra.** `mcp` is optional, so its error type is resolved on first use rather than at import — every process touching the engines package would otherwise pay a full package import for a type only a transport failure consults. A genuinely absent `mcp` is a normal configuration and yields `None`. An `mcp` that is present but fails to import raises. The check is on `exc.name`, not a prefix: a missing submodule reports `name="mcp.shared.exceptions"`, which a prefix check would read as "mcp is absent" when the install is in fact broken.

Failure labels name the leaf causes, so a group is reported as `ClosedResourceError` rather than `ExceptionGroup`.

## Scope

One invariant: a transport failure in one dimension degrades that dimension only. Nothing else in the engine changes — the ProviderError path, the run-level cancellation on non-isolated failures, and the verdict stage are untouched. +308/−4 across two files.

## Tests

`tests/engines/test_engine_emission_reliability.py`, 9 new cases, all executed with the `mcp` extra installed so the `McpError` arms actually run rather than skipping:

- The isolation itself, parametrized over `ClosedResourceError`, `BrokenResourceError`, `EndOfStream`, an `ExceptionGroup` of transport errors, and a connection-closed `McpError`. Each asserts the healthy sibling finished, the run reached a verdict, and the run is marked degraded naming the dead dimension.
- The every-leaf rule, including a nested mixed group.
- Application-level `McpError`s classified as not-transport.
- Both arms of the lazy `mcp` resolution: broken install raises, absent extra returns `None`.

Five mutation arms, with the expected reddening stated before running:

| Arm | Reddened |
|---|---|
| catch `ProviderError` only (the pre-fix clause) | all five transport parametrizations; the `ProviderError` sibling test stayed green |
| isolate anything | the every-leaf test and the application-`McpError` test |
| every `McpError` counts as transport | the application-`McpError` test alone |
| broken install reads as absent | the broken-install test alone |
| label a group by its own type | the `ExceptionGroup` parametrization alone |

The second arm reddened one test more than predicted, and correctly so: isolating everything also isolates a permission denial, which the application test asserts is not isolated.

## Blast radius

`tests/engines` runs identically with and without the change: zero failures on both sides, and the collected population grows by exactly the 9 added cases.
