### PR TITLE
fix(studio): stop the footer's diagnostics read from deciding liveness

### DIFF
--- a/apps/studio/frontend/src/components/shell/StatusFooter.test.tsx
+++ b/apps/studio/frontend/src/components/shell/StatusFooter.test.tsx
@@ -15,7 +15,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { IntlProvider } from "use-intl";
-import StatusFooter, { STATS_INITIAL_DELAY_MS } from "./StatusFooter";
+import StatusFooter, { HEALTH_PROBE_TIMEOUT_MS, STATS_INITIAL_DELAY_MS } from "./StatusFooter";
 import enMessages from "@/messages/en.json";
 
 const getStats = vi.fn();
@@ -200,5 +200,38 @@ describe("StatusFooter DB reading", () => {
       await vi.advanceTimersByTimeAsync(60_000);
     });
     expect(getStats).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up on a health probe that never answers and keeps polling", async () => {
+    // A daemon that accepts the connection and then says nothing. Without a
+    // deadline the in-flight guard stays latched, the dot keeps reporting the
+    // reading it had, and no later probe ever runs.
+    const settled: Array<(value: Response) => void> = [];
+    const fetchMock = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((resolve, reject) => {
+          settled.push(resolve);
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    getStats.mockResolvedValue(statsWith({ size_bytes: 120 * MB, size_alert: false }));
+    root = await mountFooter(container);
+
+    // Still hanging: nothing has decided the reading yet.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[aria-label="Backend unreachable"]')).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(HEALTH_PROBE_TIMEOUT_MS);
+    });
+    expect(healthDot(container).getAttribute("aria-label")).toBe("Backend unreachable");
+
+    // The guard released, so the next cadence actually probes again rather
+    // than returning at a latch left set by the abandoned request.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/studio/frontend/src/components/shell/StatusFooter.test.tsx
+++ b/apps/studio/frontend/src/components/shell/StatusFooter.test.tsx
@@ -15,7 +15,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { IntlProvider } from "use-intl";
-import StatusFooter from "./StatusFooter";
+import StatusFooter, { STATS_INITIAL_DELAY_MS } from "./StatusFooter";
 import enMessages from "@/messages/en.json";
 
 const getStats = vi.fn();
@@ -56,11 +56,21 @@ async function mountFooter(container: HTMLElement): Promise<Root> {
       </IntlProvider>,
     );
   });
-  // let the health probe and the stats read settle
+  // Health is immediate; heavyweight diagnostics deliberately wait until
+  // after first paint.
   await act(async () => {
-    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(STATS_INITIAL_DELAY_MS);
   });
   return root;
+}
+
+/** The health dot, found by the label it carries in either state. */
+function healthDot(container: HTMLElement): HTMLElement {
+  const match = container.querySelector<HTMLElement>(
+    '[aria-label="Backend healthy"], [aria-label="Backend unreachable"]',
+  );
+  if (!match) throw new Error("no health dot rendered");
+  return match;
 }
 
 /** The span carrying the DB reading, found by its rendered text. */
@@ -77,6 +87,8 @@ describe("StatusFooter DB reading", () => {
   let root: Root | null = null;
 
   beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.useFakeTimers();
     container = document.createElement("div");
     document.body.appendChild(container);
     vi.stubGlobal(
@@ -91,6 +103,7 @@ describe("StatusFooter DB reading", () => {
     container.remove();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it("marks the reading when the backend says the store is over its threshold", async () => {
@@ -134,5 +147,58 @@ describe("StatusFooter DB reading", () => {
     const span = dbSpan(container);
     expect(span.className).not.toContain("text-status-warning");
     expect(span.getAttribute("title")).toBeNull();
+  });
+
+  it("holds the diagnostics read back until after first paint", async () => {
+    getStats.mockResolvedValue(statsWith({ size_bytes: 120 * MB, size_alert: false }));
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <StatusFooter />
+        </IntlProvider>,
+      );
+    });
+    expect(getStats).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(STATS_INITIAL_DELAY_MS);
+    });
+    expect(getStats).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps reporting the backend healthy when only the diagnostics read fails", async () => {
+    getStats.mockRejectedValue(new Error("stats unavailable"));
+    root = await mountFooter(container);
+
+    expect(healthDot(container).getAttribute("aria-label")).toBe("Backend healthy");
+    expect(() => dbSpan(container)).toThrow();
+  });
+
+  it("reports the backend unreachable when the health probe itself fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("connection refused"))),
+    );
+    getStats.mockResolvedValue(statsWith({ size_bytes: 120 * MB, size_alert: false }));
+    root = await mountFooter(container);
+
+    expect(healthDot(container).getAttribute("aria-label")).toBe("Backend unreachable");
+  });
+
+  it("does not repeat heavyweight stats reads on the 30-second health cadence", async () => {
+    getStats.mockResolvedValue(statsWith({ size_bytes: 120 * MB, size_alert: false }));
+    root = await mountFooter(container);
+    expect(getStats).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4 * 60_000);
+    });
+    expect(getStats).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(getStats).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/studio/frontend/src/components/shell/StatusFooter.tsx
+++ b/apps/studio/frontend/src/components/shell/StatusFooter.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from "react";
 import { useTranslations } from "use-intl";
 import { getStats, resolveApiBase, type StudioStats } from "@/lib/api";
 
+const HEALTH_POLL_MS = 30_000;
+const STATS_POLL_MS = 5 * 60_000;
+export const STATS_INITIAL_DELAY_MS = 2_000;
+
 function formatBytes(b: number): string {
   if (b === 0) return "0 B";
   const units = ["B", "KB", "MB", "GB"];
@@ -17,30 +21,55 @@ export default function StatusFooter() {
 
   useEffect(() => {
     let active = true;
+    let healthInFlight = false;
+    let statsInFlight = false;
+    let hasStats = false;
 
-    async function poll() {
+    async function pollHealth() {
+      if (healthInFlight) return;
+      healthInFlight = true;
       try {
-        const [s] = await Promise.all([
-          getStats(),
-          fetch(`${apiBase}/health`)
-            .then((r) => {
-              if (active) setHealthy(r.ok);
-            })
-            .catch(() => {
-              if (active) setHealthy(false);
-            }),
-        ]);
-        if (active) setStats(s);
+        const response = await fetch(`${apiBase}/health`);
+        if (active) setHealthy(response.ok);
       } catch {
         if (active) setHealthy(false);
+      } finally {
+        healthInFlight = false;
       }
     }
 
-    void poll();
-    const id = setInterval(poll, 30_000);
+    async function pollStats() {
+      if (statsInFlight || document.visibilityState === "hidden") return;
+      statsInFlight = true;
+      try {
+        const next = await getStats();
+        if (active) {
+          hasStats = true;
+          setStats(next);
+        }
+      } catch {
+        // Diagnostics are optional footer context. Their failure must not
+        // override the independent /health reading or make the daemon look
+        // unavailable.
+      } finally {
+        statsInFlight = false;
+      }
+    }
+
+    void pollHealth();
+    const healthId = setInterval(() => void pollHealth(), HEALTH_POLL_MS);
+    const initialStatsId = window.setTimeout(() => void pollStats(), STATS_INITIAL_DELAY_MS);
+    const statsId = setInterval(() => void pollStats(), STATS_POLL_MS);
+    const onVisibility = () => {
+      if (document.visibilityState === "visible" && !hasStats) void pollStats();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
     return () => {
       active = false;
-      clearInterval(id);
+      clearInterval(healthId);
+      clearTimeout(initialStatsId);
+      clearInterval(statsId);
+      document.removeEventListener("visibilitychange", onVisibility);
     };
   }, [apiBase]);
 

--- a/apps/studio/frontend/src/components/shell/StatusFooter.tsx
+++ b/apps/studio/frontend/src/components/shell/StatusFooter.tsx
@@ -4,6 +4,9 @@ import { getStats, resolveApiBase, type StudioStats } from "@/lib/api";
 
 const HEALTH_POLL_MS = 30_000;
 const STATS_POLL_MS = 5 * 60_000;
+/** Deadline on one health probe. Must stay under HEALTH_POLL_MS so a probe that
+ *  hangs is abandoned before the next one is due. */
+export const HEALTH_PROBE_TIMEOUT_MS = 10_000;
 export const STATS_INITIAL_DELAY_MS = 2_000;
 
 function formatBytes(b: number): string {
@@ -28,12 +31,20 @@ export default function StatusFooter() {
     async function pollHealth() {
       if (healthInFlight) return;
       healthInFlight = true;
+      // A probe that never settles never reaches the reset below, and every
+      // later poll then returns at the guard above, so the dot keeps showing
+      // whatever it last said for as long as the page is open. A daemon that
+      // accepts the connection and then answers nothing is exactly the case
+      // this footer exists to report, so the probe carries its own deadline.
+      const controller = new AbortController();
+      const deadline = setTimeout(() => controller.abort(), HEALTH_PROBE_TIMEOUT_MS);
       try {
-        const response = await fetch(`${apiBase}/health`);
+        const response = await fetch(`${apiBase}/health`, { signal: controller.signal });
         if (active) setHealthy(response.ok);
       } catch {
         if (active) setHealthy(false);
       } finally {
+        clearTimeout(deadline);
         healthInFlight = false;
       }
     }


### PR DESCRIPTION
One invariant: the footer's cheap liveness check is independent of its expensive diagnostics read, and neither piles up behind a slow backend.

The footer ran a single poll every 30 seconds that did two unrelated things in one `Promise.all` under one `try`/`catch`: it fetched `/health`, and it fetched the full stats payload, which reads database size and connection counts. Three consequences:

- A stats failure painted the health dot red. The footer reported the daemon unreachable while it was answering `/health` normally, which is the worst possible direction for an indicator whose whole job is telling an operator whether the backend is up.
- The expensive read ran on the cheap read's cadence, twice a minute, forever, including during first paint and while the tab was in the background.
- Nothing suppressed overlap. A backend slower than the interval accumulated requests.

They are now two polls. Health keeps its 30-second cadence and stays the only input to the health dot. Stats runs every five minutes, holds back until after first paint, skips while the tab is hidden (and catches up on the first return to visibility if it has nothing yet), and swallows its own failures without touching liveness. Both guard against re-entry while a call is in flight.

**Checks**

- Frontend suite 1775 tests green (up 4 from main's 1771). Typecheck, lint, prettier clean.
- Three reverts, each run separately, each reddening exactly one test and no others, matching a prediction written before the run: making the stats catch set unhealthy reddens only the independence test; putting stats back on the 30-second interval reddens only the cadence test; firing stats at mount instead of after the delay reddens only the first-paint test.
