### PR TITLE
fix(tools): close subagent permission preset schema

### DIFF
--- a/docs/adr/ADR-0013-built-in-tool-provider-and-branch-binding.md
+++ b/docs/adr/ADR-0013-built-in-tool-provider-and-branch-binding.md
@@ -548,9 +548,11 @@ class SandboxRequest(BaseModel):
     action: SandboxAction                    # create | diff | commit | merge | discard
     message: str | None = None
 
+_SubagentPermissionPreset = Literal["read_only", "safe", "allow_all", "deny_all"]
+
 class SubagentRequest(BaseModel):
     instruction: str
-    permissions: str = "read_only"
+    permissions: _SubagentPermissionPreset = "read_only"
     max_turns: int = 20
     cwd: str | None = None
 ```

--- a/lionagi/tools/coding.py
+++ b/lionagi/tools/coding.py
@@ -10,7 +10,7 @@ import shlex
 from collections.abc import Callable, Sequence
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
@@ -69,6 +69,9 @@ class SandboxRequest(BaseModel):
     )
 
 
+_SubagentPermissionPreset = Literal["read_only", "safe", "allow_all", "deny_all"]
+
+
 class SubagentRequest(BaseModel):
     instruction: str = Field(
         ...,
@@ -77,14 +80,14 @@ class SubagentRequest(BaseModel):
             "what files to look at, and what output you expect."
         ),
     )
-    permissions: str = Field(
+    permissions: _SubagentPermissionPreset = Field(
         default="read_only",
         description=(
             "Permission level for the sub-agent. One of:\n"
             "- 'read_only': Can only read files and search (safest).\n"
             "- 'safe': Can read/write/search, bash restricted (no rm/sudo).\n"
-            "- 'inherit': Same permissions as parent agent.\n"
-            "- 'allow_all': No restrictions (use with caution)."
+            "- 'allow_all': No restrictions (use with caution).\n"
+            "- 'deny_all': Block all tool calls."
         ),
     )
     max_turns: int = Field(
@@ -764,12 +767,12 @@ class CodingToolkit(LionTool):
 
         async def subagent(
             instruction: str,
-            permissions: str = "read_only",
+            permissions: _SubagentPermissionPreset = "read_only",
             max_turns: int = 20,
             cwd: str | None = None,
         ) -> dict:
             """Spawn a sub-agent with its own Branch and coding tools to handle a task independently via a ReAct loop.
-            permissions controls what it can do: read_only (search/read only), safe (read/write/search, bash restricted), or allow_all (full access).
+            permissions controls what it can do: read_only (search/read only), safe (read/write/search, bash restricted), allow_all (full access), or deny_all (no tool calls).
             """
             from lionagi.agent.spec import AgentSpec
 

--- a/tests/tools/test_coding_toolkit.py
+++ b/tests/tools/test_coding_toolkit.py
@@ -4,11 +4,13 @@
 """Tests for CodingToolkit: bind, reader, editor, bash, search."""
 
 import asyncio
+import inspect
 
 import pytest
+from pydantic import ValidationError
 
 from lionagi.session.branch import Branch
-from lionagi.tools.coding import CodingToolkit
+from lionagi.tools.coding import CodingToolkit, SubagentRequest
 
 
 def _make_toolkit(tmp_path, notify=False):
@@ -67,6 +69,43 @@ def test_bind_tool_names_opt_in_extras(tmp_path):
 
     with pytest.raises(ValueError, match="unknown coding tool"):
         CodingToolkit(workspace_root=str(tmp_path), tools=["reader", "nope"])
+
+
+def test_subagent_request_exposes_only_resolvable_permission_presets():
+    permissions = SubagentRequest.model_json_schema()["properties"]["permissions"]
+
+    assert permissions["enum"] == ["read_only", "safe", "allow_all", "deny_all"]
+    assert permissions["default"] == "read_only"
+
+
+@pytest.mark.parametrize("preset", ["read_only", "safe", "allow_all", "deny_all"])
+def test_subagent_request_accepts_each_resolvable_permission_preset(preset):
+    request = SubagentRequest(instruction="inspect the repository", permissions=preset)
+
+    assert request.permissions == preset
+
+
+def test_subagent_request_rejects_unimplemented_permission_inheritance():
+    with pytest.raises(ValidationError, match="permissions"):
+        SubagentRequest(instruction="inspect the repository", permissions="inherit")
+
+
+def test_bound_subagent_rejects_inheritance_before_callable_execution(tmp_path):
+    branch = Branch()
+    [tool] = CodingToolkit(workspace_root=str(tmp_path), tools=["subagent"]).bind(branch)
+    branch.acts.register_tool(tool)
+
+    assert inspect.signature(tool.func_callable).parameters["permissions"].default == "read_only"
+    with pytest.raises(ValidationError, match="permissions"):
+        branch.acts.match_tool(
+            {
+                "function": "subagent",
+                "arguments": {
+                    "instruction": "inspect the repository",
+                    "permissions": "inherit",
+                },
+            }
+        )
 
 
 async def test_reader_read_returns_numbered_lines(tmp_path):


### PR DESCRIPTION
## Summary

- close the coding subagent's agent-facing permission schema to the four presets that `AgentSpec` can actually resolve
- keep the existing `read_only` default and expose `read_only | safe | allow_all | deny_all`
- reject the advertised-but-unimplemented `inherit` value during request validation, before hooks, subagent construction, or callable execution
- synchronize ADR-0013 with the executable request contract

This is a narrow current-contract fix. It does not implement true permission inheritance; ADR-0121 reserves that work for an explicit unresolved value plus a frozen resolved-policy snapshot. Mapping `inherit` to `None` here would remove policy rather than inherit it.

## Validation

- RED: the previous schema had no enum and accepted `inherit`
- 7 direct subagent request/boundary regressions passed
- 116 related CodingToolkit, AgentSpec, and permission-guard tests passed
- focused Ruff and format checks passed
- Pyright reported 0 errors
- `git diff --check`
- independent review: 0 P0 / 0 P1; the one documentation-name P2 was fixed

Two additional reader tests remain unavailable because the local SciPy `_spropack` dylib prevents Docling import; this diff does not touch those paths.

## Risk

Low and fail-early. Undocumented uppercase variants such as `SAFE` now fail at the closed schema boundary instead of reaching the case-normalizing resolver. The public schema has always documented lowercase values only.

Refs ADR-0121; closes no issue.