### PR TITLE
fix(studio): refuse SQLite-direct reads on server-backed stores

### DIFF
--- a/lionagi/studio/services/shows.py
+++ b/lionagi/studio/services/shows.py
@@ -15,8 +15,13 @@ from lionagi.libs.path_safety import safe_join
 
 from ..config import SHOWS_ROOT
 from ..registry import studio_route
+from ._db import (
+    StoreNotAddressableError,
+    require_file_store,
+    store_exists,
+    store_path,
+)
 from ._db import open_db as _open_db
-from ._db import require_file_store, store_exists, store_path
 from ._io import read_json_file as _read_json
 from ._io import read_json_file_checked as _read_json_checked
 from ._path_safety import public_path, safe_path_join
@@ -747,7 +752,18 @@ async def watch_show(topic: str) -> AsyncGenerator[str]:
 
         if not any_change and (time.time() - last_change) >= _SHOW_DONE_STABLE_SECS:
             show_status: str | None = None
-            if await _db_available():
+            try:
+                store_readable = await _db_available()
+            except StoreNotAddressableError:
+                # This generator is already streaming, so the response status is
+                # committed and the app-level 501 handler can no longer run. The
+                # refusal still did its job: no read reached the fallback file.
+                # Leaving the status unknown matches the no-store-yet case and
+                # keeps the file events, which are filesystem-derived and correct,
+                # flowing instead of aborting the stream to report a condition the
+                # client cannot be told about here.
+                store_readable = False
+            if store_readable:
                 try:
                     async with _open_db(store_path()) as db:
                         cur = await db.execute("SELECT status FROM shows WHERE topic = ?", (topic,))

--- a/lionagi/studio/services/shows.py
+++ b/lionagi/studio/services/shows.py
@@ -16,7 +16,7 @@ from lionagi.libs.path_safety import safe_join
 from ..config import SHOWS_ROOT
 from ..registry import studio_route
 from ._db import open_db as _open_db
-from ._db import store_exists, store_path
+from ._db import require_file_store, store_exists, store_path
 from ._io import read_json_file as _read_json
 from ._io import read_json_file_checked as _read_json_checked
 from ._path_safety import public_path, safe_path_join
@@ -88,6 +88,7 @@ def _extract_repo_and_branches(show_md: str | None) -> tuple[str | None, str | N
 
 
 async def _db_available() -> bool:
+    require_file_store()
     return store_exists()
 
 

--- a/lionagi/studio/services/signals.py
+++ b/lionagi/studio/services/signals.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 from ._db import open_db as _open_db
-from ._db import store_exists, store_path
+from ._db import require_file_store, store_exists, store_path
 
 
 async def get_signals_after(
@@ -18,6 +18,7 @@ async def get_signals_after(
     limit: int = 500,
 ) -> list[dict[str, Any]]:
     """Return signal rows for *session_id* with seq > *after_seq*, ordered by seq."""
+    require_file_store()
     if not store_exists():
         return []
 

--- a/lionagi/studio/services/stats.py
+++ b/lionagi/studio/services/stats.py
@@ -15,7 +15,7 @@ from . import plugins as plugins_svc
 from . import sessions as sessions_svc
 from . import shows as shows_svc
 from . import skills as skills_svc
-from ._db import get_active_connection_count, store_path
+from ._db import get_active_connection_count, require_file_store, store_path
 from ._db import open_db as _open_db
 from ._path_safety import public_path
 
@@ -249,6 +249,7 @@ async def _pragmas(db: Any) -> dict[str, Any]:
 async def get_db_stats() -> dict[str, Any]:
     from .db_maintenance import get_db_size_alert, get_last_checkpoint_at
 
+    require_file_store()
     db_path = Path(store_path())
     size_bytes = db_path.stat().st_size if db_path.exists() else 0
     wal_path = db_path.parent / (db_path.name + "-wal")
@@ -308,6 +309,11 @@ async def get_db_stats() -> dict[str, Any]:
 async def get_stats() -> dict[str, Any]:
     from lionagi.studio.services.lifecycle import get_phantom_count
 
+    # Refuse before composing a response from StateDB-backed values and the
+    # SQLite-direct diagnostics below.  Otherwise a server-backed deployment
+    # can receive a well-formed aggregate whose ``db`` section describes the
+    # unrelated fallback file.
+    require_file_store()
     return {
         "playbooks": len(playbooks_svc.list_playbooks()),
         "agents": len(agents_svc.list_agents()),

--- a/tests/apps_studio_server/test_not_answerable.py
+++ b/tests/apps_studio_server/test_not_answerable.py
@@ -185,6 +185,53 @@ def test_signal_reads_refuse_a_server_backed_store_before_fallback(tmp_path, mon
     assert exc_info.value.backend == "postgresql"
 
 
+def test_the_show_stream_survives_a_store_it_may_not_read(tmp_path, monkeypatch):
+    """A refusal inside an SSE generator has nowhere to go but the client's socket.
+
+    The other guarded sites answer a request that has not been sent yet, so
+    raising reaches the 501 handler. ``watch_show`` is already streaming by the
+    time it consults the store for terminal status, so the response status is
+    committed and a raise truncates the stream instead. Its file events come
+    from the filesystem and stay correct either way, so the guard has to leave
+    the status unknown rather than take those events down with it.
+    """
+    import lionagi.studio.services.shows as shows_mod
+
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url="postgresql://user:secret@host/db")
+
+    # Control: the condition under test is live at this configuration. Without
+    # this, a guard that silently stopped refusing would also pass below.
+    with pytest.raises(StoreNotAddressableError):
+        require_file_store()
+
+    shows_root = tmp_path / "shows"
+    (shows_root / "demo").mkdir(parents=True)
+    (shows_root / "demo" / "show.md").write_text("# demo\n")
+    monkeypatch.setattr(shows_mod, "SHOWS_ROOT", shows_root)
+    monkeypatch.setattr(shows_mod, "_SHOW_DONE_STABLE_SECS", 0)
+
+    async def drive() -> str:
+        stream = shows_mod.watch_show("demo")
+        first = await stream.__anext__()
+        # Past the first event the generator settles and consults the store. It
+        # then has nothing further to emit, so a timeout here is the pass: the
+        # stream is still open. A refusal escaping the generator surfaces as
+        # StoreNotAddressableError out of this await instead.
+        try:
+            await asyncio.wait_for(stream.__anext__(), timeout=2.0)
+        except (TimeoutError, asyncio.TimeoutError):
+            pass
+        finally:
+            await stream.aclose()
+        return first
+
+    first_event = _run(drive())
+
+    assert '"type": "new"' in first_event or '"type":"new"' in first_event
+    assert "show.md" in first_event
+
+
 # ── Readiness stays 200 no matter what (it is asked about the store, not for rows) ──
 
 

--- a/tests/apps_studio_server/test_not_answerable.py
+++ b/tests/apps_studio_server/test_not_answerable.py
@@ -145,6 +145,46 @@ def test_same_route_still_answers_rows_against_an_existing_store(tmp_path, monke
     assert names == ["demo-project"]
 
 
+@pytest.mark.parametrize(
+    ("path", "expected_route"),
+    (
+        ("/api/shows/", "/api/shows/"),
+        ("/api/stats", "/api/stats"),
+    ),
+)
+def test_remaining_sqlite_direct_routes_are_501_when_store_is_server_backed(
+    tmp_path, monkeypatch, path, expected_route
+):
+    """A partial Studio response from the fallback SQLite file is never valid.
+
+    Shows and the aggregate stats route were the two HTTP paths left outside
+    ``require_file_store``.  They must now use the same explicit refusal as
+    the other SQLite-direct services.
+    """
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url="postgresql://user:secret@host/db")
+
+    r = _client().get(path)
+
+    assert r.status_code == 501
+    body = r.json()
+    assert body["route"] == expected_route
+    assert body["backend"] == "postgresql"
+    assert "secret" not in str(body)
+
+
+def test_signal_reads_refuse_a_server_backed_store_before_fallback(tmp_path, monkeypatch):
+    """The signal reader is internal, so pin its service-level refusal directly."""
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url="postgresql://user:secret@host/db")
+
+    from lionagi.studio.services.signals import get_signals_after
+
+    with pytest.raises(StoreNotAddressableError) as exc_info:
+        _run(get_signals_after("session-1", 0))
+    assert exc_info.value.backend == "postgresql"
+
+
 # ── Readiness stays 200 no matter what (it is asked about the store, not for rows) ──
 
 


### PR DESCRIPTION
## Summary

- apply the existing `require_file_store` guard to the remaining shows, signals, and aggregate-stats SQLite-direct paths
- return the existing typed 501 response for HTTP routes instead of presenting fallback-file data as the configured server-backed store
- keep an already-started show SSE stream open when its late terminal-status probe is refused, while still preventing any fallback SQLite read
- preserve existing behavior for both an available local SQLite file and a local file that has not been created yet

These direct paths are scheduled for deletion behind `StateStore` in ADR-0118 Phase 5; this patch only fixes the current contract.

## Root cause

Three Studio service paths bypassed the store-kind guard already used by sibling SQLite-direct readers. On PostgreSQL or in-memory configurations they could therefore read a fallback local file, returning empty or unrelated data as though it came from the configured store.

The show watcher has a second constraint: its HTTP response is already committed by the time it probes terminal status. Raising there cannot reach the app-level 501 handler and instead truncates valid filesystem-derived SSE events. That one late probe therefore catches `StoreNotAddressableError`, leaves status unknown, and keeps streaming without touching the fallback database.

## Validation

- `tests/apps_studio_server/test_not_answerable.py`: 15 passed
- related shows/signals/stats suites: 60 passed
- targeted Ruff: passed
- `git diff --check`
- GitHub CI, Type Check, Benchmarks, and Vercel checks: passed
- remote compare: two focused commits, four files, `+115/-4`

## Risk

Low and backend-specific. Server-backed deployments now receive an explicit unsupported response before HTTP output begins; an already-started show stream retains its valid filesystem events and treats unreadable terminal status as unknown. Local SQLite present and not-yet-created behavior remains unchanged.

Closes #3207.