### PR TITLE
docs(adr): reconcile status on the three records whose acceptance is unconditional

### DIFF
--- a/docs/adr/ADR-0119-deterministic-declaration-and-configuration-substrate.md
+++ b/docs/adr/ADR-0119-deterministic-declaration-and-configuration-substrate.md
@@ -1,6 +1,6 @@
 # ADR-0119: Deterministic declaration and configuration substrate
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Aspirational
 - **Implementation-status**: not-started
 - **Area**: utilities

--- a/docs/adr/ADR-0120-interception-observation-and-durable-delivery-planes.md
+++ b/docs/adr/ADR-0120-interception-observation-and-durable-delivery-planes.md
@@ -1,6 +1,6 @@
 # ADR-0120: Interception, observation, and durable delivery planes
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Aspirational
 - **Implementation-status**: not-started
 - **Area**: hooks

--- a/docs/adr/ADR-0122-feature-boundaries-and-optional-runtime-profiles.md
+++ b/docs/adr/ADR-0122-feature-boundaries-and-optional-runtime-profiles.md
@@ -1,6 +1,6 @@
 # ADR-0122: Feature boundaries and optional runtime profiles
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Kind**: Aspirational
 - **Implementation-status**: not-started
 - **Area**: governance


### PR DESCRIPTION
Merging a record does not change its status field. All seven consolidation records
(ADR-0118 through ADR-0124) still read `Status: Proposed` after landing on `main`,
which means anyone citing them has to guess whether that is deliberate.

For three of them it is not. This flips those three and leaves the rest, per record.

## Changed

| Record | Status | Implementation-status |
|---|---|---|
| ADR-0119 | Proposed → **Accepted** | `not-started` (unchanged) |
| ADR-0120 | Proposed → **Accepted** | `not-started` (unchanged) |
| ADR-0122 | Proposed → **Accepted** | `not-started` (unchanged) |

Each of these three carries conditions, but every one of those conditions gates
*implementation* rather than *acceptance* — `Unset` semantics landing before code relies
on the three-state contract, per-profile characterization tests before the dispatcher
migration, breaking the `cli` ↔ `studio` cycle before any distribution split. That
distinction is exactly what the separate `Implementation-status` field exists to record,
and it stays `not-started` on all three.

## Deliberately unchanged

| Record | Stays Proposed because |
|---|---|
| ADR-0121, ADR-0123, ADR-0124 | These accept only after an expiring authoring probe has exercised the draft interface. Accepting them now would let the authoring surface freeze against an interface that is then negotiated backwards from it, which is the specific outcome the ordering exists to prevent. |
| ADR-0118 | Ordered after ADR-0123 exists as a logical contract. Accepting it first inverts that order, and its target-registry freeze is the step that depends on it. |

## Scope

Three files, three lines, `Status` only. Verified: the four records above appear nowhere
in the diff, `Implementation-status` is untouched on all seven, and no index or other
document records a status for these three that would now disagree — the ADR README links
and describes but does not carry status.