### PR TITLE
fix(ci): fail the traffic snapshot on scheduled runs when the token is missing

### DIFF
--- a/.github/workflows/clone-tracker.yml
+++ b/.github/workflows/clone-tracker.yml
@@ -74,7 +74,32 @@ jobs:
           # week, and the thing it would eventually be red ABOUT is a missing
           # measurement. Skipping writes no ledger entry, so a gap in the data
           # stays a visible gap rather than becoming a recorded zero.
+          #
+          # A warning on its own has no consumer: nothing fails, blocks or
+          # notifies if it goes unread, so the bound on how long the gap may
+          # grow is a promise rather than a control. Past the date below, a
+          # cycle that still finds no token fails instead, which sends the one
+          # notification a warning never sends. The window then closes and later
+          # cycles go back to warning, so this does not become the every-cycle
+          # red the paragraph above rejects.
+          #
+          # The window is 14 days because the largest gap between scheduled runs
+          # is 13 (the 1st to the 14th, and the 14th to the 27th), so at least
+          # one run always lands inside it. Around a month boundary the 27th and
+          # the 1st are closer together and two runs can land inside instead.
+          # That is the deliberate trade: a window narrow enough to guarantee
+          # exactly one run could fall between two runs and notify nobody at all,
+          # which is the failure this whole step exists to prevent.
+          ESCALATE_FROM=2026-08-16
+          ESCALATE_DAYS=14
           if [ -z "${GH_TOKEN:-}" ]; then
+            now=$(date -u +%s)
+            from=$(date -u -d "${ESCALATE_FROM}" +%s)
+            until=$(( from + ESCALATE_DAYS * 86400 ))
+            if [ "$now" -ge "$from" ] && [ "$now" -lt "$until" ]; then
+              echo "::error::TRAFFIC_READ_TOKEN has been missing since ${ESCALATE_FROM} and the traffic API keeps only 14 days, so every cycle without it loses that window's clone and view counts permanently. Store a fine-grained token carrying only Administration: read as TRAFFIC_READ_TOKEN. This run fails once to say so; later runs go back to warning."
+              exit 1
+            fi
             echo "::warning::TRAFFIC_READ_TOKEN is not set, so no traffic was read and nothing was appended. The ledger has a gap for this run, not a zero."
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/clone-tracker.yml
+++ b/.github/workflows/clone-tracker.yml
@@ -69,35 +69,25 @@ jobs:
         # carry the value we actually use.
         run: |
           set -euo pipefail
-          # Until the token exists, skip loudly instead of failing. A scheduled
-          # workflow that is red on every run is one nobody reads by the second
-          # week, and the thing it would eventually be red ABOUT is a missing
-          # measurement. Skipping writes no ledger entry, so a gap in the data
-          # stays a visible gap rather than becoming a recorded zero.
+          # Without the token nothing can be read, and whether that should fail
+          # depends on which run this is. A scheduled run exists to capture a
+          # window the API is about to drop, so a scheduled run without the
+          # token is losing data that no later run can recover, and failing is
+          # how that gets said to anyone. A push or a manual run is here for
+          # some other reason, and failing those would put a missing secret on
+          # surfaces that are not about traffic at all. Either way nothing is
+          # appended, so a gap in the data stays a visible gap rather than
+          # becoming a recorded zero.
           #
-          # A warning on its own has no consumer: nothing fails, blocks or
-          # notifies if it goes unread, so the bound on how long the gap may
-          # grow is a promise rather than a control. Past the date below, a
-          # cycle that still finds no token fails instead, which sends the one
-          # notification a warning never sends. The window then closes and later
-          # cycles go back to warning, so this does not become the every-cycle
-          # red the paragraph above rejects.
-          #
-          # The window is 14 days because the largest gap between scheduled runs
-          # is 13 (the 1st to the 14th, and the 14th to the 27th), so at least
-          # one run always lands inside it. Around a month boundary the 27th and
-          # the 1st are closer together and two runs can land inside instead.
-          # That is the deliberate trade: a window narrow enough to guarantee
-          # exactly one run could fall between two runs and notify nobody at all,
-          # which is the failure this whole step exists to prevent.
-          ESCALATE_FROM=2026-08-16
-          ESCALATE_DAYS=14
+          # The scheduled failure repeats every cycle until the token is stored,
+          # which is deliberate. The alternative is a run that remembers having
+          # complained already and then stays quiet, and a control that has
+          # spent its one complaint looks exactly like a control that was never
+          # armed. Three reds a month that stop the moment the secret exists is
+          # the cheaper mistake.
           if [ -z "${GH_TOKEN:-}" ]; then
-            now=$(date -u +%s)
-            from=$(date -u -d "${ESCALATE_FROM}" +%s)
-            until=$(( from + ESCALATE_DAYS * 86400 ))
-            if [ "$now" -ge "$from" ] && [ "$now" -lt "$until" ]; then
-              echo "::error::TRAFFIC_READ_TOKEN has been missing since ${ESCALATE_FROM} and the traffic API keeps only 14 days, so every cycle without it loses that window's clone and view counts permanently. Store a fine-grained token carrying only Administration: read as TRAFFIC_READ_TOKEN. This run fails once to say so; later runs go back to warning."
+            if [ "${GITHUB_EVENT_NAME:-}" = "schedule" ]; then
+              echo "::error::TRAFFIC_READ_TOKEN is not set, so this cycle read no traffic. The API keeps only 14 days, so the clone and view counts for this window are now unrecoverable. Store a fine-grained token carrying only Administration: read as TRAFFIC_READ_TOKEN."
               exit 1
             fi
             echo "::warning::TRAFFIC_READ_TOKEN is not set, so no traffic was read and nothing was appended. The ledger has a gap for this run, not a zero."


### PR DESCRIPTION
## What

The clone tracker skips with a warning when `TRAFFIC_READ_TOKEN` is absent. This makes a **scheduled** run fail instead, while push and manual runs keep warning and skipping.

## Why

A warning has no consumer. Nothing fails, blocks or notifies if it goes unread, so the bound on how large the data gap may grow was a promise rather than a control. GitHub's traffic API keeps 14 days, so every cycle without the token loses that window's clone and view counts permanently. As of this PR the ledger branch does not exist and no snapshot has ever been captured: every run so far skipped.

The event distinction is what makes the failure mean something. A scheduled run exists to capture a window the API is about to drop, so a scheduled run without the token is losing data that no later run can recover. A push to this file or a manual dispatch is here for some other reason, and failing those would put a missing secret on surfaces that are not about traffic at all.

## Why not fail only once

An earlier revision of this branch escalated inside a fixed 14-day window and then went quiet. Two problems, both fixed here:

- Every invocation inside the window failed, including pushes to this file and manual runs, not just the scheduled cycle.
- The window expired. If the first run of the workflow landed after the window closed, it would warn forever and never escalate at all.

Suppressing the repeat needs persisted state saying a complaint was already made, and a control that has spent its single complaint is indistinguishable from one that was never armed. Three reds a month that stop the moment the secret exists is the cheaper mistake. Nothing is appended on a failed run either way, so a gap in the data stays a visible gap rather than becoming a recorded zero.

## What fixes it for good

A fine-grained token carrying only `Administration: read`, stored as `TRAFFIC_READ_TOKEN`. That scope does not exist in the Actions permissions vocabulary, so the built-in `GITHUB_TOKEN` cannot be granted it under any `permissions:` block.

## Expected behaviour on merge

The workflow triggers on a push to `main` that touches its own file. That run is a `push` event, so with the token still absent it warns and skips. The first **scheduled** run after merge is the one that will go red, and that is the change working.

## Verification

The shipped shell block was extracted from the YAML by parsing it (not retyped) and run under a stubbed `gh`, five arms, all matching predictions written beforehand:

| arm | event | token | result |
|---|---|---|---|
| A | `schedule` | absent | rc=1, `::error::`, no `skipped` output |
| B | `push` | absent | rc=0, `::warning::`, `skipped=true` |
| C | `workflow_dispatch` | absent | rc=0, `::warning::`, `skipped=true` |
| D | unset | absent | rc=0, `::warning::`, `skipped=true` |
| E | `schedule` | present | falls through to the API reads, untouched |

Arm D covers `set -u` on a missing `GITHUB_EVENT_NAME`. Arm E is the control that the token-present path is unchanged; it is identified by the stub's own exit code, so it cannot be confused with the gate returning early.

Both branches of the gate are pinned by mutation, each with the mutation asserted applied before the arms were re-run:

| mutation | prediction | observed |
|---|---|---|
| `"schedule"` → a value no event uses | A drops to rc=0 and warns; B unchanged | matched |
| delete the `exit 1` | A drops to rc=0 and falls through to the warning | matched |
