### PR TITLE
fix(studio): give every button an explicit type

### DIFF
--- a/apps/studio/frontend/src/components/GraphPlaybookEditor.tsx
+++ b/apps/studio/frontend/src/components/GraphPlaybookEditor.tsx
@@ -162,6 +162,7 @@ export default function GraphPlaybookEditor({ workerName }: { workerName: string
         />
 
         <button
+          type="button"
           onClick={() => setShowModels((v) => !v)}
           className="rounded-md bg-interactive-secondary px-3 py-1 text-meta text-content-secondary hover:bg-interactive-secondary-hover hover:text-content-primary"
         >
@@ -174,6 +175,7 @@ export default function GraphPlaybookEditor({ workerName }: { workerName: string
         </button>
 
         <button
+          type="button"
           onClick={handleSave}
           disabled={saving}
           className="rounded-md bg-interactive-primary px-4 py-1 text-body font-medium text-content-inverse hover:bg-interactive-primary-hover disabled:cursor-not-allowed disabled:opacity-50"

--- a/apps/studio/frontend/src/components/canvas/SidePanel.tsx
+++ b/apps/studio/frontend/src/components/canvas/SidePanel.tsx
@@ -121,6 +121,7 @@ function NodePanel({
         <h3 className="font-mono text-sm font-semibold text-content-primary">{data.label}</h3>
         {editable && onDelete && (
           <button
+            type="button"
             onClick={() => onDelete("node", id)}
             className="text-xs text-content-muted hover:text-status-error"
           >
@@ -290,6 +291,7 @@ function EdgePanel({
         <h3 className="text-sm font-semibold text-content-primary">Link</h3>
         {editable && onDelete && (
           <button
+            type="button"
             onClick={() => onDelete("edge", id)}
             className="text-xs text-content-muted hover:text-status-error"
           >
@@ -305,6 +307,7 @@ function EdgePanel({
           <div className="flex gap-1">
             {(["simple", "code"] as const).map((m) => (
               <button
+                type="button"
                 key={m}
                 onClick={() => update("mode", m)}
                 className={`rounded px-3 py-1 text-xs font-medium ${

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -785,12 +785,14 @@ export default function WorkerCanvas({
         {editable && (
           <div className="absolute bottom-4 left-4 flex items-center gap-2 z-10">
             <button
+              type="button"
               onClick={onAddStep}
               className="rounded-md bg-interactive-secondary px-3 py-1.5 text-xs font-medium text-content-primary hover:bg-interactive-secondary-hover"
             >
               + Add Step
             </button>
             <button
+              type="button"
               onClick={handleAutoLayout}
               className="rounded-md bg-interactive-secondary px-3 py-1.5 text-xs font-medium text-content-primary hover:bg-interactive-secondary-hover"
             >

--- a/apps/studio/frontend/src/components/ui/buttonType.test.ts
+++ b/apps/studio/frontend/src/components/ui/buttonType.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function sourceFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const file = path.join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(file);
+    if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
+    return [file];
+  });
+}
+
+describe("native button safety", () => {
+  it("gives every button an explicit type so controls cannot submit a surrounding form", () => {
+    const srcRoot = path.resolve(__dirname, "../..");
+    const missing: string[] = [];
+
+    for (const file of sourceFiles(srcRoot)) {
+      const source = fs
+        .readFileSync(file, "utf8")
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/.*$/gm, "");
+      for (const match of source.matchAll(/<button\b[^>]*>/gs)) {
+        if (/\btype\s*=/.test(match[0])) continue;
+        const line = source.slice(0, match.index).split("\n").length;
+        missing.push(`${path.relative(srcRoot, file)}:${line}`);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/apps/studio/frontend/src/routes/system.tsx
+++ b/apps/studio/frontend/src/routes/system.tsx
@@ -213,6 +213,7 @@ function MaintenanceSection({ doctor }: { doctor: AdminDoctorResponse | null }) 
 
       <div className="flex flex-wrap items-center gap-2">
         <button
+          type="button"
           className={btnSecondary}
           disabled={running !== null}
           onClick={() => void run("checkpoint")}
@@ -220,6 +221,7 @@ function MaintenanceSection({ doctor }: { doctor: AdminDoctorResponse | null }) 
           {running === "checkpoint" ? t("maintenance.running") : t("maintenance.checkpointWal")}
         </button>
         <button
+          type="button"
           className={btnSecondary}
           disabled={running !== null}
           onClick={() => void run("prune")}
@@ -227,6 +229,7 @@ function MaintenanceSection({ doctor }: { doctor: AdminDoctorResponse | null }) 
           {running === "prune" ? t("maintenance.running") : t("maintenance.pruneOldData")}
         </button>
         <button
+          type="button"
           className={btnSecondary}
           disabled={running !== null}
           onClick={() => void run("vacuum")}
@@ -234,7 +237,12 @@ function MaintenanceSection({ doctor }: { doctor: AdminDoctorResponse | null }) 
           {running === "vacuum" ? t("maintenance.running") : t("maintenance.vacuumDb")}
         </button>
         {phantoms > 0 && (
-          <button className={btnDanger} disabled={running !== null} onClick={() => void pruneAll()}>
+          <button
+            type="button"
+            className={btnDanger}
+            disabled={running !== null}
+            onClick={() => void pruneAll()}
+          >
             {t("maintenance.prunePhantoms", {
               count: phantoms,
               plural: phantoms !== 1 ? "s" : "",
@@ -456,7 +464,7 @@ function SettingsSection() {
             <span className={valueCls}>
               {theme === "dark" ? t("settings.themeDark") : t("settings.themeLight")}
             </span>
-            <button className={btnBase} onClick={toggleTheme}>
+            <button type="button" className={btnBase} onClick={toggleTheme}>
               {theme === "dark" ? t("settings.switchToLight") : t("settings.switchToDark")}
             </button>
           </div>


### PR DESCRIPTION
One invariant: a `<button>` in Studio never submits a form by accident.

A button with no `type` attribute defaults to `type="submit"`. Inside a form that reloads the page or runs the form's `onSubmit` instead of the handler the button carries, and it is a latent failure: the code is wrong the whole time and only misbehaves once someone wraps a form around it. Twelve controls were in that state.

- `canvas/SidePanel.tsx` — the node delete, the link delete, and the link-mode selector
- `GraphPlaybookEditor.tsx` — the collapse toggle
- `canvas/WorkerCanvas.tsx` — two overlay toggles
- `routes/system.tsx` — checkpoint, prune, vacuum, the destructive prune-phantoms, and the theme switch

All twelve are ordinary controls, so all twelve now say `type="button"`. No behaviour changes today; this is about what happens the next time markup moves.

The test is the durable part. `ui/buttonType.test.ts` walks every `.tsx` under `src`, strips comments, and fails with the file and line of any button that does not name its type. A new untyped button now fails at the point it is written rather than at the point a form appears around it.

**Checks**

- Frontend suite 1772 tests green (82 files, up 1 file and 1 test from main). Typecheck, lint, prettier clean.
- The guard was run against `main` first and named exactly those twelve sites, so it is measuring rather than asserting a state it was written beside. Removing one `type="button"` again reddens it, naming that file and line.
