### PR TITLE
fix(cli): do not stat a transcript for a window that is not configured

### DIFF
--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -532,8 +532,11 @@ async def _one_pass(db, root: Path, states, offsets, *, since, live_window, line
         if "_precompact_" in path.name:
             continue  # PreCompact-hook backups duplicate the live transcript (same sessionId)
         try:
-            modified_at = path.stat().st_mtime
-            if since is not None and (now - modified_at) > since:
+            # Stat only where the window will read it. With no window
+            # configured -- the CLI's default -- the mtime has no other
+            # consumer, and statting for it costs one syscall per transcript
+            # per pass, which is the per-file work this loop exists to avoid.
+            if since is not None and (now - path.stat().st_mtime) > since:
                 continue
             key = str(path)
             state = states.get(key)
@@ -758,8 +761,9 @@ async def _codex_pass(db, root: Path, states, offsets, *, since, live_window, th
     reconcile: dict[str, list[_FileState]] = {}
     for path in sorted(root.rglob("rollout-*.jsonl")):
         try:
-            modified_at = path.stat().st_mtime
-            if since is not None and (now - modified_at) > since:
+            # Same as the claude pass: the mtime is the window's input and
+            # nothing else's, so an unwindowed sweep must not pay for it.
+            if since is not None and (now - path.stat().st_mtime) > since:
                 continue
             key = str(path)
             state = states.get(key)

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1105,6 +1105,116 @@ async def test_live_transcript_reconciles_until_one_final_idle_check(
 
 
 @pytest.mark.asyncio
+async def test_an_unwindowed_pass_does_not_stat_for_a_window_it_will_not_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`li mirror` defaults to no window, and mtime has no consumer but the
+    window check. Reading it anyway costs one syscall per transcript per pass,
+    on the loop whose whole purpose is not to touch settled files."""
+    import lionagi.cli.mirror as mirror_mod
+
+    root = tmp_path / "projects"
+    uid = "unwindowed"
+    path = root / "-work-acme" / f"{uid}.jsonl"
+    _write_session_file(path, uid, age_secs=10)
+    now = 1_800_000_000.0
+    os.utime(path, (now - 600, now - 600))
+
+    real_stat = Path.stat
+    stats: list[Path] = []
+
+    def _counting_stat(self: Path, *args, **kwargs):
+        if self == path:
+            stats.append(self)
+        return real_stat(self, *args, **kwargs)
+
+    async def _settled_reconcile(_db, _uid, **_kwargs):
+        return True
+
+    monkeypatch.setattr(mirror_mod.time, "time", lambda: now)
+    monkeypatch.setattr(
+        "lionagi.state.claude_mirror.reconcile_session_status",
+        _settled_reconcile,
+    )
+
+    async def _count(since: float | None) -> int:
+        states = {
+            str(path): _FileState(
+                session_uid=uid,
+                offset=path.stat().st_size,
+                project="acme",
+                attr_peeked=True,
+            )
+        }
+        stats.clear()
+        monkeypatch.setattr(Path, "stat", _counting_stat)
+        try:
+            await _one_pass(None, root, states, {}, since=since, live_window=300)
+        finally:
+            monkeypatch.setattr(Path, "stat", real_stat)
+        return len(stats)
+
+    # One stat either way for the cursor's size check, plus the window's own
+    # when there is a window to enforce.
+    assert await _count(None) == 1
+    assert await _count(3600.0) == 2
+
+
+@pytest.mark.asyncio
+async def test_an_unwindowed_codex_pass_does_not_stat_for_the_window_either(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same rule on the Codex sweep, which carries its own copy of the check."""
+    import lionagi.cli.mirror as mirror_mod
+
+    now = 1_800_000_000.0
+    uid = "0199cccc-0000-0000-0000-0000000000cc"
+    path = tmp_path / "2026" / "08" / "16" / "rollout-unwindowed.jsonl"
+    path.parent.mkdir(parents=True)
+    path.write_text("{}\n")
+    os.utime(path, (now - 600, now - 600))
+
+    real_stat = Path.stat
+    stats: list[Path] = []
+
+    def _counting_stat(self: Path, *args, **kwargs):
+        if self == path:
+            stats.append(self)
+        return real_stat(self, *args, **kwargs)
+
+    async def _settled_reconcile(_db, _uid, **_kwargs):
+        return True
+
+    monkeypatch.setattr(mirror_mod.time, "time", lambda: now)
+    monkeypatch.setattr(
+        "lionagi.state.codex_mirror.reconcile_session_status",
+        _settled_reconcile,
+    )
+
+    async def _count(since: float | None) -> int:
+        states = {
+            str(path): _FileState(
+                session_uid=uid,
+                offset=path.stat().st_size,
+                head_checked=True,
+                codex_provenance_peeked=True,
+            )
+        }
+        stats.clear()
+        monkeypatch.setattr(Path, "stat", _counting_stat)
+        try:
+            await mirror_mod._codex_pass(
+                None, tmp_path, states, {}, since=since, live_window=300, threads={}
+            )
+        finally:
+            monkeypatch.setattr(Path, "stat", real_stat)
+        return len(stats)
+
+    windowed = await _count(3600.0)
+    assert await _count(None) == windowed - 1
+
+
+@pytest.mark.asyncio
 async def test_idle_codex_rollout_status_reconciliation_also_quiesces(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Cause

The bounded-mirror change hoisted `path.stat().st_mtime` into a local above the age check in both `_one_pass` and `_codex_pass`. The previous form was `since is not None and (now - path.stat().st_mtime) > since`, where Python's short-circuit meant no stat happened at all when no window was configured. The local has no other reader in either function, so the hoist buys nothing and costs one stat syscall per transcript per pass whenever `since` is unset.

`li mirror --since` defaults to None ("all"), and the tail loop runs every three seconds, so the default CLI path pays it on every file on every pass. Studio's daemon is unaffected by default, since `LIONAGI_STUDIO_MIRROR_CLAUDE_SINCE` defaults to 24h, but it takes the same cost if that is cleared.

## Fix

Both passes read the mtime inside the condition again.

## Verification

Two tests count stat calls against a settled transcript across one pass. With no window the pass makes only the cursor's own size check; with a window it makes exactly one more. Restoring the hoisted form in either pass fails that pass's test and leaves the other green, checked one at a time.

Full `tests/cli/test_mirror.py` (139) and `tests/apps_studio_server/test_claude_mirror_tail.py` (7) pass. Ruff check and format clean.

Follow-up to #3143.