### PR TITLE
fix(studio): make no outbound request the operator did not ask for

### DIFF
--- a/apps/studio/frontend/index.html
+++ b/apps/studio/frontend/index.html
@@ -13,11 +13,6 @@
         else document.documentElement.classList.remove("dark");
       })();
     </script>
-    <script
-      defer
-      src="https://analytics.khive.ai/script.js"
-      data-website-id="2899c39b-7da3-40b5-bce5-83961982ecc6"
-    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/studio/frontend/src/components/ui/Markdown.test.ts
+++ b/apps/studio/frontend/src/components/ui/Markdown.test.ts
@@ -156,11 +156,14 @@ describe("Markdown.tsx — the file viewer renders markdown as markdown", () => 
     }
 
     const remoteUrl = remoteUrls[0];
+    // Operator messages, run output, and library content are untrusted too;
+    // the guard is the default rather than an opt-in viewer policy.
     const ordinaryHtml = renderToStaticMarkup(
       createElement(MarkdownRenderer, null, `![remote tracker](${remoteUrl})`),
     );
-    expect(ordinaryHtml).toContain("<img");
-    expect(ordinaryHtml).toContain(remoteUrl);
+    expect(ordinaryHtml).not.toContain("<img");
+    expect(ordinaryHtml).not.toContain(remoteUrl);
+    expect(ordinaryHtml).toContain("Remote image blocked");
   });
 
   it("gives a rendered document more width than raw source, since tables need it", () => {

--- a/apps/studio/frontend/src/components/ui/Markdown.tsx
+++ b/apps/studio/frontend/src/components/ui/Markdown.tsx
@@ -30,7 +30,10 @@ export interface MarkdownProps {
   fileContext?: FileResolutionContext;
 }
 
-const RemoteImageContext = createContext(false);
+// Markdown content comes from agents, tools, plugins, and artifact files. A
+// remote image URL can beacon the viewer's IP and encode run data in its path,
+// so blocking is the safe default for every surface, not only the file viewer.
+const RemoteImageContext = createContext(true);
 
 export function RemoteImageGuard({ children }: { children: ReactNode }) {
   return <RemoteImageContext.Provider value>{children}</RemoteImageContext.Provider>;

--- a/apps/studio/frontend/src/lib/indexSecurity.test.ts
+++ b/apps/studio/frontend/src/lib/indexSecurity.test.ts
@@ -1,0 +1,14 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Studio document security", () => {
+  it("does not execute third-party scripts in the authenticated application document", () => {
+    const html = fs.readFileSync(path.resolve(__dirname, "../../index.html"), "utf8");
+    const scriptSources = Array.from(html.matchAll(/<script\b[^>]*\bsrc=["']([^"']+)/gi), (m) =>
+      m[1].trim(),
+    );
+
+    expect(scriptSources).toEqual(["/src/main.tsx"]);
+  });
+});


### PR DESCRIPTION
One invariant: an authenticated Studio page makes no outbound request the operator did not ask for. Two entrances closed.

**The application document loaded a third-party analytics script.** It runs code from another origin inside the authenticated app, and it reports every page view of a self-hosted deployment to a host the operator never chose. Removed. `src/lib/indexSecurity.test.ts` reads `index.html` and requires the app's own entry module to be the only script source, so a re-add fails a test rather than shipping quietly.

**Markdown blocked remote images only for the file viewer.** The guard was opt-in through `RemoteImageGuard`, so it covered previewed artifacts and nothing else. Markdown on every other surface comes from the same untrusted places: agent output, tool results, plugin content, artifact files. A remote image URL in any of them beacons the viewer's IP the moment it renders and can carry run data in its path. The block is now the default for all surfaces. Nothing disappears silently: the reader still sees that an image was withheld.

Scope is deliberately narrow. No behaviour changes beyond those two.

**Checks**

- Frontend suite 1772 tests green; typecheck, lint, prettier clean.
- Each change was verified to be load-bearing by reverting it in isolation: restoring the opt-in context reddens exactly the remote-image test, re-adding the script tag reddens exactly the document test. Neither reverted change touches any other test.
