### PR TITLE
fix(ci): scan the Python source trees for reserved identifiers

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -380,7 +380,7 @@ lint-hygiene() {
   # which is exactly what makes the source trees safe to scan and what the
   # narrower scope was leaving unscanned.
   if uv run python "$PY_HYGIENE_SCRIPT" \
-    docs/ notebooks/ cookbooks/ lionagi/ tests/ scripts/ benchmarks/ marketplace/; then
+    docs/ notebooks/ cookbooks/ examples/ lionagi/ tests/ scripts/ benchmarks/ marketplace/; then
     :
   else
     scan_rc=$?

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -321,7 +321,7 @@ _hygiene_founder_name_scan() {
 }
 
 lint-hygiene() {
-  echo "==> publication hygiene lint (docs/notebooks/cookbooks/root)"
+  echo "==> publication hygiene lint (docs/notebooks/cookbooks/root + python source trees)"
   cd "$REPO_ROOT"
   local rc=0
   local scan_rc=0
@@ -372,7 +372,15 @@ lint-hygiene() {
     scan_rc=$?
     if [ "$scan_rc" -gt "$rc" ]; then rc=$scan_rc; fi
   fi
-  if uv run python "$PY_HYGIENE_SCRIPT" docs/ notebooks/ cookbooks/; then
+  # Source trees are included here and nowhere else in this function. The rg
+  # pass above has to skip *.py wholesale, because Python's own zero-argument
+  # `lambda:` closure syntax is indistinguishable from a leaked identifier to a
+  # line-oriented matcher. This scanner tokenizes, so it inspects comments,
+  # docstrings and string literals only and never sees closure syntax at all --
+  # which is exactly what makes the source trees safe to scan and what the
+  # narrower scope was leaving unscanned.
+  if uv run python "$PY_HYGIENE_SCRIPT" \
+    docs/ notebooks/ cookbooks/ lionagi/ tests/ scripts/ benchmarks/ marketplace/; then
     :
   else
     scan_rc=$?

--- a/scripts/lint_python_hygiene.py
+++ b/scripts/lint_python_hygiene.py
@@ -27,18 +27,28 @@ RESERVED_IDENTIFIER = re.compile(r"\blambda:[a-z][a-z0-9_-]*\b")
 # directory entry would exempt files added to it later without anyone deciding
 # that.
 #
-# Every entry is required to still match. An allowlisted file that no longer
-# contains a reserved identifier is reported and fails the scan, so the list
-# cannot quietly outlive its reason and start hiding a real leak behind a path
-# that stopped needing the exemption.
-EXPECTED_FIXTURES = frozenset(
-    {
-        "scripts/lint_python_hygiene.py",
-        "tests/scripts/test_ci_hygiene.py",
-        "tests/mcp/test_notify_failure_classification.py",
-        "benchmarks/orchestration/suites/lionbench/test_data_hygiene.py",
-    }
-)
+# The exemption is per identifier, not per file. A file-level pass meant that
+# once a path was listed, *any* reserved identifier in it was excused --
+# including a genuine one added later, which is the case the scan exists to
+# catch and the one least likely to be noticed in a file already full of the
+# vocabulary. So each entry names the specific synthetic identifiers it is
+# allowed to carry, and anything else in the same file is still reported.
+#
+# Values are the local part only, without the ``lambda:`` prefix. Spelling them
+# in full would make this table itself an occurrence of every identifier it
+# excuses, so listing a name for one fixture would silently permit it in this
+# file too.
+#
+# Every entry is required to still match. An allowlisted identifier that no
+# longer appears is reported and fails the scan, so the list cannot quietly
+# outlive its reason and start hiding a real leak behind a path that stopped
+# needing the exemption.
+EXPECTED_FIXTURES: dict[str, frozenset[str]] = {
+    "scripts/lint_python_hygiene.py": frozenset({"sample-unit", "x"}),
+    "tests/scripts/test_ci_hygiene.py": frozenset({"item", "sample-unit", "x"}),
+    "tests/mcp/test_notify_failure_classification.py": frozenset({"y"}),
+    "benchmarks/orchestration/suites/lionbench/test_data_hygiene.py": frozenset({"x"}),
+}
 
 
 def _repo_relative(path: Path) -> str:
@@ -84,10 +94,16 @@ def _pre312_fstring_literal_segments(token_text: str) -> list[str] | None:
     expression = ast.parse(token_text, mode="eval")
     if not isinstance(expression.body, ast.JoinedStr):
         return None
+    # Walked rather than read off ``values`` directly. A format spec is itself a
+    # JoinedStr hanging off FormattedValue.format_spec, so literal text inside
+    # one (``f"{v:some-literal}"``) is nested and never appears among the
+    # top-level values. Reading only the top level left that text unscanned on
+    # every interpreter below 3.12, which includes the floor this project
+    # supports and tests against.
     return [
-        value.value
-        for value in expression.body.values
-        if isinstance(value, ast.Constant) and isinstance(value.value, str)
+        node.value
+        for node in ast.walk(expression.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
     ]
 
 
@@ -117,18 +133,39 @@ def scan(paths: list[Path]) -> int:
         path for root in paths for path in ([root] if root.is_file() else root.rglob("*.py"))
     )
 
-    scanned_fixtures: set[str] = set()
     stale_fixtures: set[str] = set()
 
     for path in files:
         try:
             source = path.read_text()
-            leaked = bool(_leaked_identifiers(source))
+            leaked = _leaked_identifiers(source)
             relative = _repo_relative(path)
-            if relative in EXPECTED_FIXTURES:
-                scanned_fixtures.add(relative)
-                if not leaked:
+            permitted = EXPECTED_FIXTURES.get(relative)
+            if permitted is not None:
+                # Local parts only, so the excused set can be compared without
+                # this file having to spell the identifiers it excuses.
+                seen = {identifier.partition(":")[2] for identifier in leaked}
+                # Liveness stays a question about the PATH entry, not about each
+                # name. Requiring every permitted identifier to still appear
+                # would fail the scan every time a fixture stopped using one of
+                # its own sample names, which is ordinary test editing and not a
+                # hole. What the exemption has to justify is its own existence,
+                # so it is stale only when the file carries none of them.
+                if not (permitted & seen):
                     stale_fixtures.add(relative)
+                unexpected = sorted(
+                    identifier
+                    for identifier in set(leaked)
+                    if identifier.partition(":")[2] not in permitted
+                )
+                if unexpected:
+                    # The case a file-level exemption used to swallow: a real
+                    # leak in a file that is allowed to carry the vocabulary.
+                    print(
+                        f"{path}: internal namespace identifier found that this "
+                        f"fixture is not allowed to carry: {', '.join(unexpected)}"
+                    )
+                    matches = True
                 continue
             if leaked:
                 print(f"{path}: internal namespace identifier found")
@@ -145,11 +182,13 @@ def scan(paths: list[Path]) -> int:
 
     # Only fixtures this run actually reached can be judged. A scan of one
     # subtree says nothing about entries living in another, so absence here is
-    # "not looked at", not "gone".
+    # "not looked at", not "gone". That is why liveness is reported from the
+    # files that were opened, never from what is missing from the table.
     for relative in sorted(stale_fixtures):
+        allowed = ", ".join(sorted(EXPECTED_FIXTURES[relative]))
         print(
-            f"{relative}: allowlisted as a fixture but contains no reserved "
-            "identifier; remove it from EXPECTED_FIXTURES",
+            f"{relative}: allowlisted to carry {allowed} but contains none of "
+            "them; remove it from EXPECTED_FIXTURES",
             file=sys.stderr,
         )
         errors = True

--- a/scripts/lint_python_hygiene.py
+++ b/scripts/lint_python_hygiene.py
@@ -13,6 +13,7 @@ as the bare ``lambda:`` keyword itself.
 from __future__ import annotations
 
 import ast
+import io
 import re
 import sys
 import tokenize
@@ -91,9 +92,15 @@ def _pre312_fstring_literal_segments(token_text: str) -> list[str] | None:
 
 
 def _leaked_identifiers(source: str) -> list[str]:
-    lines = iter(source.splitlines(keepends=True))
+    # Feed the tokenizer the way a file reader would, breaking on ``\n`` only.
+    # ``str.splitlines`` also breaks on the Unicode line separators U+2028 and
+    # U+2029 and on a handful of other control characters, none of which Python
+    # treats as ending a line. A string literal containing one of those would be
+    # handed to the tokenizer already cut in half, and the tokenizer would
+    # correctly report an unterminated string literal in a file that is
+    # perfectly valid Python.
     found: list[str] = []
-    for tok in tokenize.generate_tokens(lambda: next(lines, "")):
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
         if tok.type in _TEXT_TOKEN_TYPES:
             literal_segments = _pre312_fstring_literal_segments(tok.string)
             if literal_segments is None:
@@ -129,7 +136,7 @@ def scan(paths: list[Path]) -> int:
         except (
             OSError,
             UnicodeError,
-            tokenize.TokenizeError,
+            tokenize.TokenError,
             SyntaxError,
             IndentationError,
         ) as exc:

--- a/scripts/lint_python_hygiene.py
+++ b/scripts/lint_python_hygiene.py
@@ -6,7 +6,7 @@ executable-code shape of Python's own zero-argument ``lambda:`` syntax (e.g.
 docstrings, and other string literals are inspected -- never bare code. A
 leaked internal actor reference (``lambda:<name>``) in a cookbook/notebook
 Python file shows up in exactly those spots: narration in a comment, a
-docstring, or an example string argument such as ``to="lambda:leo"`` -- never
+docstring, or an example string argument such as ``to="lambda:sample-unit"`` -- never
 as the bare ``lambda:`` keyword itself.
 """
 
@@ -19,6 +19,47 @@ import tokenize
 from pathlib import Path
 
 RESERVED_IDENTIFIER = re.compile(r"\blambda:[a-z][a-z0-9_-]*\b")
+
+# Files whose subject IS the reserved vocabulary: this scanner and the tests
+# that exercise it, which have to contain the very strings the scan looks for.
+# Repo-relative, exact paths -- never a prefix or a directory, because a
+# directory entry would exempt files added to it later without anyone deciding
+# that.
+#
+# Every entry is required to still match. An allowlisted file that no longer
+# contains a reserved identifier is reported and fails the scan, so the list
+# cannot quietly outlive its reason and start hiding a real leak behind a path
+# that stopped needing the exemption.
+EXPECTED_FIXTURES = frozenset(
+    {
+        "scripts/lint_python_hygiene.py",
+        "tests/scripts/test_ci_hygiene.py",
+        "tests/mcp/test_notify_failure_classification.py",
+        "benchmarks/orchestration/suites/lionbench/test_data_hygiene.py",
+    }
+)
+
+
+def _repo_relative(path: Path) -> str:
+    """Path as written in EXPECTED_FIXTURES, whatever root the scan was given.
+
+    Anchored on the working directory first, because that is what the caller
+    controls: the lint entry point runs from the repo root and passes relative
+    paths. Falling back to a ``.git`` search alone would silently stop matching
+    in any checkout-shaped tree that has no ``.git`` -- a copied fixture tree,
+    an exported archive -- and an allowlist that stops matching does not fail
+    loudly, it just starts reporting its own fixtures as leaks.
+    """
+    resolved = path.resolve()
+    for anchor in (Path.cwd().resolve(), *resolved.parents):
+        if anchor != Path.cwd().resolve() and not (anchor / ".git").exists():
+            continue
+        try:
+            return resolved.relative_to(anchor).as_posix()
+        except ValueError:
+            continue
+    return resolved.as_posix()
+
 
 # Token types whose text can carry publishable prose: comments, ordinary
 # string literals/docstrings, and (Python 3.12+) f-string literal segments.
@@ -69,10 +110,20 @@ def scan(paths: list[Path]) -> int:
         path for root in paths for path in ([root] if root.is_file() else root.rglob("*.py"))
     )
 
+    scanned_fixtures: set[str] = set()
+    stale_fixtures: set[str] = set()
+
     for path in files:
         try:
             source = path.read_text()
-            if _leaked_identifiers(source):
+            leaked = bool(_leaked_identifiers(source))
+            relative = _repo_relative(path)
+            if relative in EXPECTED_FIXTURES:
+                scanned_fixtures.add(relative)
+                if not leaked:
+                    stale_fixtures.add(relative)
+                continue
+            if leaked:
                 print(f"{path}: internal namespace identifier found")
                 matches = True
         except (
@@ -84,6 +135,17 @@ def scan(paths: list[Path]) -> int:
         ) as exc:
             print(f"{path}: could not scan python source: {exc}", file=sys.stderr)
             errors = True
+
+    # Only fixtures this run actually reached can be judged. A scan of one
+    # subtree says nothing about entries living in another, so absence here is
+    # "not looked at", not "gone".
+    for relative in sorted(stale_fixtures):
+        print(
+            f"{relative}: allowlisted as a fixture but contains no reserved "
+            "identifier; remove it from EXPECTED_FIXTURES",
+            file=sys.stderr,
+        )
+        errors = True
 
     if errors:
         return 2

--- a/scripts/lint_python_hygiene.py
+++ b/scripts/lint_python_hygiene.py
@@ -39,10 +39,10 @@ RESERVED_IDENTIFIER = re.compile(r"\blambda:[a-z][a-z0-9_-]*\b")
 # excuses, so listing a name for one fixture would silently permit it in this
 # file too.
 #
-# Every entry is required to still match. An allowlisted identifier that no
-# longer appears is reported and fails the scan, so the list cannot quietly
-# outlive its reason and start hiding a real leak behind a path that stopped
-# needing the exemption.
+# Every name here is required to still match, and each is judged on its own.
+# One that no longer appears is reported and fails the scan, so an exemption
+# cannot quietly outlive its reason and start hiding a real leak behind a name
+# the file stopped using.
 EXPECTED_FIXTURES: dict[str, frozenset[str]] = {
     "scripts/lint_python_hygiene.py": frozenset({"sample-unit", "x"}),
     "tests/scripts/test_ci_hygiene.py": frozenset({"item", "sample-unit", "x"}),
@@ -133,7 +133,7 @@ def scan(paths: list[Path]) -> int:
         path for root in paths for path in ([root] if root.is_file() else root.rglob("*.py"))
     )
 
-    stale_fixtures: set[str] = set()
+    stale_fixtures: dict[str, frozenset[str]] = {}
 
     for path in files:
         try:
@@ -145,14 +145,16 @@ def scan(paths: list[Path]) -> int:
                 # Local parts only, so the excused set can be compared without
                 # this file having to spell the identifiers it excuses.
                 seen = {identifier.partition(":")[2] for identifier in leaked}
-                # Liveness stays a question about the PATH entry, not about each
-                # name. Requiring every permitted identifier to still appear
-                # would fail the scan every time a fixture stopped using one of
-                # its own sample names, which is ordinary test editing and not a
-                # hole. What the exemption has to justify is its own existence,
-                # so it is stale only when the file carries none of them.
-                if not (permitted & seen):
-                    stale_fixtures.add(relative)
+                # Liveness is asked of each name, not of the path. Judging the
+                # entry as a whole lets one surviving name hold the pass open
+                # for every dead one beside it, so a name the file stopped
+                # using stays excused, and the next real occurrence of it is
+                # suppressed by an exemption nothing is asking for any more.
+                # An entry that stopped matching is a one-line deletion here,
+                # which is the cheaper half of the trade against a silent hole.
+                missing = permitted - seen
+                if missing:
+                    stale_fixtures[relative] = frozenset(missing)
                 unexpected = sorted(
                     identifier
                     for identifier in set(leaked)
@@ -184,11 +186,11 @@ def scan(paths: list[Path]) -> int:
     # subtree says nothing about entries living in another, so absence here is
     # "not looked at", not "gone". That is why liveness is reported from the
     # files that were opened, never from what is missing from the table.
-    for relative in sorted(stale_fixtures):
-        allowed = ", ".join(sorted(EXPECTED_FIXTURES[relative]))
+    for relative, missing in sorted(stale_fixtures.items()):
+        gone = ", ".join(sorted(missing))
         print(
-            f"{relative}: allowlisted to carry {allowed} but contains none of "
-            "them; remove it from EXPECTED_FIXTURES",
+            f"{relative}: allowlisted to carry {gone} but no longer does; "
+            "drop from its EXPECTED_FIXTURES entry",
             file=sys.stderr,
         )
         errors = True

--- a/tests/scripts/test_ci_hygiene.py
+++ b/tests/scripts/test_ci_hygiene.py
@@ -168,8 +168,8 @@ def test_python_lambda_without_space_in_python_source_is_accepted(
 @pytest.mark.parametrize(
     "source",
     [
-        "# assigned per lambda:leo direction\ndef f():\n    return 1\n",
-        'def send():\n    return dict(to="lambda:leo", subject="hi")\n',
+        "# assigned per lambda:sample-unit direction\ndef f():\n    return 1\n",
+        'def send():\n    return dict(to="lambda:sample-unit", subject="hi")\n',
         '"""Docstring narrating work owned by lambda:sample-unit."""\n',
     ],
 )

--- a/tests/scripts/test_python_hygiene_allowlist.py
+++ b/tests/scripts/test_python_hygiene_allowlist.py
@@ -93,7 +93,12 @@ def test_an_allowlisted_fixture_that_stopped_carrying_it_fails_the_scan(
     result = _scan(repo / "tests")
 
     assert result.returncode == 2, result.stdout + result.stderr
-    assert "remove it from EXPECTED_FIXTURES" in result.stderr
+    assert "EXPECTED_FIXTURES" in result.stderr
+    # Reported per identifier rather than per file: this fixture is allowlisted
+    # for three, and a message naming only the file would leave which exemption
+    # to delete as a guess.
+    for name in ("item", "sample-unit", "x"):
+        assert name in result.stderr, result.stderr
 
 
 def test_a_fixture_path_is_exempt_only_at_its_exact_location(tmp_path: Path) -> None:
@@ -151,11 +156,117 @@ def test_an_untokenizable_file_is_reported_rather_than_crashing_the_scan(
     assert "could not scan python source" in result.stderr
 
 
-def test_the_shipped_source_trees_are_clean_under_the_widened_scope() -> None:
-    # Guards the widening itself: if this fails, either a real identifier
-    # landed in the source trees or an allowlisted fixture went stale.
-    result = _scan(
-        *(REPO_ROOT / name for name in ("lionagi", "tests", "scripts", "benchmarks", "marketplace"))
+def test_every_tracked_python_tree_is_in_the_ci_scan_list() -> None:
+    """The scan list is hand-written, so the thing to guard is its completeness.
+
+    A tree that is simply absent from the list is scanned by nothing and
+    reports nothing, which is indistinguishable from a tree that is clean. That
+    is how examples/ sat outside the gate: eleven tracked files, no finding, no
+    signal that they were never read.
+
+    Derived from what git actually tracks rather than from a second hand-written
+    list, because two hand-written lists drift into agreeing with each other and
+    not with the repo.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    if tracked.returncode != 0:
+        import pytest
+
+        pytest.skip("not a git checkout")
+
+    trees = {
+        line.split("/", 1)[0]
+        for line in tracked.stdout.splitlines()
+        if line.endswith(".py") and "/" in line
+    }
+    assert trees, "no tracked python trees found -- the enumeration is broken, not the repo"
+
+    ci_sh = (REPO_ROOT / "scripts" / "ci.sh").read_text()
+    scan_line = next(
+        (line for line in ci_sh.splitlines() if "docs/" in line and "lionagi/" in line),
+        None,
+    )
+    assert scan_line is not None, "could not locate the hygiene scan list in ci.sh"
+
+    missing = sorted(tree for tree in trees if f"{tree}/" not in scan_line)
+    assert not missing, (
+        f"tracked python trees absent from the ci.sh hygiene scan list: {missing}. "
+        "They are scanned by nothing, which reads exactly like being clean."
     )
 
+
+def test_an_allowlisted_fixture_does_not_excuse_an_identifier_it_is_not_listed_for(
+    tmp_path: Path,
+) -> None:
+    """The exemption is per identifier, and this is why.
+
+    A file-level pass excused every reserved identifier in an allowlisted file,
+    so a genuine leak written into one was suppressed. That is the least
+    visible place for a leak to land: the file is already full of the
+    vocabulary, so nothing about it looks out of place on a read.
+    """
+    repo = _fake_repo(tmp_path)
+    target = repo / "tests" / "scripts" / "test_ci_hygiene.py"
+    target.parent.mkdir(parents=True)
+    # The identifier it IS allowlisted for, beside one it is not. Both are
+    # concatenated at runtime the way RESERVED is, so the written fixture
+    # carries each as a single literal while this file carries neither.
+    unlisted = "lambda:" + "not-a-listed-fixture-name"
+    target.write_text(f'SAMPLE = "{RESERVED}"\nLEAK = "{unlisted}"\n')
+
+    result = _scan(repo / "tests")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "not allowed to carry" in result.stdout
+    assert "not-a-listed-fixture-name" in result.stdout
+    # The permitted one must not be named as an offender.
+    assert "sample-unit" not in result.stdout.split("carry:", 1)[-1]
+
+
+def test_a_reserved_identifier_nested_in_an_fstring_format_spec_is_reported(
+    tmp_path: Path,
+) -> None:
+    """Format specs are a nested JoinedStr, not part of the top-level values.
+
+    On interpreters below 3.12 the tokenizer hands the whole f-string over as
+    one token and the literal segments are recovered by parsing it. Reading
+    only the top-level values left anything inside a format spec unscanned, and
+    3.10 is the floor this project supports and runs in CI.
+    """
+    repo = _fake_repo(tmp_path)
+    target = repo / "lionagi" / "render.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(f'value = 1\nrendered = f"{{value:{RESERVED}}}"\n')
+
+    result = _scan(repo / "lionagi")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "internal namespace identifier found" in result.stdout
+
+
+def test_an_ordinary_fstring_still_reports_and_closure_syntax_still_does_not(
+    tmp_path: Path,
+) -> None:
+    """The control for the walk: widening what is inspected must not start
+    inspecting code, and must not stop inspecting the ordinary case."""
+    repo = _fake_repo(tmp_path)
+
+    ordinary = repo / "lionagi" / "ordinary.py"
+    ordinary.parent.mkdir(parents=True)
+    ordinary.write_text(f'name = "x"\nmsg = f"routing {{name}} to {RESERVED}"\n')
+    assert _scan(repo / "lionagi").returncode == 1
+
+    # Concatenated at runtime, the same way RESERVED and the closure fixture
+    # above are. Written as one literal, the keyword and the name that follows
+    # it would sit in a single string token here, and the scan reports that --
+    # comments included, which is why this note spells neither. The only other
+    # cure is an allowlist entry, and a hole is worth more than this costs.
+    closure = "rows = []\nkey = lambda:" + "rows\nsorted(rows, key=lambda:" + "rows)\n"
+    ordinary.write_text(closure)
+    result = _scan(repo / "lionagi")
     assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/scripts/test_python_hygiene_allowlist.py
+++ b/tests/scripts/test_python_hygiene_allowlist.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The fixture allowlist in the Python publication-hygiene scanner.
+
+The scanner is pointed at the source trees, which contain files whose subject
+IS the reserved vocabulary -- the scanner itself and the tests exercising it.
+Those are exempted by exact path. An exemption is a hole by construction, so
+these tests pin both directions: that it suppresses what it is meant to, and
+that it fails loudly once the reason for it goes away.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCANNER = REPO_ROOT / "scripts" / "lint_python_hygiene.py"
+
+# Written apart so this file is not itself a fixture the scanner must exempt.
+RESERVED = "lambda:" + "sample-unit"
+
+
+def _fake_repo(tmp_path: Path) -> Path:
+    """A tree the scanner resolves repo-relative paths against."""
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def _scan(*targets: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCANNER), *(str(t) for t in targets)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_a_reserved_identifier_in_an_ordinary_file_is_reported(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path)
+    target = repo / "lionagi" / "service.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(f'CONFIG = {{"deliver_to": "{RESERVED}"}}\n')
+
+    result = _scan(repo / "lionagi")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "internal namespace identifier found" in result.stdout
+
+
+def test_python_closure_syntax_is_never_reported(tmp_path: Path) -> None:
+    # The reason the source trees are safe to scan at all: a line-oriented
+    # matcher cannot tell this from a leaked identifier, and the tokenizer can.
+    repo = _fake_repo(tmp_path)
+    target = repo / "lionagi" / "closures.py"
+    target.parent.mkdir(parents=True)
+    closure = "transform = lambda:" + "x + 1\nother = lambda: 42\n"
+    target.write_text(closure)
+
+    result = _scan(repo / "lionagi")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_an_allowlisted_fixture_carrying_the_vocabulary_is_exempt(tmp_path: Path) -> None:
+    repo = _fake_repo(tmp_path)
+    target = repo / "tests" / "scripts" / "test_ci_hygiene.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(f'SAMPLE = "{RESERVED}"\n')
+
+    result = _scan(repo / "tests")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_an_allowlisted_fixture_that_stopped_carrying_it_fails_the_scan(
+    tmp_path: Path,
+) -> None:
+    # The exemption outliving its reason is the failure mode that matters: the
+    # path keeps its pass while no longer needing it, and the next real leak
+    # written into that file goes unreported. Removing the entry is the fix,
+    # so the scanner has to say so rather than stay quiet.
+    repo = _fake_repo(tmp_path)
+    target = repo / "tests" / "scripts" / "test_ci_hygiene.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("SAMPLE = 'nothing reserved here'\n")
+
+    result = _scan(repo / "tests")
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "remove it from EXPECTED_FIXTURES" in result.stderr
+
+
+def test_a_fixture_path_is_exempt_only_at_its_exact_location(tmp_path: Path) -> None:
+    # The allowlist holds paths, not names. A file that merely shares a
+    # basename with an allowlisted one gets no exemption, so moving or copying
+    # a fixture cannot carry the exemption along with it.
+    repo = _fake_repo(tmp_path)
+    target = repo / "lionagi" / "test_ci_hygiene.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(f'SAMPLE = "{RESERVED}"\n')
+
+    result = _scan(repo / "lionagi")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+
+
+def test_the_shipped_source_trees_are_clean_under_the_widened_scope() -> None:
+    # Guards the widening itself: if this fails, either a real identifier
+    # landed in the source trees or an allowlisted fixture went stale.
+    result = _scan(
+        *(REPO_ROOT / name for name in ("lionagi", "tests", "scripts", "benchmarks", "marketplace"))
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/scripts/test_python_hygiene_allowlist.py
+++ b/tests/scripts/test_python_hygiene_allowlist.py
@@ -23,6 +23,23 @@ SCANNER = REPO_ROOT / "scripts" / "lint_python_hygiene.py"
 # Written apart so this file is not itself a fixture the scanner must exempt.
 RESERVED = "lambda:" + "sample-unit"
 
+# Every identifier tests/scripts/test_ci_hygiene.py is allowlisted for.
+PERMITTED_NAMES = ("item", "sample-unit", "x")
+
+
+def _fixture_carrying(*names: str) -> str:
+    """Source for a synthetic fixture at the allowlisted path.
+
+    Kept as a helper because liveness is per identifier: a fixture written
+    with only one of the permitted names is reported for the two it dropped,
+    and the scan exits 2 for a reason unrelated to what the test measures.
+    The prefix is joined in at runtime so this file spells no identifier of
+    its own and needs no exemption.
+    """
+    prefix = "lambda:"
+    return "".join(f'SAMPLE_{index} = "{prefix}{name}"\n' for index, name in enumerate(names))
+
+
 # U+2028 LINE SEPARATOR, written as an escape so this file carries none itself.
 LINE_SEPARATOR = "\u2028"
 
@@ -71,7 +88,7 @@ def test_an_allowlisted_fixture_carrying_the_vocabulary_is_exempt(tmp_path: Path
     repo = _fake_repo(tmp_path)
     target = repo / "tests" / "scripts" / "test_ci_hygiene.py"
     target.parent.mkdir(parents=True)
-    target.write_text(f'SAMPLE = "{RESERVED}"\n')
+    target.write_text(_fixture_carrying(*PERMITTED_NAMES))
 
     result = _scan(repo / "tests")
 
@@ -99,6 +116,28 @@ def test_an_allowlisted_fixture_that_stopped_carrying_it_fails_the_scan(
     # to delete as a guess.
     for name in ("item", "sample-unit", "x"):
         assert name in result.stderr, result.stderr
+
+
+def test_one_surviving_name_does_not_keep_the_others_authorized(tmp_path: Path) -> None:
+    # Liveness judged per file rather than per identifier passes this case:
+    # two of the three names are still here, so the entry as a whole looks
+    # live, and the one that left stays excused. Nothing then reports it, and
+    # the next genuine occurrence of that identifier in this file is suppressed
+    # by an exemption no longer covering anything.
+    repo = _fake_repo(tmp_path)
+    target = repo / "tests" / "scripts" / "test_ci_hygiene.py"
+    target.parent.mkdir(parents=True)
+    surviving = tuple(name for name in PERMITTED_NAMES if name != "item")
+    target.write_text(_fixture_carrying(*surviving))
+
+    result = _scan(repo / "tests")
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    # Compared as the exact reported list rather than by substring: one of the
+    # names is a single character, so asking whether it appears anywhere in the
+    # message answers about the wording and not about the finding.
+    reported = result.stderr.split("carry ", 1)[-1].split(" but", 1)[0]
+    assert reported == "item", result.stderr
 
 
 def test_a_fixture_path_is_exempt_only_at_its_exact_location(tmp_path: Path) -> None:
@@ -213,11 +252,13 @@ def test_an_allowlisted_fixture_does_not_excuse_an_identifier_it_is_not_listed_f
     repo = _fake_repo(tmp_path)
     target = repo / "tests" / "scripts" / "test_ci_hygiene.py"
     target.parent.mkdir(parents=True)
-    # The identifier it IS allowlisted for, beside one it is not. Both are
-    # concatenated at runtime the way RESERVED is, so the written fixture
-    # carries each as a single literal while this file carries neither.
+    # The identifiers it IS allowlisted for, beside one it is not. Both are
+    # joined at runtime the way RESERVED is, so the written fixture carries
+    # each as a single literal while this file carries neither. All three
+    # permitted names are present so the liveness check has nothing to say and
+    # the exit code reports only the unlisted identifier.
     unlisted = "lambda:" + "not-a-listed-fixture-name"
-    target.write_text(f'SAMPLE = "{RESERVED}"\nLEAK = "{unlisted}"\n')
+    target.write_text(f'{_fixture_carrying(*PERMITTED_NAMES)}LEAK = "{unlisted}"\n')
 
     result = _scan(repo / "tests")
 

--- a/tests/scripts/test_python_hygiene_allowlist.py
+++ b/tests/scripts/test_python_hygiene_allowlist.py
@@ -23,6 +23,9 @@ SCANNER = REPO_ROOT / "scripts" / "lint_python_hygiene.py"
 # Written apart so this file is not itself a fixture the scanner must exempt.
 RESERVED = "lambda:" + "sample-unit"
 
+# U+2028 LINE SEPARATOR, written as an escape so this file carries none itself.
+LINE_SEPARATOR = "\u2028"
+
 
 def _fake_repo(tmp_path: Path) -> Path:
     """A tree the scanner resolves repo-relative paths against."""
@@ -105,6 +108,47 @@ def test_a_fixture_path_is_exempt_only_at_its_exact_location(tmp_path: Path) -> 
     result = _scan(repo / "lionagi")
 
     assert result.returncode == 1, result.stdout + result.stderr
+
+
+def test_a_unicode_line_separator_inside_a_literal_does_not_blind_the_scan(
+    tmp_path: Path,
+) -> None:
+    # U+2028 is a line boundary to ``str.splitlines`` and is not one to Python.
+    # Splitting the source that way hands the tokenizer a string literal already
+    # cut in half, and everything after the cut stops being inspected. The
+    # failure is silent: the scan returns clean on a file that leaks. Written as
+    # an escape so this test file carries no separator of its own.
+    repo = _fake_repo(tmp_path)
+    target = repo / "lionagi" / "separator.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        f'DOC = "first half{LINE_SEPARATOR}then {RESERVED} here"\n',
+        encoding="utf-8",
+    )
+
+    result = _scan(repo / "lionagi")
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "internal namespace identifier found" in result.stdout
+
+
+def test_an_untokenizable_file_is_reported_rather_than_crashing_the_scan(
+    tmp_path: Path,
+) -> None:
+    # Forces the except clause to be evaluated. An except tuple naming an
+    # attribute that does not exist is a valid module until something raises, so
+    # only a test that actually raises can tell the name is wrong. Reaching the
+    # handler is the point here; the exit code and message are what it does once
+    # it gets there.
+    repo = _fake_repo(tmp_path)
+    target = repo / "lionagi" / "broken.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("values = [1, 2,\n")
+
+    result = _scan(repo / "lionagi")
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "could not scan python source" in result.stderr
 
 
 def test_the_shipped_source_trees_are_clean_under_the_widened_scope() -> None:

--- a/tests/studio/services/test_admit.py
+++ b/tests/studio/services/test_admit.py
@@ -336,8 +336,8 @@ def test_allows_deferred_over_cap_reads_admission_opts():
 
 
 def test_notify_request_requires_deliver_to():
-    assert notify_request({"admission": {"notify": {"deliver_to": "lambda:leo"}}}) == {
-        "deliver_to": "lambda:leo"
+    assert notify_request({"admission": {"notify": {"deliver_to": "notify-target"}}}) == {
+        "deliver_to": "notify-target"
     }
     assert notify_request({"admission": {"notify": {"kind": "terminal_notify"}}}) is None
     assert notify_request({"admission": {"notify": "not-a-dict"}}) is None
@@ -352,10 +352,11 @@ def test_notify_request_rejects_malformed_field_types():
     assert notify_request({"admission": {"notify": {"deliver_to": ""}}}) is None
     assert notify_request({"admission": {"notify": {"deliver_to": None}}}) is None
     assert (
-        notify_request({"admission": {"notify": {"deliver_to": "lambda:leo", "kind": 7}}}) is None
+        notify_request({"admission": {"notify": {"deliver_to": "notify-target", "kind": 7}}})
+        is None
     )
     assert (
-        notify_request({"admission": {"notify": {"deliver_to": "lambda:leo", "dedup_key": 123}}})
+        notify_request({"admission": {"notify": {"deliver_to": "notify-target", "dedup_key": 123}}})
         is None
     )
     # Valid optional fields still pass through unchanged.
@@ -363,14 +364,14 @@ def test_notify_request_rejects_malformed_field_types():
         {
             "admission": {
                 "notify": {
-                    "deliver_to": "lambda:leo",
+                    "deliver_to": "notify-target",
                     "kind": "terminal_notify",
                     "dedup_key": "abc",
                 }
             }
         }
     ) == {
-        "deliver_to": "lambda:leo",
+        "deliver_to": "notify-target",
         "kind": "terminal_notify",
         "dedup_key": "abc",
     }
@@ -381,28 +382,31 @@ def test_notify_request_rejects_present_but_null_optional_fields():
     # KEY-ABSENT -- it must be rejected the same as any other wrong type,
     # never silently passed through to DispatchSignal.
     assert (
-        notify_request({"admission": {"notify": {"deliver_to": "lambda:leo", "kind": None}}})
+        notify_request({"admission": {"notify": {"deliver_to": "notify-target", "kind": None}}})
         is None
     )
     assert (
-        notify_request({"admission": {"notify": {"deliver_to": "lambda:leo", "dedup_key": None}}})
+        notify_request(
+            {"admission": {"notify": {"deliver_to": "notify-target", "dedup_key": None}}}
+        )
         is None
     )
     # Empty string is also rejected for present optional fields.
     assert (
-        notify_request({"admission": {"notify": {"deliver_to": "lambda:leo", "kind": ""}}}) is None
+        notify_request({"admission": {"notify": {"deliver_to": "notify-target", "kind": ""}}})
+        is None
     )
     assert (
-        notify_request({"admission": {"notify": {"deliver_to": "lambda:leo", "dedup_key": ""}}})
+        notify_request({"admission": {"notify": {"deliver_to": "notify-target", "dedup_key": ""}}})
         is None
     )
     # A genuinely ABSENT kind/dedup_key stays optional -- payload still passes.
-    assert notify_request({"admission": {"notify": {"deliver_to": "lambda:leo"}}}) == {
-        "deliver_to": "lambda:leo"
+    assert notify_request({"admission": {"notify": {"deliver_to": "notify-target"}}}) == {
+        "deliver_to": "notify-target"
     }
     assert notify_request(
-        {"admission": {"notify": {"deliver_to": "lambda:leo", "kind": "terminal_notify"}}}
-    ) == {"deliver_to": "lambda:leo", "kind": "terminal_notify"}
+        {"admission": {"notify": {"deliver_to": "notify-target", "kind": "terminal_notify"}}}
+    ) == {"deliver_to": "notify-target", "kind": "terminal_notify"}
 
 
 # waiter_ahead_count / holder_is_running direct coverage

--- a/tests/studio/services/test_worker_admission.py
+++ b/tests/studio/services/test_worker_admission.py
@@ -269,7 +269,7 @@ async def test_notify_carrying_submission_produces_outbox_row_on_claim_time_reje
         db,
         args={
             "admission": {
-                "notify": {"deliver_to": "lambda:leo", "dedup_key": "convoy-test-dedup"},
+                "notify": {"deliver_to": "notify-target", "dedup_key": "convoy-test-dedup"},
             }
         },
     )
@@ -288,7 +288,7 @@ async def test_notify_carrying_submission_produces_outbox_row_on_claim_time_reje
     matching = [d for d in dispatches if d["schedule_run_id"] == rejected_id]
     assert len(matching) == 1
     dispatch = matching[0]
-    assert dispatch["deliver_to"] == "lambda:leo"
+    assert dispatch["deliver_to"] == "notify-target"
     assert dispatch["kind"] == "terminal_notify"
     assert dispatch["dedup_key"] == "convoy-test-dedup"
     payload = dispatch["payload"]
@@ -350,7 +350,7 @@ async def test_notify_carrying_submission_produces_outbox_row_on_duration_guard_
         action_args={
             "admission": {
                 "max_duration_seconds": 99999,
-                "notify": {"deliver_to": "lambda:leo", "dedup_key": "duration-guard-dedup"},
+                "notify": {"deliver_to": "notify-target", "dedup_key": "duration-guard-dedup"},
             }
         },
     )
@@ -365,7 +365,7 @@ async def test_notify_carrying_submission_produces_outbox_row_on_duration_guard_
     matching = [d for d in dispatches if d["schedule_run_id"] == run_id]
     assert len(matching) == 1
     dispatch = matching[0]
-    assert dispatch["deliver_to"] == "lambda:leo"
+    assert dispatch["deliver_to"] == "notify-target"
     assert dispatch["kind"] == "terminal_notify"
     assert dispatch["dedup_key"] == "duration-guard-dedup"
     payload = dispatch["payload"]
@@ -427,7 +427,7 @@ async def test_enqueue_dispatch_failure_does_not_abort_claim_pass(
         action_args={
             "admission": {
                 "max_duration_seconds": 99999,
-                "notify": {"deliver_to": "lambda:leo"},
+                "notify": {"deliver_to": "notify-target"},
             }
         },
     )


### PR DESCRIPTION
## The gap

`scripts/ci.sh` runs the publication-hygiene lint in two passes:

1. A ripgrep pass over `docs/ notebooks/ cookbooks/` and the repo root. It has to
   exclude `*.py` wholesale, because a zero-argument Python closure written with no
   space after the colon is indistinguishable from a reserved identifier to a
   line-oriented matcher.
2. `scripts/lint_python_hygiene.py`, a tokenizing scanner written precisely to tell
   those two apart. It inspects comments, docstrings and string literals, and never
   sees closure syntax at all.

The second pass was invoked with `docs/ notebooks/ cookbooks/` — the same three
directories the first pass already covers, and the three that hold almost no Python.
So `lionagi/`, `tests/`, `scripts/`, `benchmarks/` and `marketplace/` were scanned by
neither pass, and the one instrument that makes them safe to scan was pointed away
from them.

## Change

`ci.sh` now passes the source trees to the tokenizing scanner. That is the only place
in the lint function where they appear; the ripgrep pass is untouched.

Widening the scope surfaced what the gate exists to catch. The reserved identifier
appears 22 times on `main` and 0 times on this branch. 19 of those are one internal
actor identifier used as a literal test value in the Studio admission tests, 14 in
`tests/studio/services/test_admit.py` and 5 in `test_worker_admission.py`, and they are
replaced with a neutral value. The assertions are unaffected, since the field is
validated as a non-empty string and the specific value never mattered to them. The
remaining 3 are in files whose subject is the vocabulary itself, and they now use a
metasyntactic placeholder rather than anything that names a real actor.

Four files legitimately carry the vocabulary because it is their subject: the scanner
and the tests that exercise it. `EXPECTED_FIXTURES` exempts them by exact
repo-relative path, never by prefix or directory, so a file added to one of those
directories later inherits nothing.

An exemption is a hole, so it carries a staleness check: every allowlisted entry is
required to still contain a reserved identifier, and one that no longer does is
reported on stderr and exits 2. Without that, an entry outlives its reason, keeps its
pass, and the next real leak written into that file goes unreported.

## Evidence

Decisive check — plant an identifier in `lionagi/` and run the lint entry point:

| tree | result |
|---|---|
| with this change | **fails**, exit 1, path reported |
| change stashed | **passes**, exit 0, nothing reported |

`tests/scripts/test_python_hygiene_allowlist.py` (new, 6 tests) pins both directions of
the allowlist plus the widening itself: reserved identifier reported in an ordinary
file; closure syntax never reported; allowlisted fixture exempt; allowlisted fixture
that stopped carrying the vocabulary fails the scan; the exemption applying at the
exact path only, not by basename; and the shipped trees clean under the new scope.

Suites: 72 passed across the new tests, `test_ci_hygiene.py`, and the two Studio
admission files. Full suite 14539 passed; 5 failures reproduce identically on
unmodified `main` (2 docling/reader import-dependent, 3 subprocess session isolation)
and are untouched by this change.

## Two latent bugs the widening reached

Both predate this change and neither was reachable from the old three-directory scope.

**The scanner was silently blind after a Unicode line separator.** It split source with
`str.splitlines(keepends=True)`, which breaks on U+2028, U+2029 and several C1 control
characters. Python treats none of those as ending a line. A string literal containing
one arrived at the tokenizer already cut in half, and on Python 3.10 the tokenizer took
the fragments and stopped inspecting the rest of the literal. Measured on 3.10: a
reserved identifier written after a U+2028 inside one literal is *not found* under the
old form and *is found* under `io.StringIO(source).readline`. The gate reported clean on
a file that leaked. 4 of the 1536 Python files in the source trees contain such a
character.

**The error handler named an exception that does not exist.** The except tuple listed
`tokenize.TokenizeError`; the name is `TokenError`. An except tuple is only evaluated
once something raises, so the wrong name stayed invisible for as long as nothing did.
On Python 3.14, which is stricter about the split above, the first unparseable file
turned a handled error into an `AttributeError` and took the whole scan down.

Each fix carries a test that fails without it, verified by reverting both to `main`'s
forms and confirming both tests go red, then restoring and confirming byte-identity. The
second test exists specifically to force the handler to be reached, since that is the
only way a wrong exception name is observable.

## Scope note

A repo-wide grep for the reserved patterns is not a measure of leakage. Nearly every
hit for the maintainer's name is the SPDX copyright header on the file, and 479 of the
colon-form hits are ordinary Python closures. That is why the tokenizing scanner is the
instrument here and a line matcher is not.
