### PR TITLE
fix(cli,studio): refuse pid liveness and stop signals on rows from another machine

### DIFF
--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -189,9 +189,7 @@ def recorded_pid_is_foreign(metadata: dict[str, Any] | None) -> bool:
     return isinstance(host, str) and bool(host) and host != socket.gethostname()
 
 
-# Stands in for a recorded identity mode that is present but not a string.
-# Deliberately a string, so every caller's "is this a mode I know" comparison
-# keeps working unchanged, and deliberately one no writer produces.
+# A string, so mode comparisons keep working, and one no writer produces.
 UNRECOGNIZED_IDENTITY_MODE = "<unrecognized>"
 
 
@@ -225,24 +223,16 @@ def recorded_identity_mode(metadata: dict[str, Any] | None) -> str | None:
     return mode if isinstance(mode, str) else UNRECOGNIZED_IDENTITY_MODE
 
 
-# Modes whose stop-and-liveness protocol is this one: a pid in this host's pid
-# space, signalled directly. Anything else names a protocol living elsewhere.
+# Modes whose stop protocol is a pid in this host's pid space.
 _LOCALLY_JUDGEABLE_MODES = ("local", "in_process")
 
 
 def recorded_row_is_foreign(metadata: dict[str, Any] | None) -> bool:
-    """Whether a row's recorded process is one this host has no standing to judge.
+    """Whether this host has any standing to judge a row's recorded process.
 
-    Both questions, in this order, because the order is what makes each answer
-    safe. A row announcing an identity mode this code does not recognize names
-    a stop-and-liveness protocol living somewhere else, and is refused outright.
-    Only then is the host asked, and ``recorded_pid_is_foreign`` is allowed to
-    read an unreadable host marker as "no host recorded" precisely because a
-    row written by something alien has already been turned away by the mode.
-
-    This is the form every caller wants. Asking the host question alone inherits
-    that permissive reading without the refusal that pays for it, which is a
-    quiet way to get a row judged on a local pid that was never local.
+    Mode first, then host: the host check may read an unreadable marker as
+    "none recorded", which is only safe once an alien mode has been refused.
+    Callers want this, not ``recorded_pid_is_foreign`` alone.
     """
     mode = recorded_identity_mode(metadata)
     if mode is not None and mode not in _LOCALLY_JUDGEABLE_MODES:

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -146,43 +146,7 @@ def pid_alive(pid: int) -> bool:
 
 
 def recorded_pid_is_foreign(metadata: dict[str, Any] | None) -> bool:
-    """Whether a run's recorded pid belongs to a different machine.
-
-    A pid is only a name inside one host's pid space. When several hosts share
-    a state store, every local check applied to a remote row answers about
-    whichever unrelated local process happens to hold that number: it reads as
-    a real answer, and it is about the wrong process. So this is asked before
-    any pid on such a row is signalled or believed.
-
-    Absence of ``pid_host`` is not foreignness. Rows written before the marker
-    existed cannot be placed either way, and treating "unknown origin" as
-    "another machine" would stop every one of them from being cancelled or
-    swept. The callers that go on to act still have their own identity checks;
-    this only removes the rows where those checks could not mean anything.
-
-    A value that is present but unreadable -- empty, or not a string -- reads
-    the same way, as no host recorded, which is worth stating because the
-    neighbouring identity-mode reader deliberately does the opposite. It can
-    tell a row it does not understand from a row that predates it, and refuses
-    the first. The difference is that a mode has several legitimate spellings
-    and gains more over time, so an unrecognized one plausibly names a protocol
-    written by something newer. A host does not: this marker is written in one
-    place, always from ``socket.gethostname()``, so no writer past or present
-    emits a malformed one and an unreadable value names nothing to defer to.
-
-    What makes that safe is not the marker. A row that announces an identity
-    mode this code does not know is refused before the host is consulted at
-    all, so a genuinely alien writer never reaches this question. What remains
-    is a row claiming a local mode whose pid happens to match a live local pid,
-    and the recorded creation time is what answers that -- it rejects the
-    coincidence whatever the host field says, which is the check that has to
-    hold for this one to be a fast path rather than a guarantee.
-
-    Nor is a self-reported host a trust boundary. Nothing here authenticates a
-    hostname, so a row claiming this machine's name is indistinguishable from
-    one written on it. This removes rows whose local answer would be
-    meaningless; it does not defend against a writer that lies.
-    """
+    """Whether a run's recorded pid belongs to a different host; missing or unreadable ``pid_host`` reads as not-foreign, since pids are host-local and a self-reported hostname is not authenticated."""
     if not isinstance(metadata, dict):
         return False
     host = metadata.get("pid_host")
@@ -194,27 +158,7 @@ UNRECOGNIZED_IDENTITY_MODE = "<unrecognized>"
 
 
 def recorded_identity_mode(metadata: dict[str, Any] | None) -> str | None:
-    """The run's recorded process identity mode, or None if none was recorded.
-
-    The distinction this preserves is between a row that never carried the
-    marker and a row that carries one this code cannot read. Only the first is
-    a legacy row that has to be judged by the other checks; the second names a
-    stop-and-liveness protocol living somewhere else, and is exactly the case
-    every caller here refuses.
-
-    An ``isinstance(mode, str)`` test at the call site collapses the two, and
-    it collapses them in the permissive direction: a mode recorded as a number
-    or a nested object reads as absent, and the row is then treated as an
-    ordinary local one whose pid can be signalled and whose silence can be
-    read as death. So the type check happens here, once, and a present
-    non-string comes back as `UNRECOGNIZED_IDENTITY_MODE` rather than as None.
-
-    Absence is decided by whether the key is there, not by whether its value
-    is None. A row carrying an explicit null is a row that recorded something
-    this code cannot read, which is the second case and not the first, and
-    reading the value alone puts exactly that row back on the permissive
-    branch the paragraph above exists to close.
-    """
+    """The run's recorded process identity mode; missing key is None (legacy row), present-but-non-string is `UNRECOGNIZED_IDENTITY_MODE` rather than None so it gets refused, not treated as an ordinary local row."""
     if not isinstance(metadata, dict):
         return None
     if "process_identity_mode" not in metadata:
@@ -228,27 +172,15 @@ _LOCALLY_JUDGEABLE_MODES = ("local", "in_process")
 
 
 def recorded_row_is_foreign(metadata: dict[str, Any] | None) -> bool:
-    """Whether this host has any standing to judge a row's recorded process.
-
-    Mode first, then host: the host check may read an unreadable marker as
-    "none recorded", which is only safe once an alien mode has been refused.
-    Callers want this, not ``recorded_pid_is_foreign`` alone.
-    """
+    """Whether this host has any standing to judge a row's recorded process; mode is checked before pid, since an unreadable host marker is only safe to treat as absent once an alien mode has been refused."""
     mode = recorded_identity_mode(metadata)
     if mode is not None and mode not in _LOCALLY_JUDGEABLE_MODES:
         return True
     return recorded_pid_is_foreign(metadata)
 
 
-# Boot time is read from the OS on each side of the comparison and can drift by
-# a little across clock adjustments and suspend/resume cycles. A real reboot
-# moves it by far more than this, so the tolerance costs nothing and avoids
-# reading jitter as a reboot.
-#
-# It lives here, beside the host check, rather than next to either caller,
-# because both the kill path and the liveness probe answer the same question
-# about the same recorded value. Two copies of a number that has to agree is
-# how one of them ends up being a process create-time tolerance instead.
+# Boot time drifts a little across clock adjustments/suspend-resume; a real
+# reboot moves it by far more, so this absorbs jitter without missing reboots.
 BOOT_TIME_TOLERANCE = 5.0
 
 

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import socket
 import threading
 from collections.abc import Sequence
 from pathlib import Path
@@ -142,6 +143,75 @@ def pid_alive(pid: int) -> bool:
         return True
     except OSError:
         return False
+
+
+def recorded_pid_is_foreign(metadata: dict[str, Any] | None) -> bool:
+    """Whether a run's recorded pid belongs to a different machine.
+
+    A pid is only a name inside one host's pid space. When several hosts share
+    a state store, every local check applied to a remote row answers about
+    whichever unrelated local process happens to hold that number: it reads as
+    a real answer, and it is about the wrong process. So this is asked before
+    any pid on such a row is signalled or believed.
+
+    Absence of ``pid_host`` is not foreignness. Rows written before the marker
+    existed cannot be placed either way, and treating "unknown origin" as
+    "another machine" would stop every one of them from being cancelled or
+    swept. The callers that go on to act still have their own identity checks;
+    this only removes the rows where those checks could not mean anything.
+    """
+    if not isinstance(metadata, dict):
+        return False
+    host = metadata.get("pid_host")
+    return isinstance(host, str) and bool(host) and host != socket.gethostname()
+
+
+# Stands in for a recorded identity mode that is present but not a string.
+# Deliberately a string, so every caller's "is this a mode I know" comparison
+# keeps working unchanged, and deliberately one no writer produces.
+UNRECOGNIZED_IDENTITY_MODE = "<unrecognized>"
+
+
+def recorded_identity_mode(metadata: dict[str, Any] | None) -> str | None:
+    """The run's recorded process identity mode, or None if none was recorded.
+
+    The distinction this preserves is between a row that never carried the
+    marker and a row that carries one this code cannot read. Only the first is
+    a legacy row that has to be judged by the other checks; the second names a
+    stop-and-liveness protocol living somewhere else, and is exactly the case
+    every caller here refuses.
+
+    An ``isinstance(mode, str)`` test at the call site collapses the two, and
+    it collapses them in the permissive direction: a mode recorded as a number
+    or a nested object reads as absent, and the row is then treated as an
+    ordinary local one whose pid can be signalled and whose silence can be
+    read as death. So the type check happens here, once, and a present
+    non-string comes back as `UNRECOGNIZED_IDENTITY_MODE` rather than as None.
+
+    Absence is decided by whether the key is there, not by whether its value
+    is None. A row carrying an explicit null is a row that recorded something
+    this code cannot read, which is the second case and not the first, and
+    reading the value alone puts exactly that row back on the permissive
+    branch the paragraph above exists to close.
+    """
+    if not isinstance(metadata, dict):
+        return None
+    if "process_identity_mode" not in metadata:
+        return None
+    mode = metadata["process_identity_mode"]
+    return mode if isinstance(mode, str) else UNRECOGNIZED_IDENTITY_MODE
+
+
+# Boot time is read from the OS on each side of the comparison and can drift by
+# a little across clock adjustments and suspend/resume cycles. A real reboot
+# moves it by far more than this, so the tolerance costs nothing and avoids
+# reading jitter as a reboot.
+#
+# It lives here, beside the host check, rather than next to either caller,
+# because both the kill path and the liveness probe answer the same question
+# about the same recorded value. Two copies of a number that has to agree is
+# how one of them ends up being a process create-time tolerance instead.
+BOOT_TIME_TOLERANCE = 5.0
 
 
 _SEARCH_ORDER = ("sessions", "invocations", "plays", "shows")

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -159,6 +159,29 @@ def recorded_pid_is_foreign(metadata: dict[str, Any] | None) -> bool:
     "another machine" would stop every one of them from being cancelled or
     swept. The callers that go on to act still have their own identity checks;
     this only removes the rows where those checks could not mean anything.
+
+    A value that is present but unreadable -- empty, or not a string -- reads
+    the same way, as no host recorded, which is worth stating because the
+    neighbouring identity-mode reader deliberately does the opposite. It can
+    tell a row it does not understand from a row that predates it, and refuses
+    the first. The difference is that a mode has several legitimate spellings
+    and gains more over time, so an unrecognized one plausibly names a protocol
+    written by something newer. A host does not: this marker is written in one
+    place, always from ``socket.gethostname()``, so no writer past or present
+    emits a malformed one and an unreadable value names nothing to defer to.
+
+    What makes that safe is not the marker. A row that announces an identity
+    mode this code does not know is refused before the host is consulted at
+    all, so a genuinely alien writer never reaches this question. What remains
+    is a row claiming a local mode whose pid happens to match a live local pid,
+    and the recorded creation time is what answers that -- it rejects the
+    coincidence whatever the host field says, which is the check that has to
+    hold for this one to be a fast path rather than a guarantee.
+
+    Nor is a self-reported host a trust boundary. Nothing here authenticates a
+    hostname, so a row claiming this machine's name is indistinguishable from
+    one written on it. This removes rows whose local answer would be
+    meaningless; it does not defend against a writer that lies.
     """
     if not isinstance(metadata, dict):
         return False

--- a/lionagi/cli/_util.py
+++ b/lionagi/cli/_util.py
@@ -225,6 +225,31 @@ def recorded_identity_mode(metadata: dict[str, Any] | None) -> str | None:
     return mode if isinstance(mode, str) else UNRECOGNIZED_IDENTITY_MODE
 
 
+# Modes whose stop-and-liveness protocol is this one: a pid in this host's pid
+# space, signalled directly. Anything else names a protocol living elsewhere.
+_LOCALLY_JUDGEABLE_MODES = ("local", "in_process")
+
+
+def recorded_row_is_foreign(metadata: dict[str, Any] | None) -> bool:
+    """Whether a row's recorded process is one this host has no standing to judge.
+
+    Both questions, in this order, because the order is what makes each answer
+    safe. A row announcing an identity mode this code does not recognize names
+    a stop-and-liveness protocol living somewhere else, and is refused outright.
+    Only then is the host asked, and ``recorded_pid_is_foreign`` is allowed to
+    read an unreadable host marker as "no host recorded" precisely because a
+    row written by something alien has already been turned away by the mode.
+
+    This is the form every caller wants. Asking the host question alone inherits
+    that permissive reading without the refusal that pays for it, which is a
+    quiet way to get a row judged on a local pid that was never local.
+    """
+    mode = recorded_identity_mode(metadata)
+    if mode is not None and mode not in _LOCALLY_JUDGEABLE_MODES:
+        return True
+    return recorded_pid_is_foreign(metadata)
+
+
 # Boot time is read from the OS on each side of the comparison and can drift by
 # a little across clock adjustments and suspend/resume cycles. A real reboot
 # moves it by far more than this, so the tolerance costs nothing and avoids

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -19,6 +19,7 @@ from lionagi.state.db import PLAY_ACTIVE_STATUSES as _PLAY_ACTIVE_STATUSES
 from ._logging import log_error, warn
 from ._util import _TABLE_TO_ENTITY_TYPE, AmbiguousIdError
 from ._util import pid_alive as _pid_alive
+from ._util import recorded_identity_mode as _recorded_identity_mode
 from ._util import recorded_row_is_foreign as _recorded_row_is_foreign
 from ._util import resolve_entity as _resolve_entity
 
@@ -408,6 +409,11 @@ async def _persist_cancel(
         pass
 
 
+# Outcomes where nothing was signalled and nothing was persisted, so reporting
+# them as kills would claim work that did not happen.
+_NOT_A_KILL = ("identity_mismatch", "foreign_host")
+
+
 async def _kill_one(
     db: Any,
     entity_type: str,
@@ -423,22 +429,32 @@ async def _kill_one(
 
     pid = _read_pid_from_entity(row)
     signal_used = "no_pid"
+    meta = row.get("node_metadata") if isinstance(row.get("node_metadata"), dict) else {}
+
+    # Foreignness is a property of the row, not of whether it recorded a pid.
+    # Signalling would hit an unrelated local process, and cancelling would
+    # report a kill that never happened — which is what a foreign row carrying
+    # no pid used to get, having skipped this guard entirely.
+    if _recorded_row_is_foreign(meta):
+        host = meta.get("pid_host")
+        where = (
+            repr(host)
+            if isinstance(host, str) and host
+            else f"identity mode {_recorded_identity_mode(meta)!r}"
+        )
+        subject = f"pid {pid}" if pid is not None else "the run"
+        warn(
+            f"  {entity_type} {entity_id[:12]}: {subject} was recorded under "
+            f"{where}, which this host cannot judge — kill skipped"
+        )
+        return {
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "signal": "foreign_host",
+            "pid": pid,
+        }
 
     if pid is not None:
-        meta = row.get("node_metadata") if isinstance(row.get("node_metadata"), dict) else {}
-        if _recorded_row_is_foreign(meta):
-            # Another host's pid space: signalling it would hit an unrelated
-            # local process, and cancelling would report a kill that never was.
-            warn(
-                f"  {entity_type} {entity_id[:12]}: pid {pid} was recorded on "
-                f"{meta.get('pid_host')!r}, not this host — kill skipped"
-            )
-            return {
-                "entity_type": entity_type,
-                "entity_id": entity_id,
-                "signal": "foreign_host",
-                "pid": pid,
-            }
         expected_session_id = entity_id if entity_type == "session" else None
         raw_ct = meta.get("pid_create_time")
         try:
@@ -580,7 +596,7 @@ async def _do_kill(
                     verbose=verbose,
                 )
                 results.append(r)
-                if r["signal"] == "identity_mismatch":
+                if r["signal"] in _NOT_A_KILL:
                     blocked.append(r)
                 else:
                     print(
@@ -597,7 +613,7 @@ async def _do_kill(
             verbose=verbose,
         )
         results.append(r)
-        if r["signal"] == "identity_mismatch":
+        if r["signal"] in _NOT_A_KILL:
             blocked.append(r)
         else:
             print(f"killed {entity_type} {row['id'][:12]} (signal={r['signal']}, pid={r['pid']})")

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import os
 import signal
+import socket
 import time
 from typing import Any, Literal
 
@@ -45,10 +46,22 @@ def _read_pid_from_entity(entity: dict[str, Any]) -> int | None:
 
 
 def current_pid_markers() -> dict[str, Any]:
-    """PID + create_time for the current process, for kill verification (CWE-362)."""
+    """PID + create_time + host for the current process, for kill verification (CWE-362).
+
+    The host travels with the pid because a pid is only a name inside one
+    machine's pid space. Readers that decide whether a recorded pid may be
+    signalled, or whether its silence means death, ask whether the row came
+    from somewhere else; they can only answer that for rows that say where
+    they came from. Recording it here, beside the pid it qualifies, is what
+    makes those readers able to answer at all.
+
+    A row that predates this marker records no host and stays on the path for
+    rows whose origin cannot be placed, which is the existing behaviour.
+    """
     return {
         "pid": os.getpid(),
         "pid_create_time": psutil.Process(os.getpid()).create_time(),
+        "pid_host": socket.gethostname(),
     }
 
 

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -47,18 +47,7 @@ def _read_pid_from_entity(entity: dict[str, Any]) -> int | None:
 
 
 def current_pid_markers() -> dict[str, Any]:
-    """PID + create_time + host for the current process, for kill verification (CWE-362).
-
-    The host travels with the pid because a pid is only a name inside one
-    machine's pid space. Readers that decide whether a recorded pid may be
-    signalled, or whether its silence means death, ask whether the row came
-    from somewhere else; they can only answer that for rows that say where
-    they came from. Recording it here, beside the pid it qualifies, is what
-    makes those readers able to answer at all.
-
-    A row that predates this marker records no host and stays on the path for
-    rows whose origin cannot be placed, which is the existing behaviour.
-    """
+    """PID + create_time + host for the current process, for kill verification (CWE-362); the host travels with the pid since a pid is only a name inside one machine's pid space."""
     return {
         "pid": os.getpid(),
         "pid_create_time": psutil.Process(os.getpid()).create_time(),

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -438,11 +438,8 @@ async def _kill_one(
     if pid is not None:
         meta = row.get("node_metadata") if isinstance(row.get("node_metadata"), dict) else {}
         if _recorded_row_is_foreign(meta):
-            # This pid names a process in another host's pid space. Signalling
-            # it would aim at whatever unrelated local process holds that
-            # number, and recording a cancellation would report a kill that
-            # never happened to a run still going on the machine that owns it.
-            # Refused for the same reason an identity mismatch is.
+            # Another host's pid space: signalling it would hit an unrelated
+            # local process, and cancelling would report a kill that never was.
             warn(
                 f"  {entity_type} {entity_id[:12]}: pid {pid} was recorded on "
                 f"{meta.get('pid_host')!r}, not this host — kill skipped"
@@ -708,12 +705,8 @@ async def _do_kill_all_stale(
                     continue
 
                 pid = _read_pid_from_entity(row_dict)
-                # Asked before liveness, not inside it, because a remote row's
-                # pid is normally absent from this host and absence is what the
-                # sweep reads as dead. Judged on the liveness branch this check
-                # would never run for exactly the rows it exists to protect,
-                # and every row from another machine would be cancelled here
-                # while its process kept running there.
+                # Before liveness: a remote row's pid is absent here, and the
+                # sweep reads absence as dead.
                 if _recorded_row_is_foreign(
                     row_dict.get("node_metadata")
                     if isinstance(row_dict.get("node_metadata"), dict)

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -19,6 +19,7 @@ from lionagi.state.db import PLAY_ACTIVE_STATUSES as _PLAY_ACTIVE_STATUSES
 from ._logging import log_error, warn
 from ._util import _TABLE_TO_ENTITY_TYPE, AmbiguousIdError
 from ._util import pid_alive as _pid_alive
+from ._util import recorded_row_is_foreign as _recorded_row_is_foreign
 from ._util import resolve_entity as _resolve_entity
 
 
@@ -436,6 +437,22 @@ async def _kill_one(
 
     if pid is not None:
         meta = row.get("node_metadata") if isinstance(row.get("node_metadata"), dict) else {}
+        if _recorded_row_is_foreign(meta):
+            # This pid names a process in another host's pid space. Signalling
+            # it would aim at whatever unrelated local process holds that
+            # number, and recording a cancellation would report a kill that
+            # never happened to a run still going on the machine that owns it.
+            # Refused for the same reason an identity mismatch is.
+            warn(
+                f"  {entity_type} {entity_id[:12]}: pid {pid} was recorded on "
+                f"{meta.get('pid_host')!r}, not this host — kill skipped"
+            )
+            return {
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "signal": "foreign_host",
+                "pid": pid,
+            }
         expected_session_id = entity_id if entity_type == "session" else None
         raw_ct = meta.get("pid_create_time")
         try:
@@ -654,6 +671,7 @@ async def _do_kill_all_stale(
     skipped_live = 0
     skipped_recent = 0
     skipped_unverifiable = 0
+    skipped_foreign = 0
     skipped_unlinked_plays = 0
     unverifiable_tracked = 0
 
@@ -690,6 +708,24 @@ async def _do_kill_all_stale(
                     continue
 
                 pid = _read_pid_from_entity(row_dict)
+                # Asked before liveness, not inside it, because a remote row's
+                # pid is normally absent from this host and absence is what the
+                # sweep reads as dead. Judged on the liveness branch this check
+                # would never run for exactly the rows it exists to protect,
+                # and every row from another machine would be cancelled here
+                # while its process kept running there.
+                if _recorded_row_is_foreign(
+                    row_dict.get("node_metadata")
+                    if isinstance(row_dict.get("node_metadata"), dict)
+                    else {}
+                ):
+                    skipped_foreign += 1
+                    if verbose:
+                        print(
+                            f"  skip {entity_type} {entity_id[:12]}: pid recorded on another host"
+                        )
+                    continue
+
                 # A live pid alone isn't enough — the OS may have reused it.
                 # Correlate against the row's own session id/create_time (same
                 # fields the direct-kill path uses) so a recycled pid occupied
@@ -913,6 +949,7 @@ async def _do_kill_all_stale(
         f"\n{prefix} {killed} stale entities "
         f"[skipped_recent={skipped_recent}, skipped_live_pid={skipped_live}, "
         f"skipped_unverifiable_pid={skipped_unverifiable}, "
+        f"skipped_foreign_host={skipped_foreign}, "
         f"skipped_unlinked_plays={skipped_unlinked_plays}]"
     )
     if unverifiable_tracked:

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -1116,7 +1116,7 @@ async def _doctor(
 
     from sqlalchemy import text
 
-    from lionagi.cli._util import pid_alive
+    from lionagi.cli._util import pid_alive, recorded_row_is_foreign
     from lionagi.cli.kill import _check_pid_identity, _read_pid_from_entity
 
     async with StateDB() as db:
@@ -1152,6 +1152,14 @@ async def _doctor(
                 except ValueError:
                     meta = None
             entity["node_metadata"] = meta if isinstance(meta, dict) else None
+            if recorded_row_is_foreign(entity["node_metadata"]):
+                # Asked before liveness for the same reason the stale sweep
+                # asks before it: a row recorded on another machine has no pid
+                # here, and this loop reads a pid it cannot find as reapable.
+                # Inside the liveness branch the check would never run for the
+                # rows it exists to protect.
+                skipped += 1
+                continue
             pid = _read_pid_from_entity(entity)
             if pid is not None and pid_alive(pid):
                 # A live PID alone isn't proof: the OS can hand a dead session's

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -1153,11 +1153,8 @@ async def _doctor(
                     meta = None
             entity["node_metadata"] = meta if isinstance(meta, dict) else None
             if recorded_row_is_foreign(entity["node_metadata"]):
-                # Asked before liveness for the same reason the stale sweep
-                # asks before it: a row recorded on another machine has no pid
-                # here, and this loop reads a pid it cannot find as reapable.
-                # Inside the liveness branch the check would never run for the
-                # rows it exists to protect.
+                # Before liveness: a remote row has no pid here, and a pid
+                # this loop cannot find reads as reapable.
                 skipped += 1
                 continue
             pid = _read_pid_from_entity(entity)

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -290,6 +290,7 @@ async def mirror_session(
                 "project": project,
                 "project_source": project_source,
                 "artifacts_path": cwd,
+                "node_metadata": {"process_identity_mode": "external"},
                 "started_at": first_ts,
                 "updated_at": last_ts,
             }

--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -498,6 +498,7 @@ async def mirror_session(
     await db.create_progression(bprog)
     if existing is None:
         meta = dict(node_metadata or {})
+        meta.setdefault("process_identity_mode", "external")
         meta[_IMPORT_KEY] = _import_block(source_path, tally)
         if terminal_provider_error is not None:
             meta[MIRROR_PROVIDER_ERROR_KEY] = terminal_provider_error

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -411,7 +411,7 @@ def process_identity_is_foreign(session: dict[str, Any]) -> bool:
     somewhere this daemon cannot see. With a shared state store that turns
     into one host marking another host's working runs failed.
     """
-    from lionagi.cli._util import recorded_identity_mode, recorded_pid_is_foreign
+    from lionagi.cli._util import recorded_row_is_foreign
 
     meta = session.get("node_metadata")
     if isinstance(meta, str):
@@ -422,16 +422,14 @@ def process_identity_is_foreign(session: dict[str, Any]) -> bool:
     if not isinstance(meta, dict):
         return False
 
-    mode = recorded_identity_mode(meta)
-    if mode is not None and mode not in ("local", "in_process"):
-        return True
-
+    # Mode first, then host, both in `recorded_row_is_foreign` so the CLI
+    # reapers ask the same composed question rather than a weaker half of it.
     # Asked of the host alone, not of "host and a readable pid": a row from
     # another machine is that machine's business whether or not its pid
     # parses, and the pid-less fallback in process_liveness matches on session
     # id against *this* host's process table, which reads the wrong machine's
     # answer just as confidently.
-    return recorded_pid_is_foreign(meta)
+    return recorded_row_is_foreign(meta)
 
 
 def process_liveness(

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 import os
+import socket
 import sqlite3
 import subprocess
 import threading
@@ -394,6 +395,46 @@ _PID_CREATE_TIME_TOLERANCE = 1.0
 HEALTH_SCAN_LIMIT = 500
 
 
+def process_identity_is_foreign(session: dict[str, Any]) -> bool:
+    """Whether this machine could not observe the run's process even in principle.
+
+    True when the row records a host that is not this one, or an identity mode
+    this code does not know how to check. Both mean the same thing: nothing
+    measurable here bears on whether that run is alive.
+
+    ``process_liveness`` already answers ``None`` for these, which is correct
+    as an answer to "is it alive". The reapers need the distinction because
+    they read a non-``True`` liveness as evidence of death once the row has
+    gone stale, and lean on the staleness grace to keep a merely quiet run
+    safe. That grace is protection against a *momentary* blind spot. Being on
+    another machine is a permanent one, so waiting adds no information and the
+    row is reaped precisely because it is healthy enough to keep running
+    somewhere this daemon cannot see. With a shared state store that turns
+    into one host marking another host's working runs failed.
+    """
+    from lionagi.cli._util import recorded_identity_mode, recorded_pid_is_foreign
+
+    meta = session.get("node_metadata")
+    if isinstance(meta, str):
+        try:
+            meta = json.loads(meta)
+        except ValueError:
+            return False
+    if not isinstance(meta, dict):
+        return False
+
+    mode = recorded_identity_mode(meta)
+    if mode is not None and mode not in ("local", "in_process"):
+        return True
+
+    # Asked of the host alone, not of "host and a readable pid": a row from
+    # another machine is that machine's business whether or not its pid
+    # parses, and the pid-less fallback in process_liveness matches on session
+    # id against *this* host's process table, which reads the wrong machine's
+    # answer just as confidently.
+    return recorded_pid_is_foreign(meta)
+
+
 def process_liveness(
     session: dict[str, Any],
     artifacts_path: Path | None,
@@ -403,6 +444,9 @@ def process_liveness(
     dead, None = unknown (no recorded pid/no process match)."""
     pid: int | None = None
     create_time: float | None = None
+    pid_host: str | None = None
+    pid_boot_time: float | None = None
+    identity_mode: str | None = None
 
     meta = session.get("node_metadata")
     if isinstance(meta, str):
@@ -411,15 +455,61 @@ def process_liveness(
         except ValueError:
             meta = None
     if isinstance(meta, dict):
-        raw_pid = meta.get("pid")
+        from lionagi.cli._util import recorded_identity_mode
+
+        identity_mode = recorded_identity_mode(meta)
+        # An in-process run has no process of its own; it records the process
+        # hosting it under separate keys, deliberately not "pid", so that the
+        # kill path cannot mistake the host for the run's own process. The
+        # host still bounds the run's liveness: if it is gone, the run is.
+        in_process = identity_mode == "in_process"
+        raw_pid = meta.get("host_pid" if in_process else "pid")
         if raw_pid is not None:
             try:
                 pid = int(raw_pid)
             except (TypeError, ValueError):
                 pid = None
-        raw_ct = meta.get("pid_create_time")
+        raw_ct = meta.get("host_pid_create_time" if in_process else "pid_create_time")
         if isinstance(raw_ct, int | float):
             create_time = float(raw_ct)
+        raw_host = meta.get("pid_host")
+        if isinstance(raw_host, str):
+            pid_host = raw_host
+        raw_boot = meta.get("pid_boot_time")
+        if isinstance(raw_boot, int | float):
+            pid_boot_time = float(raw_boot)
+
+    if identity_mode not in (None, "local", "in_process"):
+        return None
+    if pid is not None and pid_host is not None and pid_host != socket.gethostname():
+        return None
+    if pid is not None and pid_boot_time is not None:
+        rebooted_since = False
+        try:
+            import psutil
+
+            from lionagi.cli._util import BOOT_TIME_TOLERANCE
+
+            # Boot-time drift needs its own tolerance, not the process
+            # create-time one. Create times are compared against a value the
+            # kernel fixed when the process started, so a second is generous
+            # there. Boot time is re-derived from the current clock on every
+            # read, so an NTP step or a suspend/resume moves it by more than a
+            # second on a machine that never rebooted — and reading that as a
+            # reboot reports a healthy local session as dead, which is what
+            # the lifecycle reapers act on.
+            rebooted_since = abs(psutil.boot_time() - pid_boot_time) > BOOT_TIME_TOLERANCE
+        except Exception:
+            # Failing to read the boot time leaves this one check unevaluated;
+            # it does not make the run unknowable. Answering "unknown" here
+            # would be worse than not having the check at all: the lifecycle
+            # reapers read any non-True liveness as death once the row goes
+            # stale, so a machine where this read keeps failing would reap
+            # every live session it has. The pid checks below still run, which
+            # is the same best-effort stance the status/start-time read takes.
+            _log.debug("boot-time comparison for pid %s failed", pid, exc_info=True)
+        if rebooted_since:
+            return False
 
     if pid is None and artifacts_path is not None and artifacts_path.exists():
         pid = _find_pid_file(artifacts_path)
@@ -692,6 +782,11 @@ def _classify_phantom(
     session = {"id": row["id"], "node_metadata": node_metadata}
     # A running session is never a phantom while its process is observably alive.
     if process_liveness(session, ap, ps_snapshot) is True:
+        return None
+    # Nor when the process is not this machine's to observe: the staleness
+    # grace below cannot rescue a row whose liveness is permanently invisible
+    # here, so without this a healthy run on another host reaps as dead.
+    if process_identity_is_foreign(session):
         return None
     # Not yet stale: it may simply not have written artifacts yet, so give it
     # the benefit of the doubt rather than reap a fresh/quiet session.

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -395,22 +395,7 @@ HEALTH_SCAN_LIMIT = 500
 
 
 def process_identity_is_foreign(session: dict[str, Any]) -> bool:
-    """Whether this machine could not observe the run's process even in principle.
-
-    True when the row records a host that is not this one, or an identity mode
-    this code does not know how to check. Both mean the same thing: nothing
-    measurable here bears on whether that run is alive.
-
-    ``process_liveness`` already answers ``None`` for these, which is correct
-    as an answer to "is it alive". The reapers need the distinction because
-    they read a non-``True`` liveness as evidence of death once the row has
-    gone stale, and lean on the staleness grace to keep a merely quiet run
-    safe. That grace is protection against a *momentary* blind spot. Being on
-    another machine is a permanent one, so waiting adds no information and the
-    row is reaped precisely because it is healthy enough to keep running
-    somewhere this daemon cannot see. With a shared state store that turns
-    into one host marking another host's working runs failed.
-    """
+    """Whether this machine could not observe the run's process even in principle, so a reaper must not read its silence as death."""
     from lionagi.cli._util import recorded_row_is_foreign
 
     meta = session.get("node_metadata")
@@ -422,13 +407,8 @@ def process_identity_is_foreign(session: dict[str, Any]) -> bool:
     if not isinstance(meta, dict):
         return False
 
-    # Mode first, then host, both in `recorded_row_is_foreign` so the CLI
-    # reapers ask the same composed question rather than a weaker half of it.
-    # Asked of the host alone, not of "host and a readable pid": a row from
-    # another machine is that machine's business whether or not its pid
-    # parses, and the pid-less fallback in process_liveness matches on session
-    # id against *this* host's process table, which reads the wrong machine's
-    # answer just as confidently.
+    # Host is asked alone, never "host and a readable pid": the pid-less
+    # fallback below matches on session id against this host's own process table.
     return recorded_row_is_foreign(meta)
 
 
@@ -454,10 +434,8 @@ def process_liveness(
         from lionagi.cli._util import recorded_identity_mode
 
         identity_mode = recorded_identity_mode(meta)
-        # An in-process run has no process of its own; it records the process
-        # hosting it under separate keys, deliberately not "pid", so that the
-        # kill path cannot mistake the host for the run's own process. The
-        # host still bounds the run's liveness: if it is gone, the run is.
+        # An in-process run has no process of its own; it records the host
+        # process under separate keys so the kill path can't mistake the two.
         in_process = identity_mode == "in_process"
         raw_pid = meta.get("host_pid" if in_process else "pid")
         if raw_pid is not None:
@@ -475,20 +453,8 @@ def process_liveness(
     if identity_mode not in (None, "local", "in_process"):
         return None
 
-    # Asked of the host alone, never of "host and a readable pid". Gating it on
-    # a parsed pid left two ways for a remote row to be answered locally.
-    #
-    # A row whose pid does not parse skipped the question entirely and then
-    # reached the artifacts fallback below, which resolves a pid against *this*
-    # machine's process table. Another host's row could pick up a local pid
-    # that way and be reported alive by a machine that cannot see it.
-    #
-    # And an empty pid_host read here as "a host that is not mine" while the
-    # reapers' foreign-row guard read the same value as "no host recorded". A
-    # live row sat in the gap: not foreign enough to be protected, foreign
-    # enough to be answered unknown, and a non-True answer becomes death once
-    # the row goes stale. Both readings now come from one predicate, so they
-    # cannot disagree about a value neither of them was written for.
+    # Asked of the host alone, never "host and a readable pid" -- a pid that
+    # fails to parse must not fall through to the local-machine pid fallback below.
     from lionagi.cli._util import recorded_pid_is_foreign
 
     if recorded_pid_is_foreign(meta if isinstance(meta, dict) else None):
@@ -500,23 +466,12 @@ def process_liveness(
 
             from lionagi.cli._util import BOOT_TIME_TOLERANCE
 
-            # Boot-time drift needs its own tolerance, not the process
-            # create-time one. Create times are compared against a value the
-            # kernel fixed when the process started, so a second is generous
-            # there. Boot time is re-derived from the current clock on every
-            # read, so an NTP step or a suspend/resume moves it by more than a
-            # second on a machine that never rebooted — and reading that as a
-            # reboot reports a healthy local session as dead, which is what
-            # the lifecycle reapers act on.
+            # Boot time is re-derived from the clock each read, so it needs its
+            # own (looser) tolerance than the process create-time comparison.
             rebooted_since = abs(psutil.boot_time() - pid_boot_time) > BOOT_TIME_TOLERANCE
         except Exception:
-            # Failing to read the boot time leaves this one check unevaluated;
-            # it does not make the run unknowable. Answering "unknown" here
-            # would be worse than not having the check at all: the lifecycle
-            # reapers read any non-True liveness as death once the row goes
-            # stale, so a machine where this read keeps failing would reap
-            # every live session it has. The pid checks below still run, which
-            # is the same best-effort stance the status/start-time read takes.
+            # A failed boot-time read leaves this check unevaluated, not the run
+            # unknowable -- the pid checks below still run.
             _log.debug("boot-time comparison for pid %s failed", pid, exc_info=True)
         if rebooted_since:
             return False
@@ -794,8 +749,7 @@ def _classify_phantom(
     if process_liveness(session, ap, ps_snapshot) is True:
         return None
     # Nor when the process is not this machine's to observe: the staleness
-    # grace below cannot rescue a row whose liveness is permanently invisible
-    # here, so without this a healthy run on another host reaps as dead.
+    # grace can't rescue a run whose liveness is permanently invisible here.
     if process_identity_is_foreign(session):
         return None
     # Not yet stale: it may simply not have written artifacts yet, so give it

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -7,7 +7,6 @@ import asyncio
 import json
 import logging
 import os
-import socket
 import sqlite3
 import subprocess
 import threading
@@ -444,7 +443,6 @@ def process_liveness(
     dead, None = unknown (no recorded pid/no process match)."""
     pid: int | None = None
     create_time: float | None = None
-    pid_host: str | None = None
     pid_boot_time: float | None = None
     identity_mode: str | None = None
 
@@ -472,16 +470,30 @@ def process_liveness(
         raw_ct = meta.get("host_pid_create_time" if in_process else "pid_create_time")
         if isinstance(raw_ct, int | float):
             create_time = float(raw_ct)
-        raw_host = meta.get("pid_host")
-        if isinstance(raw_host, str):
-            pid_host = raw_host
         raw_boot = meta.get("pid_boot_time")
         if isinstance(raw_boot, int | float):
             pid_boot_time = float(raw_boot)
 
     if identity_mode not in (None, "local", "in_process"):
         return None
-    if pid is not None and pid_host is not None and pid_host != socket.gethostname():
+
+    # Asked of the host alone, never of "host and a readable pid". Gating it on
+    # a parsed pid left two ways for a remote row to be answered locally.
+    #
+    # A row whose pid does not parse skipped the question entirely and then
+    # reached the artifacts fallback below, which resolves a pid against *this*
+    # machine's process table. Another host's row could pick up a local pid
+    # that way and be reported alive by a machine that cannot see it.
+    #
+    # And an empty pid_host read here as "a host that is not mine" while the
+    # reapers' foreign-row guard read the same value as "no host recorded". A
+    # live row sat in the gap: not foreign enough to be protected, foreign
+    # enough to be answered unknown, and a non-True answer becomes death once
+    # the row goes stale. Both readings now come from one predicate, so they
+    # cannot disagree about a value neither of them was written for.
+    from lionagi.cli._util import recorded_pid_is_foreign
+
+    if recorded_pid_is_foreign(meta if isinstance(meta, dict) else None):
         return None
     if pid is not None and pid_boot_time is not None:
         rebooted_since = False

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -238,9 +238,7 @@ async def reap_null_status_sessions(*, stale_hours: float | None = None) -> int:
                 # Process still alive — skip, it may write its own status.
                 continue
             if process_identity_is_foreign(session):
-                # Hosted on another machine: nothing observable here says
-                # whether it is alive, and the staleness grace below cannot
-                # supply that, so reaping it would guess.
+                # Hosted elsewhere: nothing observable here says it's dead, so reaping would guess.
                 continue
 
             updated_at = row.get("updated_at") or row.get("started_at") or 0.0
@@ -453,10 +451,7 @@ async def reap_stale_plays(*, stale_hours: float | None = None) -> int:
                             session = {"id": srow["id"], "node_metadata": srow.get("node_metadata")}
                             if await _resolve_liveness(session, _artifacts_path(srow)) is True:
                                 continue
-                            # Child session hosted elsewhere: this machine
-                            # cannot tell a dead runner from a working one, so
-                            # the play stays in flight rather than be blocked
-                            # on a blind guess.
+                            # Hosted elsewhere: can't tell dead from working, so stay in flight.
                             if process_identity_is_foreign(session):
                                 continue
 
@@ -707,10 +702,7 @@ async def reap_stale_shows(*, stale_hours: float | None = None) -> int:
                         if await _resolve_liveness(session, _artifacts_path(srow)) is True:
                             live = True
                             break
-                        # A child hosted on another machine is unmeasurable from
-                        # here, which is not the same as dead. Treated like a
-                        # live child so the show is left alone: the only honest
-                        # move when this daemon cannot see the process.
+                        # Unmeasurable is not dead: treated as live so the show is left alone.
                         if process_identity_is_foreign(session):
                             live = True
                             break

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -13,7 +13,12 @@ from lionagi.state.db import StateDB, state_db_known_absent
 from lionagi.state.reasons import RunReasons, SessionReasons, ShowReasons
 
 from . import admin as admin_svc
-from .admin import _artifacts_path, process_liveness, resolve_process_liveness_probe
+from .admin import (
+    _artifacts_path,
+    process_identity_is_foreign,
+    process_liveness,
+    resolve_process_liveness_probe,
+)
 from .shows import _SHOW_TERMINAL_STATUSES, _play_dirs
 from .shows import _read_json as _read_show_json
 
@@ -232,6 +237,11 @@ async def reap_null_status_sessions(*, stale_hours: float | None = None) -> int:
             if await _resolve_liveness(session, artifacts) is True:
                 # Process still alive — skip, it may write its own status.
                 continue
+            if process_identity_is_foreign(session):
+                # Hosted on another machine: nothing observable here says
+                # whether it is alive, and the staleness grace below cannot
+                # supply that, so reaping it would guess.
+                continue
 
             updated_at = row.get("updated_at") or row.get("started_at") or 0.0
             if now - updated_at < stale_seconds:
@@ -442,6 +452,12 @@ async def reap_stale_plays(*, stale_hours: float | None = None) -> int:
                         if srow is not None:
                             session = {"id": srow["id"], "node_metadata": srow.get("node_metadata")}
                             if await _resolve_liveness(session, _artifacts_path(srow)) is True:
+                                continue
+                            # Child session hosted elsewhere: this machine
+                            # cannot tell a dead runner from a working one, so
+                            # the play stays in flight rather than be blocked
+                            # on a blind guess.
+                            if process_identity_is_foreign(session):
                                 continue
 
                     updated_at_raw = row.get("updated_at")
@@ -689,6 +705,13 @@ async def reap_stale_shows(*, stale_hours: float | None = None) -> int:
                             continue
                         session = {"id": srow["id"], "node_metadata": srow.get("node_metadata")}
                         if await _resolve_liveness(session, _artifacts_path(srow)) is True:
+                            live = True
+                            break
+                        # A child hosted on another machine is unmeasurable from
+                        # here, which is not the same as dead. Treated like a
+                        # live child so the show is left alone: the only honest
+                        # move when this daemon cannot see the process.
+                        if process_identity_is_foreign(session):
                             live = True
                             break
                     if live:

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -223,11 +223,18 @@ async def list_runs(
     for s in sessions:
         alive: bool | None = None
         if s.get("status") == "running":
-            from .admin import resolve_process_liveness_probe
+            from .admin import process_identity_is_foreign, resolve_process_liveness_probe
 
-            alive = await resolve_process_liveness_probe(
-                lambda snapshot, row=s: _session_liveness(row, snapshot)
-            )
+            # A row recording another machine's process is left unknown without
+            # paying for the host scan to say so. The scan reads this machine's
+            # process table, so the answer is None whether or not it is taken:
+            # skipping it changes the cost and not the verdict. A page of
+            # imported rows would otherwise trigger the very scan the
+            # targeted-first path exists to ration.
+            if not process_identity_is_foreign(s):
+                alive = await resolve_process_liveness_probe(
+                    lambda snapshot, row=s: _session_liveness(row, snapshot)
+                )
         out.append(_run_row(s, now, process_alive=alive))
 
     tagmap = await run_tags.tags_for_sessions([r["id"] for r in out])

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -225,12 +225,8 @@ async def list_runs(
         if s.get("status") == "running":
             from .admin import process_identity_is_foreign, resolve_process_liveness_probe
 
-            # A row recording another machine's process is left unknown without
-            # paying for the host scan to say so. The scan reads this machine's
-            # process table, so the answer is None whether or not it is taken:
-            # skipping it changes the cost and not the verdict. A page of
-            # imported rows would otherwise trigger the very scan the
-            # targeted-first path exists to ration.
+            # A foreign row is left unknown without paying for the host scan: the
+            # scan reads this machine's process table, so the answer is None either way.
             if not process_identity_is_foreign(s):
                 alive = await resolve_process_liveness_probe(
                     lambda snapshot, row=s: _session_liveness(row, snapshot)

--- a/tests/apps_studio_server/test_adversarial_reapers.py
+++ b/tests/apps_studio_server/test_adversarial_reapers.py
@@ -32,6 +32,7 @@ async def _seed_session(
     started_at: float | None = None,
     updated_at: float | None = None,
     artifacts_path: str | None = None,
+    node_metadata: dict | None = None,
 ) -> str:
     sid = str(uuid.uuid4())
     now = time.time()
@@ -45,6 +46,7 @@ async def _seed_session(
                 "name": "adv-test-session",
                 "status": status,
                 "started_at": started_at or now,
+                "node_metadata": node_metadata,
             }
         )
         updates: dict = {}
@@ -459,3 +461,138 @@ def test_1173_prune_preserves_recent_terminal_sessions(tmp_path, monkeypatch):
 
     assert result["sessions_pruned"] == 0
     assert run_async(_get_session_status(db_path, sid)) == "completed"
+
+
+# ── shared state store: rows this machine cannot see are not this machine's to judge ──
+
+
+def test_a_stale_session_hosted_on_another_machine_is_not_reaped(tmp_path, monkeypatch):
+    """A reaper reads this host's process table, so a remote row is unmeasurable here.
+
+    The reapers keep a session alive only on a positive liveness reading and
+    otherwise lean on a staleness grace to protect a merely quiet run. That
+    grace answers a momentary blind spot. Being on another machine is a
+    permanent one, so waiting supplies nothing and the row is reaped precisely
+    because it is still running somewhere this daemon cannot see.
+    """
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    import lionagi.studio.services.admin as admin_mod
+    import lionagi.studio.services.lifecycle as lc_mod
+
+    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+
+    stale_time = time.time() - 7200
+    remote = run_async(
+        _seed_session(
+            db_path,
+            status=None,
+            started_at=stale_time,
+            updated_at=stale_time,
+            node_metadata={"pid": 4242, "pid_host": "some-other-host"},
+        )
+    )
+    local = run_async(
+        _seed_session(
+            db_path,
+            status=None,
+            started_at=stale_time,
+            updated_at=stale_time,
+            node_metadata={"pid": 4243, "pid_host": "this-host"},
+        )
+    )
+
+    # Not patched to a constant: the real function has to be the thing that
+    # answers, or this test would pass against a liveness check that had
+    # stopped consulting the row at all.
+    assert lc_mod.process_liveness is admin_mod.process_liveness
+
+    from lionagi.studio.services.lifecycle import reap_null_status_sessions
+
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
+
+    assert run_async(_get_session_status(db_path, remote)) is None, (
+        "another host's row must be left exactly as it was"
+    )
+    assert run_async(_count_transitions(db_path, remote)) == 0
+    assert run_async(_get_session_status(db_path, local)) == "failed", (
+        "the local row must still be reaped — otherwise this passes on a dead reaper"
+    )
+    assert count == 1
+
+
+def test_phantom_classifier_returns_no_reason_for_another_machines_row(tmp_path, monkeypatch):
+    """The classifier that feeds the phantom reaper, checked directly.
+
+    Its verdict is what the reaper writes `failed` from, so the local row
+    beside it fixes what the answer would otherwise have been.
+    """
+    import lionagi.studio.services.admin as admin_mod
+
+    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+
+    now = time.time()
+    stale = now - 7200
+
+    def _row(meta: dict) -> dict:
+        return {
+            "id": str(uuid.uuid4()),
+            "updated_at": stale,
+            "artifacts_path": None,
+            "node_metadata": meta,
+        }
+
+    class _Row(dict):
+        def keys(self):  # noqa: D102 — sqlite3.Row-shaped access used by the classifier
+            return super().keys()
+
+    remote = _Row(_row({"pid": 4242, "pid_host": "some-other-host"}))
+    local = _Row(_row({"pid": 4242, "pid_host": "this-host"}))
+
+    monkeypatch.setattr(admin_mod, "_pid_is_live", lambda pid: False)
+
+    assert (
+        admin_mod._classify_phantom(remote, now=now, stale_seconds=3600, ps_snapshot="") is None
+    ), "another host's stale row must produce no phantom reason"
+    assert (
+        admin_mod._classify_phantom(local, now=now, stale_seconds=3600, ps_snapshot="")
+        == "process_dead"
+    ), "a local stale row with a dead pid must still classify — otherwise nothing is being tested"
+
+
+def test_process_identity_is_foreign_reads_host_and_unknown_modes(monkeypatch):
+    """Foreign means "not measurable here", which covers two distinct records."""
+    import lionagi.studio.services.admin as admin_mod
+
+    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+    foreign = admin_mod.process_identity_is_foreign
+
+    assert foreign({"node_metadata": {"pid_host": "other-host"}}) is True
+    assert foreign({"node_metadata": {"process_identity_mode": "external"}}) is True
+    # A mode this code does know how to check is not foreign on its own.
+    assert foreign({"node_metadata": {"process_identity_mode": "local"}}) is False
+    assert foreign({"node_metadata": {"process_identity_mode": "in_process"}}) is False
+    assert foreign({"node_metadata": {"pid_host": "this-host"}}) is False
+    assert foreign({"node_metadata": {"pid": 1}}) is False
+    assert foreign({"node_metadata": None}) is False
+    assert foreign({}) is False
+    # Stored as JSON text by some read paths; the same answer either way.
+    assert foreign({"node_metadata": '{"pid_host": "other-host"}'}) is True
+    assert foreign({"node_metadata": "not json at all"}) is False
+
+    # A marker recorded with the wrong type is still a marker, and it still
+    # names a mode this code cannot check. Read as an absent one it would put
+    # the row back in reach of the reapers, which treat a non-True liveness as
+    # death once the row goes stale.
+    assert foreign({"node_metadata": {"process_identity_mode": 123}}) is True
+    assert foreign({"node_metadata": {"process_identity_mode": {"kind": "remote"}}}) is True
+    # Absence keeps its own meaning, and absence is the key not being there.
+    # An old row predates the marker entirely, so that is the shape a legacy
+    # row actually has, and it is still judged by the host check.
+    assert foreign({"node_metadata": {}}) is False
+    # A key present and set to null is not that row. No writer here emits it:
+    # every site that records this key writes a string literal, so a null can
+    # only have come from somewhere this code does not control, which is the
+    # same "marker I cannot read" case as the wrong-typed values above.
+    assert foreign({"node_metadata": {"process_identity_mode": None}}) is True

--- a/tests/apps_studio_server/test_adversarial_reapers.py
+++ b/tests/apps_studio_server/test_adversarial_reapers.py
@@ -468,14 +468,7 @@ def test_1173_prune_preserves_recent_terminal_sessions(tmp_path, monkeypatch):
 
 
 def test_a_stale_session_hosted_on_another_machine_is_not_reaped(tmp_path, monkeypatch):
-    """A reaper reads this host's process table, so a remote row is unmeasurable here.
-
-    The reapers keep a session alive only on a positive liveness reading and
-    otherwise lean on a staleness grace to protect a merely quiet run. That
-    grace answers a momentary blind spot. Being on another machine is a
-    permanent one, so waiting supplies nothing and the row is reaped precisely
-    because it is still running somewhere this daemon cannot see.
-    """
+    """A reaper reads this host's process table, so a remote row is unmeasurable here and must not be reaped on a staleness grace meant for a momentary blind spot."""
     db_path = tmp_path / "state.db"
     _monkey_db(monkeypatch, db_path)
 
@@ -504,9 +497,7 @@ def test_a_stale_session_hosted_on_another_machine_is_not_reaped(tmp_path, monke
         )
     )
 
-    # Not patched to a constant: the real function has to be the thing that
-    # answers, or this test would pass against a liveness check that had
-    # stopped consulting the row at all.
+    # Not patched to a constant: the real function must be the thing answering.
     assert lc_mod.process_liveness is admin_mod.process_liveness
 
     from lionagi.studio.services.lifecycle import reap_null_status_sessions
@@ -524,11 +515,7 @@ def test_a_stale_session_hosted_on_another_machine_is_not_reaped(tmp_path, monke
 
 
 def test_phantom_classifier_returns_no_reason_for_another_machines_row(tmp_path, monkeypatch):
-    """The classifier that feeds the phantom reaper, checked directly.
-
-    Its verdict is what the reaper writes `failed` from, so the local row
-    beside it fixes what the answer would otherwise have been.
-    """
+    """The classifier that feeds the phantom reaper, checked directly against a local-row control."""
     import lionagi.studio.services.admin as admin_mod
 
     monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
@@ -582,18 +569,11 @@ def test_process_identity_is_foreign_reads_host_and_unknown_modes(monkeypatch):
     assert foreign({"node_metadata": '{"pid_host": "other-host"}'}) is True
     assert foreign({"node_metadata": "not json at all"}) is False
 
-    # A marker recorded with the wrong type is still a marker, and it still
-    # names a mode this code cannot check. Read as an absent one it would put
-    # the row back in reach of the reapers, which treat a non-True liveness as
-    # death once the row goes stale.
+    # A wrong-typed marker is still a marker naming an unchecked mode, not an absent one.
     assert foreign({"node_metadata": {"process_identity_mode": 123}}) is True
     assert foreign({"node_metadata": {"process_identity_mode": {"kind": "remote"}}}) is True
-    # Absence keeps its own meaning, and absence is the key not being there.
-    # An old row predates the marker entirely, so that is the shape a legacy
-    # row actually has, and it is still judged by the host check.
+    # Absence is the key not being there; a legacy row predating the marker is still host-checked.
     assert foreign({"node_metadata": {}}) is False
-    # A key present and set to null is not that row. No writer here emits it:
-    # every site that records this key writes a string literal, so a null can
-    # only have come from somewhere this code does not control, which is the
-    # same "marker I cannot read" case as the wrong-typed values above.
+    # An explicit null is not that row: every writer here emits a string literal, so
+    # null names an unreadable marker, same as the wrong-typed values above.
     assert foreign({"node_metadata": {"process_identity_mode": None}}) is True

--- a/tests/apps_studio_server/test_adversarial_reapers.py
+++ b/tests/apps_studio_server/test_adversarial_reapers.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import socket
 import time
 import uuid
 from pathlib import Path
@@ -481,7 +482,7 @@ def test_a_stale_session_hosted_on_another_machine_is_not_reaped(tmp_path, monke
     import lionagi.studio.services.admin as admin_mod
     import lionagi.studio.services.lifecycle as lc_mod
 
-    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+    monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
 
     stale_time = time.time() - 7200
     remote = run_async(
@@ -530,7 +531,7 @@ def test_phantom_classifier_returns_no_reason_for_another_machines_row(tmp_path,
     """
     import lionagi.studio.services.admin as admin_mod
 
-    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+    monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
 
     now = time.time()
     stale = now - 7200
@@ -565,7 +566,7 @@ def test_process_identity_is_foreign_reads_host_and_unknown_modes(monkeypatch):
     """Foreign means "not measurable here", which covers two distinct records."""
     import lionagi.studio.services.admin as admin_mod
 
-    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+    monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
     foreign = admin_mod.process_identity_is_foreign
 
     assert foreign({"node_metadata": {"pid_host": "other-host"}}) is True

--- a/tests/apps_studio_server/test_process_liveness.py
+++ b/tests/apps_studio_server/test_process_liveness.py
@@ -149,9 +149,8 @@ async def test_explicit_nonlocal_run_is_unverifiable_without_legacy_snapshot(mon
 
 
 def test_process_identity_from_another_host_is_unknown(monkeypatch):
-    # Patched on the socket module itself rather than through the admin module:
-    # the host question is answered by recorded_pid_is_foreign in cli._util, and
-    # both modules read the same module object.
+    # Patched on socket itself: the host question is answered by cli._util's
+    # recorded_pid_is_foreign, which reads the same module object.
     monkeypatch.setattr(socket, "gethostname", lambda: "current-host")
     session = {
         "id": "remote-session",
@@ -167,14 +166,7 @@ def test_process_identity_from_another_host_is_unknown(monkeypatch):
 
 
 def test_an_unreadable_identity_mode_is_unknown_not_local():
-    """A mode marker of the wrong type must not be read as no marker at all.
-
-    Everything else on this row is a genuine live local process, so the two
-    readings give opposite answers: absent-marker takes the local path and
-    reports the run alive, while present-but-unreadable reports unknown. The
-    first is a positive liveness claim about a run whose stop-and-liveness
-    protocol this code does not implement.
-    """
+    """A mode marker of the wrong type must read as unknown, not as no marker at all."""
     markers = {
         "pid": os.getpid(),
         "pid_create_time": psutil.Process(os.getpid()).create_time(),
@@ -194,15 +186,7 @@ def test_an_unreadable_identity_mode_is_unknown_not_local():
 
 
 def test_a_boot_time_that_drifted_within_tolerance_is_not_a_reboot(monkeypatch):
-    """Clock jitter must not read as a reboot on the liveness path either.
-
-    Boot time is re-derived from the current clock on every read, so an NTP
-    step or a suspend/resume moves it on a machine that never rebooted. Process
-    create time is not like that: the kernel fixed it once, so the tighter
-    create-time tolerance is generous there and far too tight here. Reading
-    drift as a reboot reports a healthy local session as dead, and the
-    lifecycle reapers act on that answer.
-    """
+    """Clock jitter (NTP step, suspend/resume) must not read as a reboot on the liveness path."""
     import lionagi.studio.services.admin as admin_mod
     from lionagi.cli._util import BOOT_TIME_TOLERANCE
 
@@ -224,11 +208,7 @@ def test_a_boot_time_that_drifted_within_tolerance_is_not_a_reboot(monkeypatch):
 
 
 def test_a_boot_time_from_before_the_last_reboot_is_dead(monkeypatch):
-    """The control for the tolerance: a real reboot still reads as dead.
-
-    Without it, widening the tolerance to something absurd would pass the test
-    above and the check would have stopped detecting reissued pids.
-    """
+    """Control for the tolerance test: a real reboot still reads as dead."""
     import lionagi.studio.services.admin as admin_mod
 
     monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
@@ -246,14 +226,7 @@ def test_a_boot_time_from_before_the_last_reboot_is_dead(monkeypatch):
 
 
 def test_a_boot_time_that_cannot_be_read_does_not_make_a_live_process_unknown(monkeypatch):
-    """A failed boot-time read leaves one check unevaluated; it is not an answer.
-
-    Reporting unknown here is worse than never having had the check: the
-    lifecycle reapers read any non-True liveness as death once the row goes
-    stale, so on a machine where this read keeps failing every live session
-    would eventually be reaped. The pid checks still run, which is the same
-    best-effort stance the status and create-time reads already take.
-    """
+    """A failed boot-time read leaves that check unevaluated, not the whole run unknown."""
     monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
 
     recorded_boot = psutil.boot_time()
@@ -277,11 +250,7 @@ def test_a_boot_time_that_cannot_be_read_does_not_make_a_live_process_unknown(mo
 
 
 def test_a_failed_boot_time_read_still_reports_a_dead_pid_as_dead(monkeypatch):
-    """The control: falling through to the pid checks means they still decide.
-
-    Without this, returning True unconditionally on a read failure would pass
-    the test above while reporting every dead session as alive.
-    """
+    """Control: falling through to the pid checks means they still decide, not an unconditional True."""
     monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
 
     recorded_boot = psutil.boot_time()
@@ -304,15 +273,7 @@ def test_a_failed_boot_time_read_still_reports_a_dead_pid_as_dead(monkeypatch):
     assert process_liveness(session, None, ps_snapshot="") is False
 
 
-# ---------------------------------------------------------------------------
-# The host question, asked once
-#
-# The oracle used to answer it with its own inline comparison while the
-# reapers' foreign-row guard answered it with recorded_pid_is_foreign. Two
-# implementations of one predicate disagreed about the values neither was
-# written for, and the disagreement was only visible from a caller that
-# consulted both.
-# ---------------------------------------------------------------------------
+# The host question, asked once via recorded_pid_is_foreign (not two implementations).
 
 
 @pytest.mark.parametrize(
@@ -326,15 +287,7 @@ def test_a_failed_boot_time_read_still_reports_a_dead_pid_as_dead(monkeypatch):
     ],
 )
 def test_the_guard_and_the_oracle_read_every_shape_of_pid_host_the_same_way(host_value, is_foreign):
-    """The property is agreement, not either answer taken alone.
-
-    Asserting only the oracle would let the guard drift back, and asserting
-    only the guard would miss the case that actually bit: an empty pid_host
-    read as "no host recorded" by the guard and as "a host that is not mine"
-    by the oracle. A row sat in that gap with a live process, unprotected by
-    the guard and answered unknown by the oracle, and the reapers turn a
-    non-True answer into death once the row goes stale.
-    """
+    """Asserts agreement between the guard and the oracle, not either alone -- an empty pid_host once read differently by each, leaving a live row unprotected."""
     from lionagi.cli._util import recorded_pid_is_foreign
 
     meta = {
@@ -353,18 +306,7 @@ def test_the_guard_and_the_oracle_read_every_shape_of_pid_host_the_same_way(host
 
 
 def test_an_unknown_identity_mode_is_refused_before_the_host_is_consulted():
-    """The order these two checks run in is what makes a malformed host safe.
-
-    The host guard reads an unreadable ``pid_host`` as no host recorded, which
-    is only defensible because a row written by something this code does not
-    understand is already refused a step earlier, by its identity mode. That is
-    an ordering dependency and nothing else asserts it: swap the two and a row
-    announcing a foreign protocol would be judged on a local pid, with the host
-    field the only thing left to catch it and unable to.
-
-    Asserted through the caller, and against a host guard that says *not*
-    foreign for the same row, so it cannot pass by the host answer changing.
-    """
+    """Mode must be checked before host: an unreadable pid_host is only safe to treat as absent once an alien mode has already been refused."""
     from lionagi.cli._util import recorded_pid_is_foreign
     from lionagi.studio.services.admin import process_identity_is_foreign
 
@@ -383,15 +325,7 @@ def test_an_unknown_identity_mode_is_refused_before_the_host_is_consulted():
 
 
 def test_a_pid_that_collides_with_a_live_local_one_is_rejected_by_its_creation_time():
-    """The check the host marker is a fast path in front of, not a substitute for.
-
-    A row from elsewhere whose pid happens to name a live process here is the
-    failure the host marker exists to make cheap to spot. It is not the only
-    thing standing in the way: the recorded creation time rejects the
-    coincidence on its own, and it keeps doing so when the host field says
-    nothing usable. If this stops holding, an unreadable host stops being safe
-    to treat as absent.
-    """
+    """The host marker is a fast path, not a substitute: create-time still rejects the coincidence when the host field is unusable."""
     live_pid = os.getpid()
     real_create_time = psutil.Process(live_pid).create_time()
 
@@ -402,13 +336,7 @@ def test_a_pid_that_collides_with_a_live_local_one_is_rejected_by_its_creation_t
 
 
 def test_an_unparseable_pid_on_a_foreign_row_cannot_pick_up_a_local_one(tmp_path):
-    """The artifact fallback resolves a pid against *this* machine.
-
-    The host check used to be gated on having parsed a pid, so a row whose pid
-    was unreadable skipped it entirely and then reached the fallback below,
-    which reads the local process table. Another machine's row could acquire a
-    local pid that way and be reported alive by a host that cannot see it.
-    """
+    """A foreign row with an unparseable pid must not fall through to the local-machine artifact fallback."""
     (tmp_path / "session.pid").write_text(str(os.getpid()))  # a live LOCAL pid
 
     session = {
@@ -420,11 +348,7 @@ def test_an_unparseable_pid_on_a_foreign_row_cannot_pick_up_a_local_one(tmp_path
 
 
 def test_the_same_unparseable_pid_on_a_local_row_still_uses_the_artifact_fallback(tmp_path):
-    """The control, and the reason the fix is a reorder rather than a removal.
-
-    Without this, deleting the fallback outright would satisfy the test above
-    while breaking every local row that relies on the pid file.
-    """
+    """Control: a local row still uses the artifact fallback, so the fix above is a reorder, not a removal."""
     (tmp_path / "session.pid").write_text(str(os.getpid()))
 
     session = {

--- a/tests/apps_studio_server/test_process_liveness.py
+++ b/tests/apps_studio_server/test_process_liveness.py
@@ -149,9 +149,10 @@ async def test_explicit_nonlocal_run_is_unverifiable_without_legacy_snapshot(mon
 
 
 def test_process_identity_from_another_host_is_unknown(monkeypatch):
-    import lionagi.studio.services.admin as admin_mod
-
-    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "current-host")
+    # Patched on the socket module itself rather than through the admin module:
+    # the host question is answered by recorded_pid_is_foreign in cli._util, and
+    # both modules read the same module object.
+    monkeypatch.setattr(socket, "gethostname", lambda: "current-host")
     session = {
         "id": "remote-session",
         "node_metadata": {
@@ -205,7 +206,7 @@ def test_a_boot_time_that_drifted_within_tolerance_is_not_a_reboot(monkeypatch):
     import lionagi.studio.services.admin as admin_mod
     from lionagi.cli._util import BOOT_TIME_TOLERANCE
 
-    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+    monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
     drift = BOOT_TIME_TOLERANCE / 2
     assert drift > 0, "a zero tolerance would make this test assert nothing"
 
@@ -230,7 +231,7 @@ def test_a_boot_time_from_before_the_last_reboot_is_dead(monkeypatch):
     """
     import lionagi.studio.services.admin as admin_mod
 
-    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+    monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
     session = {
         "id": "pre-reboot-session",
         "node_metadata": {
@@ -253,9 +254,7 @@ def test_a_boot_time_that_cannot_be_read_does_not_make_a_live_process_unknown(mo
     would eventually be reaped. The pid checks still run, which is the same
     best-effort stance the status and create-time reads already take.
     """
-    import lionagi.studio.services.admin as admin_mod
-
-    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+    monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
 
     recorded_boot = psutil.boot_time()
 
@@ -283,9 +282,7 @@ def test_a_failed_boot_time_read_still_reports_a_dead_pid_as_dead(monkeypatch):
     Without this, returning True unconditionally on a read failure would pass
     the test above while reporting every dead session as alive.
     """
-    import lionagi.studio.services.admin as admin_mod
-
-    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+    monkeypatch.setattr(socket, "gethostname", lambda: "this-host")
 
     recorded_boot = psutil.boot_time()
     dead = _dead_pid()
@@ -305,3 +302,85 @@ def test_a_failed_boot_time_read_still_reports_a_dead_pid_as_dead(monkeypatch):
     }
 
     assert process_liveness(session, None, ps_snapshot="") is False
+
+
+# ---------------------------------------------------------------------------
+# The host question, asked once
+#
+# The oracle used to answer it with its own inline comparison while the
+# reapers' foreign-row guard answered it with recorded_pid_is_foreign. Two
+# implementations of one predicate disagreed about the values neither was
+# written for, and the disagreement was only visible from a caller that
+# consulted both.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host_value, is_foreign",
+    [
+        pytest.param({}, False, id="pid_host-absent-is-a-legacy-row-not-a-foreign-one"),
+        pytest.param({"pid_host": ""}, False, id="empty-pid_host-records-no-host"),
+        pytest.param({"pid_host": 1234}, False, id="non-string-pid_host-records-no-host"),
+        pytest.param({"pid_host": None}, False, id="null-pid_host-records-no-host"),
+        pytest.param({"pid_host": "definitely-another-machine"}, True, id="a-real-other-host"),
+    ],
+)
+def test_the_guard_and_the_oracle_read_every_shape_of_pid_host_the_same_way(host_value, is_foreign):
+    """The property is agreement, not either answer taken alone.
+
+    Asserting only the oracle would let the guard drift back, and asserting
+    only the guard would miss the case that actually bit: an empty pid_host
+    read as "no host recorded" by the guard and as "a host that is not mine"
+    by the oracle. A row sat in that gap with a live process, unprotected by
+    the guard and answered unknown by the oracle, and the reapers turn a
+    non-True answer into death once the row goes stale.
+    """
+    from lionagi.cli._util import recorded_pid_is_foreign
+
+    meta = {
+        "pid": os.getpid(),
+        "pid_create_time": psutil.Process(os.getpid()).create_time(),
+        **host_value,
+    }
+
+    assert recorded_pid_is_foreign(meta) is is_foreign
+
+    liveness = process_liveness({"id": "s", "node_metadata": meta}, None, ps_snapshot="")
+    # Foreign => unknown. Not foreign => this genuinely live process is seen.
+    assert (liveness is None) is is_foreign
+    if not is_foreign:
+        assert liveness is True
+
+
+def test_an_unparseable_pid_on_a_foreign_row_cannot_pick_up_a_local_one(tmp_path):
+    """The artifact fallback resolves a pid against *this* machine.
+
+    The host check used to be gated on having parsed a pid, so a row whose pid
+    was unreadable skipped it entirely and then reached the fallback below,
+    which reads the local process table. Another machine's row could acquire a
+    local pid that way and be reported alive by a host that cannot see it.
+    """
+    (tmp_path / "session.pid").write_text(str(os.getpid()))  # a live LOCAL pid
+
+    session = {
+        "id": "remote-session",
+        "node_metadata": {"pid": "not-a-number", "pid_host": "definitely-another-machine"},
+    }
+
+    assert process_liveness(session, tmp_path, ps_snapshot="") is None
+
+
+def test_the_same_unparseable_pid_on_a_local_row_still_uses_the_artifact_fallback(tmp_path):
+    """The control, and the reason the fix is a reorder rather than a removal.
+
+    Without this, deleting the fallback outright would satisfy the test above
+    while breaking every local row that relies on the pid file.
+    """
+    (tmp_path / "session.pid").write_text(str(os.getpid()))
+
+    session = {
+        "id": "local-session",
+        "node_metadata": {"pid": "not-a-number", "pid_host": socket.gethostname()},
+    }
+
+    assert process_liveness(session, tmp_path, ps_snapshot="") is True

--- a/tests/apps_studio_server/test_process_liveness.py
+++ b/tests/apps_studio_server/test_process_liveness.py
@@ -352,6 +352,55 @@ def test_the_guard_and_the_oracle_read_every_shape_of_pid_host_the_same_way(host
         assert liveness is True
 
 
+def test_an_unknown_identity_mode_is_refused_before_the_host_is_consulted():
+    """The order these two checks run in is what makes a malformed host safe.
+
+    The host guard reads an unreadable ``pid_host`` as no host recorded, which
+    is only defensible because a row written by something this code does not
+    understand is already refused a step earlier, by its identity mode. That is
+    an ordering dependency and nothing else asserts it: swap the two and a row
+    announcing a foreign protocol would be judged on a local pid, with the host
+    field the only thing left to catch it and unable to.
+
+    Asserted through the caller, and against a host guard that says *not*
+    foreign for the same row, so it cannot pass by the host answer changing.
+    """
+    from lionagi.cli._util import recorded_pid_is_foreign
+    from lionagi.studio.services.admin import process_identity_is_foreign
+
+    meta = {
+        "pid": os.getpid(),
+        "pid_create_time": psutil.Process(os.getpid()).create_time(),
+        "process_identity_mode": "a-protocol-this-code-does-not-know",
+        "pid_host": 1234,
+    }
+
+    assert recorded_pid_is_foreign(meta) is False, (
+        "premise: the host guard does not catch this row, so the refusal below "
+        "can only come from the identity-mode check running first"
+    )
+    assert process_identity_is_foreign({"id": "s", "node_metadata": meta}) is True
+
+
+def test_a_pid_that_collides_with_a_live_local_one_is_rejected_by_its_creation_time():
+    """The check the host marker is a fast path in front of, not a substitute for.
+
+    A row from elsewhere whose pid happens to name a live process here is the
+    failure the host marker exists to make cheap to spot. It is not the only
+    thing standing in the way: the recorded creation time rejects the
+    coincidence on its own, and it keeps doing so when the host field says
+    nothing usable. If this stops holding, an unreadable host stops being safe
+    to treat as absent.
+    """
+    live_pid = os.getpid()
+    real_create_time = psutil.Process(live_pid).create_time()
+
+    for host in ({}, {"pid_host": 1234}, {"pid_host": ""}):
+        meta = {"pid": live_pid, "pid_create_time": real_create_time - 9999, **host}
+        liveness = process_liveness({"id": "s", "node_metadata": meta}, None, ps_snapshot="")
+        assert liveness is False, f"pid collision admitted as live for pid_host={host}"
+
+
 def test_an_unparseable_pid_on_a_foreign_row_cannot_pick_up_a_local_one(tmp_path):
     """The artifact fallback resolves a pid against *this* machine.
 

--- a/tests/apps_studio_server/test_process_liveness.py
+++ b/tests/apps_studio_server/test_process_liveness.py
@@ -4,7 +4,10 @@
 
 import json
 import os
+import socket
 import subprocess
+import time
+from unittest.mock import AsyncMock
 
 import psutil
 import pytest
@@ -90,4 +93,215 @@ def test_node_metadata_pid_with_matching_create_time_but_zombie_status_is_dead(m
     monkeypatch.setattr(psutil, "Process", _ZombieProcess)
 
     session = {"id": "s1", "node_metadata": {"pid": pid, "pid_create_time": ct}}
+    assert process_liveness(session, None, ps_snapshot="") is False
+
+
+async def test_identity_complete_runs_page_does_not_capture_process_table(monkeypatch):
+    import lionagi.studio.services.admin as admin_mod
+    import lionagi.studio.services.run_tags as run_tags_mod
+    import lionagi.studio.services.runs as runs_mod
+
+    created = psutil.Process(os.getpid()).create_time()
+    sessions = [
+        {
+            "id": f"session-{i}",
+            "status": "running",
+            "started_at": time.time(),
+            "updated_at": time.time(),
+            "node_metadata": {"pid": os.getpid(), "pid_create_time": created},
+        }
+        for i in range(20)
+    ]
+    monkeypatch.setattr(runs_mod._sessions_svc, "list_sessions", AsyncMock(return_value=sessions))
+    monkeypatch.setattr(run_tags_mod, "tags_for_sessions", AsyncMock(return_value={}))
+    snapshot = AsyncMock(return_value="")
+    monkeypatch.setattr(admin_mod, "cached_ps_snapshot", snapshot)
+
+    result = await runs_mod.list_runs(limit=20)
+
+    assert len(result) == 20
+    snapshot.assert_not_awaited()
+
+
+async def test_explicit_nonlocal_run_is_unverifiable_without_legacy_snapshot(monkeypatch):
+    import lionagi.studio.services.admin as admin_mod
+    import lionagi.studio.services.run_tags as run_tags_mod
+    import lionagi.studio.services.runs as runs_mod
+
+    sessions = [
+        {
+            "id": "imported-session",
+            "status": "running",
+            "started_at": time.time(),
+            "updated_at": time.time(),
+            "node_metadata": {"process_identity_mode": "external"},
+        }
+    ]
+    monkeypatch.setattr(runs_mod._sessions_svc, "list_sessions", AsyncMock(return_value=sessions))
+    monkeypatch.setattr(run_tags_mod, "tags_for_sessions", AsyncMock(return_value={}))
+    snapshot = AsyncMock(return_value="")
+    monkeypatch.setattr(admin_mod, "cached_ps_snapshot", snapshot)
+
+    result = await runs_mod.list_runs(limit=1)
+
+    assert len(result) == 1
+    snapshot.assert_not_awaited()
+
+
+def test_process_identity_from_another_host_is_unknown(monkeypatch):
+    import lionagi.studio.services.admin as admin_mod
+
+    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "current-host")
+    session = {
+        "id": "remote-session",
+        "node_metadata": {
+            "pid": os.getpid(),
+            "pid_create_time": psutil.Process(os.getpid()).create_time(),
+            "pid_host": "another-host",
+            "pid_boot_time": psutil.boot_time(),
+        },
+    }
+
+    assert process_liveness(session, None, ps_snapshot="") is None
+
+
+def test_an_unreadable_identity_mode_is_unknown_not_local():
+    """A mode marker of the wrong type must not be read as no marker at all.
+
+    Everything else on this row is a genuine live local process, so the two
+    readings give opposite answers: absent-marker takes the local path and
+    reports the run alive, while present-but-unreadable reports unknown. The
+    first is a positive liveness claim about a run whose stop-and-liveness
+    protocol this code does not implement.
+    """
+    markers = {
+        "pid": os.getpid(),
+        "pid_create_time": psutil.Process(os.getpid()).create_time(),
+        "pid_host": socket.gethostname(),
+        "pid_boot_time": psutil.boot_time(),
+    }
+
+    # Control: without a mode marker at all, this exact row is observed alive.
+    assert process_liveness({"id": "s", "node_metadata": dict(markers)}, None) is True
+
+    for unreadable in (123, {"kind": "remote"}, ["external"]):
+        session = {
+            "id": "s",
+            "node_metadata": {**markers, "process_identity_mode": unreadable},
+        }
+        assert process_liveness(session, None) is None
+
+
+def test_a_boot_time_that_drifted_within_tolerance_is_not_a_reboot(monkeypatch):
+    """Clock jitter must not read as a reboot on the liveness path either.
+
+    Boot time is re-derived from the current clock on every read, so an NTP
+    step or a suspend/resume moves it on a machine that never rebooted. Process
+    create time is not like that: the kernel fixed it once, so the tighter
+    create-time tolerance is generous there and far too tight here. Reading
+    drift as a reboot reports a healthy local session as dead, and the
+    lifecycle reapers act on that answer.
+    """
+    import lionagi.studio.services.admin as admin_mod
+    from lionagi.cli._util import BOOT_TIME_TOLERANCE
+
+    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+    drift = BOOT_TIME_TOLERANCE / 2
+    assert drift > 0, "a zero tolerance would make this test assert nothing"
+
+    session = {
+        "id": "drifted-session",
+        "node_metadata": {
+            "pid": os.getpid(),
+            "pid_create_time": psutil.Process(os.getpid()).create_time(),
+            "pid_host": "this-host",
+            "pid_boot_time": psutil.boot_time() - drift,
+        },
+    }
+
+    assert process_liveness(session, None, ps_snapshot="") is True
+
+
+def test_a_boot_time_from_before_the_last_reboot_is_dead(monkeypatch):
+    """The control for the tolerance: a real reboot still reads as dead.
+
+    Without it, widening the tolerance to something absurd would pass the test
+    above and the check would have stopped detecting reissued pids.
+    """
+    import lionagi.studio.services.admin as admin_mod
+
+    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+    session = {
+        "id": "pre-reboot-session",
+        "node_metadata": {
+            "pid": os.getpid(),
+            "pid_create_time": psutil.Process(os.getpid()).create_time(),
+            "pid_host": "this-host",
+            "pid_boot_time": psutil.boot_time() - 86400.0,
+        },
+    }
+
+    assert process_liveness(session, None, ps_snapshot="") is False
+
+
+def test_a_boot_time_that_cannot_be_read_does_not_make_a_live_process_unknown(monkeypatch):
+    """A failed boot-time read leaves one check unevaluated; it is not an answer.
+
+    Reporting unknown here is worse than never having had the check: the
+    lifecycle reapers read any non-True liveness as death once the row goes
+    stale, so on a machine where this read keeps failing every live session
+    would eventually be reaped. The pid checks still run, which is the same
+    best-effort stance the status and create-time reads already take.
+    """
+    import lionagi.studio.services.admin as admin_mod
+
+    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+
+    recorded_boot = psutil.boot_time()
+
+    def _unreadable_boot_time():
+        raise OSError("boot time unavailable")
+
+    monkeypatch.setattr(psutil, "boot_time", _unreadable_boot_time)
+
+    session = {
+        "id": "live-session",
+        "node_metadata": {
+            "pid": os.getpid(),
+            "pid_create_time": psutil.Process(os.getpid()).create_time(),
+            "pid_host": "this-host",
+            "pid_boot_time": recorded_boot,
+        },
+    }
+
+    assert process_liveness(session, None, ps_snapshot="") is True
+
+
+def test_a_failed_boot_time_read_still_reports_a_dead_pid_as_dead(monkeypatch):
+    """The control: falling through to the pid checks means they still decide.
+
+    Without this, returning True unconditionally on a read failure would pass
+    the test above while reporting every dead session as alive.
+    """
+    import lionagi.studio.services.admin as admin_mod
+
+    monkeypatch.setattr(admin_mod.socket, "gethostname", lambda: "this-host")
+
+    recorded_boot = psutil.boot_time()
+    dead = _dead_pid()
+
+    def _unreadable_boot_time():
+        raise OSError("boot time unavailable")
+
+    monkeypatch.setattr(psutil, "boot_time", _unreadable_boot_time)
+
+    session = {
+        "id": "dead-session",
+        "node_metadata": {
+            "pid": dead,
+            "pid_host": "this-host",
+            "pid_boot_time": recorded_boot,
+        },
+    }
+
     assert process_liveness(session, None, ps_snapshot="") is False

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -827,6 +827,94 @@ async def test_kill_one_refuses_a_row_recorded_on_another_host(
         ] == "running", "cancelled a row whose process is alive on another machine"
 
 
+async def test_kill_one_refuses_a_foreign_row_that_recorded_no_pid(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Foreignness belongs to the row, not to whether it recorded a pid: a foreign row with no pid used to skip the guard and be persisted as cancelled with nothing signalled."""
+    import socket
+
+    async with StateDB() as db:
+        local_sid = str(uuid.uuid4())
+        foreign_sid = str(uuid.uuid4())
+        for sid, meta in (
+            (local_sid, {}),
+            (foreign_sid, {"pid_host": "some-other-machine"}),
+        ):
+            prog = str(uuid.uuid4())
+            await db.create_progression(prog)
+            await db.create_session(
+                {
+                    "id": sid,
+                    "progression_id": prog,
+                    "status": "running",
+                    "started_at": time.time(),
+                    "node_metadata": meta,
+                }
+            )
+
+        assert socket.gethostname() != "some-other-machine"
+
+        # CONTROL: a local row with no pid is still cancelled, so the refusal
+        # below is attributable to the host marker and not to the absent pid.
+        row = db._row_to_dict(
+            await db.fetch_one("SELECT * FROM sessions WHERE id = ?", (local_sid,))
+        )
+        control = await _kill_one(db, "session", local_sid, row, user_reason="")
+        assert control["signal"] == "no_pid"
+        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (local_sid,)))[
+            "status"
+        ] == "cancelled", (
+            f"control row was not cancelled ({control['signal']}), so this test cannot "
+            "attribute the refusal below to the host marker"
+        )
+
+        row = db._row_to_dict(
+            await db.fetch_one("SELECT * FROM sessions WHERE id = ?", (foreign_sid,))
+        )
+        result = await _kill_one(db, "session", foreign_sid, row, user_reason="")
+
+        assert result["signal"] == "foreign_host"
+        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (foreign_sid,)))[
+            "status"
+        ] == "running", "cancelled another machine's row without signalling anything"
+
+
+async def test_do_kill_a_foreign_row_reports_failure(temp_db_path: Path, capsys):
+    """A host that cannot judge a row must not report a kill: no 'killed' line, exit code 1.
+
+    The control is a local row with no pid either, which DOES report a kill --
+    without it this passes on any refusal rather than on this one.
+    """
+    local_sid = str(uuid.uuid4())
+    foreign_sid = str(uuid.uuid4())
+    async with StateDB() as db:
+        for sid, meta in ((local_sid, {}), (foreign_sid, {"pid_host": "some-other-machine"})):
+            prog = str(uuid.uuid4())
+            await db.create_progression(prog)
+            await db.create_session(
+                {
+                    "id": sid,
+                    "progression_id": prog,
+                    "status": "running",
+                    "started_at": time.time(),
+                    "node_metadata": meta,
+                }
+            )
+
+    assert await _do_kill(local_sid) == 0, (
+        "control row was refused, so the refusal below proves nothing"
+    )
+    assert "killed" in capsys.readouterr().out
+
+    assert await _do_kill(foreign_sid) == 1, "a refused kill must return non-zero"
+    assert "killed" not in capsys.readouterr().out, "reported a kill that never happened"
+
+    async with StateDB() as db:
+        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (foreign_sid,)))[
+            "status"
+        ] == "running"
+
+
 async def test_kill_one_skips_recycled_pid_via_create_time(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -715,15 +715,7 @@ def test_current_pid_markers_records_own_pid():
 def test_recorded_markers_read_as_foreign_from_another_machine(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """A row this code writes must be placeable by the machine that reads it.
-
-    The assertion is made from the position of a second machine sharing the
-    state store, because that is the only position from which the marker does
-    any work. Asking on the machine that wrote the row proves nothing either
-    way: a row carrying no host reads as "origin unknown", which is the same
-    permissive branch as "origin is you", so a same-machine check passes
-    whether or not the host was ever recorded.
-    """
+    """Asserted from a second machine sharing the state store, since a same-machine check would pass whether or not the host was ever recorded."""
     import socket
 
     from lionagi.cli._util import recorded_pid_is_foreign
@@ -741,15 +733,7 @@ def test_recorded_markers_read_as_foreign_from_another_machine(
 
 
 def test_the_composed_guard_refuses_a_mode_the_host_question_would_pass():
-    """What the host question alone does not answer, and why order matters.
-
-    Reading an unreadable host marker as "no host recorded" is only safe
-    because a row written by something this code does not understand is turned
-    away first, by its identity mode. A caller that asks the host question
-    alone inherits the permissive reading without the refusal that pays for
-    it. The row below is exactly that gap: its host is this machine, so the
-    host question says local, and its mode names a protocol living elsewhere.
-    """
+    """Mode must be checked before host: a row whose host is local but whose mode names a foreign protocol is the gap the host question alone would miss."""
     import socket
 
     from lionagi.cli._util import recorded_pid_is_foreign, recorded_row_is_foreign

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -712,6 +712,34 @@ def test_current_pid_markers_records_own_pid():
     assert markers["pid_create_time"] == pytest.approx(psutil.Process(os.getpid()).create_time())
 
 
+def test_recorded_markers_read_as_foreign_from_another_machine(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A row this code writes must be placeable by the machine that reads it.
+
+    The assertion is made from the position of a second machine sharing the
+    state store, because that is the only position from which the marker does
+    any work. Asking on the machine that wrote the row proves nothing either
+    way: a row carrying no host reads as "origin unknown", which is the same
+    permissive branch as "origin is you", so a same-machine check passes
+    whether or not the host was ever recorded.
+    """
+    import socket
+
+    from lionagi.cli._util import recorded_pid_is_foreign
+    from lionagi.cli.kill import current_pid_markers
+
+    markers = current_pid_markers()
+    assert recorded_pid_is_foreign(markers) is False, "our own row is not foreign to us"
+
+    real_host = socket.gethostname()
+    monkeypatch.setattr(socket, "gethostname", lambda: f"not-{real_host}")
+    assert recorded_pid_is_foreign(markers) is True, (
+        "a row recorded here must read as foreign from another machine, or that "
+        "machine signals our pid and reads our silence as our death"
+    )
+
+
 async def test_kill_one_skips_recycled_pid_via_create_time(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -778,14 +778,7 @@ def test_the_composed_guard_refuses_a_mode_the_host_question_would_pass():
 async def test_kill_one_refuses_a_row_recorded_on_another_host(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """A pid from another machine is not this machine's pid to signal.
-
-    Both rows here are identical except for the host marker, and the fake
-    process is built to be positively identified as the run: matching
-    create_time and a matching session marker. So the control is genuinely
-    killed, which is what makes the refusal below attributable to the marker
-    and not to some other check happening to refuse.
-    """
+    """A pid from another machine is not this machine's pid to signal."""
     import socket
 
     async with StateDB() as db:
@@ -812,8 +805,7 @@ async def test_kill_one_refuses_a_row_recorded_on_another_host(
 
         assert socket.gethostname() != "some-other-machine"
 
-        # CONTROL: same row without the marker. It must actually be killed,
-        # or the refusal below is evidence of nothing.
+        # CONTROL: must actually be killed, or the refusal proves nothing.
         kill_calls = _mock_psutil(
             monkeypatch,
             cmdline=["/usr/bin/python3", "-m", "lionagi.cli"],
@@ -830,11 +822,8 @@ async def test_kill_one_refuses_a_row_recorded_on_another_host(
         )
         assert kill_calls, "control sent no signal"
 
-        # SUBJECT: identical row, recorded elsewhere. The local process is
-        # re-mocked to match THIS row's session id, so the pid here is one the
-        # identity check would positively confirm. That is the case the marker
-        # exists for: a collision the other checks cannot see, where without
-        # the host question this row is killed rather than merely mismatched.
+        # SUBJECT: identical row, recorded elsewhere. Re-mocked to match this
+        # row's session id, so without the host check it would be killed.
         kill_calls = _mock_psutil(
             monkeypatch,
             cmdline=["/usr/bin/python3", "-m", "lionagi.cli"],

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -740,6 +740,120 @@ def test_recorded_markers_read_as_foreign_from_another_machine(
     )
 
 
+def test_the_composed_guard_refuses_a_mode_the_host_question_would_pass():
+    """What the host question alone does not answer, and why order matters.
+
+    Reading an unreadable host marker as "no host recorded" is only safe
+    because a row written by something this code does not understand is turned
+    away first, by its identity mode. A caller that asks the host question
+    alone inherits the permissive reading without the refusal that pays for
+    it. The row below is exactly that gap: its host is this machine, so the
+    host question says local, and its mode names a protocol living elsewhere.
+    """
+    import socket
+
+    from lionagi.cli._util import recorded_pid_is_foreign, recorded_row_is_foreign
+
+    alien = {
+        "pid": 4242,
+        "pid_host": socket.gethostname(),
+        "process_identity_mode": "container-supervisor",
+    }
+    assert recorded_pid_is_foreign(alien) is False, (
+        "premise: the host half passes this row, so the refusal below is the mode's"
+    )
+    assert recorded_row_is_foreign(alien) is True
+
+    # A mode recorded as a non-string is unreadable, not absent, and is
+    # refused for the same reason.
+    assert recorded_row_is_foreign({"pid": 1, "process_identity_mode": 7}) is True
+
+    # The modes whose protocol is this one, and a row that predates the marker.
+    for local in ("local", "in_process"):
+        assert recorded_row_is_foreign({"pid": 1, "process_identity_mode": local}) is False
+    assert recorded_row_is_foreign({"pid": 1}) is False
+    assert recorded_row_is_foreign(None) is False
+
+
+async def test_kill_one_refuses_a_row_recorded_on_another_host(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A pid from another machine is not this machine's pid to signal.
+
+    Both rows here are identical except for the host marker, and the fake
+    process is built to be positively identified as the run: matching
+    create_time and a matching session marker. So the control is genuinely
+    killed, which is what makes the refusal below attributable to the marker
+    and not to some other check happening to refuse.
+    """
+    import socket
+
+    async with StateDB() as db:
+        local_sid = str(uuid.uuid4())
+        foreign_sid = str(uuid.uuid4())
+        for sid, meta in (
+            (local_sid, {"pid": 4242, "pid_create_time": 100.0}),
+            (
+                foreign_sid,
+                {"pid": 4242, "pid_create_time": 100.0, "pid_host": "some-other-machine"},
+            ),
+        ):
+            prog = str(uuid.uuid4())
+            await db.create_progression(prog)
+            await db.create_session(
+                {
+                    "id": sid,
+                    "progression_id": prog,
+                    "status": "running",
+                    "started_at": time.time(),
+                    "node_metadata": meta,
+                }
+            )
+
+        assert socket.gethostname() != "some-other-machine"
+
+        # CONTROL: same row without the marker. It must actually be killed,
+        # or the refusal below is evidence of nothing.
+        kill_calls = _mock_psutil(
+            monkeypatch,
+            cmdline=["/usr/bin/python3", "-m", "lionagi.cli"],
+            environ={"LIONAGI_SESSION_ID": local_sid},
+            create_time=100.0,
+        )
+        row = db._row_to_dict(
+            await db.fetch_one("SELECT * FROM sessions WHERE id = ?", (local_sid,))
+        )
+        control = await _kill_one(db, "session", local_sid, row, user_reason="")
+        assert control["signal"] in ("sigterm", "sigkill"), (
+            f"control row was not killed ({control['signal']}), so this test cannot "
+            "attribute the refusal below to the host marker"
+        )
+        assert kill_calls, "control sent no signal"
+
+        # SUBJECT: identical row, recorded elsewhere. The local process is
+        # re-mocked to match THIS row's session id, so the pid here is one the
+        # identity check would positively confirm. That is the case the marker
+        # exists for: a collision the other checks cannot see, where without
+        # the host question this row is killed rather than merely mismatched.
+        kill_calls = _mock_psutil(
+            monkeypatch,
+            cmdline=["/usr/bin/python3", "-m", "lionagi.cli"],
+            environ={"LIONAGI_SESSION_ID": foreign_sid},
+            create_time=100.0,
+        )
+        signals_after_control = len(kill_calls)
+        row = db._row_to_dict(
+            await db.fetch_one("SELECT * FROM sessions WHERE id = ?", (foreign_sid,))
+        )
+        result = await _kill_one(db, "session", foreign_sid, row, user_reason="")
+
+        assert result["signal"] == "foreign_host"
+        assert len(kill_calls) == signals_after_control, "signalled a pid on another host"
+        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (foreign_sid,)))[
+            "status"
+        ] == "running", "cancelled a row whose process is alive on another machine"
+
+
 async def test_kill_one_skips_recycled_pid_via_create_time(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/cli/test_smart_staleness.py
+++ b/tests/cli/test_smart_staleness.py
@@ -345,14 +345,7 @@ async def _seed_session_with_metadata(db: StateDB, meta: dict) -> str:
 async def test_do_kill_all_stale_does_not_sweep_a_row_recorded_on_another_host(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """A row from another machine must survive a sweep that cannot see its pid.
-
-    `_pid_alive` is False for both rows, which is not a contrivance: it is the
-    ordinary state of affairs for a row whose process runs on a different
-    machine. That absence is what the sweep reads as dead, so the control here
-    is genuinely cancelled and the only difference between the two rows is the
-    recorded host.
-    """
+    """A row from another machine must survive a sweep, even though `_pid_alive` reads False for it just as it does for the genuinely dead control row."""
     import socket
 
     monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: False)

--- a/tests/cli/test_smart_staleness.py
+++ b/tests/cli/test_smart_staleness.py
@@ -323,3 +323,59 @@ async def test_do_kill_all_stale_dry_run_child_derived(
     async with StateDB() as db:
         row = await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,))
         assert row["status"] == "running"  # unchanged
+
+
+async def _seed_session_with_metadata(db: StateDB, meta: dict) -> str:
+    """A backdated running session carrying *meta* as its node_metadata."""
+    sid = str(uuid.uuid4())
+    prog = str(uuid.uuid4())
+    await db.create_progression(prog)
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": prog,
+            "status": "running",
+            "started_at": time.time() - 7200,
+            "node_metadata": meta,
+        }
+    )
+    return sid
+
+
+async def test_do_kill_all_stale_does_not_sweep_a_row_recorded_on_another_host(
+    temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A row from another machine must survive a sweep that cannot see its pid.
+
+    `_pid_alive` is False for both rows, which is not a contrivance: it is the
+    ordinary state of affairs for a row whose process runs on a different
+    machine. That absence is what the sweep reads as dead, so the control here
+    is genuinely cancelled and the only difference between the two rows is the
+    recorded host.
+    """
+    import socket
+
+    monkeypatch.setattr("lionagi.cli.kill._pid_alive", lambda pid: False)
+    assert socket.gethostname() != "some-other-machine"
+
+    async with StateDB() as db:
+        local_sid = await _seed_session_with_metadata(db, {"pid": 4242})
+        foreign_sid = await _seed_session_with_metadata(
+            db, {"pid": 4242, "pid_host": "some-other-machine"}
+        )
+
+    rc = await _do_kill_all_stale(threshold_seconds=3600, dry_run=False)
+    assert rc == 0
+
+    async with StateDB() as db:
+        control = await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (local_sid,))
+        subject = await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (foreign_sid,))
+
+    assert control["status"] == "cancelled", (
+        f"control row was not swept (status {control['status']}), so this test cannot "
+        "attribute the survival below to the host marker"
+    )
+    assert subject["status"] == "running", (
+        "swept a row recorded on another machine; its pid is absent here because the "
+        "process is running there, and absence was read as death"
+    )


### PR DESCRIPTION
A pid names a process only inside one host's pid space. Where several machines
share a state store, a local liveness check applied to a row written elsewhere
answers about whichever unrelated local process happens to hold that number.
The answer looks like a real one, and it decides whether a run gets reaped and
whether a pid gets signalled.

## What changes

- `recorded_pid_is_foreign()` and `recorded_identity_mode()` in `lionagi/cli/_util.py`,
  so the host check and the identity-mode read live in one place rather than
  beside each caller.
- The studio lifecycle guards (`admin.py`, `lifecycle.py`) consult both before
  signalling a pid or reading silence as death.
- The run listing skips the host scan for foreign rows. The scan reads this
  machine's process table, so liveness is unknown either way; skipping it
  changes the cost and not the answer, and keeps a page of imported rows from
  triggering the scan the targeted-first path exists to ration.
- The claude and codex mirrors record `process_identity_mode` on import, which
  is the producer side of what those readers consume.

## Two decisions worth flagging

**Absence of the marker is not foreignness.** Rows written before the marker
existed cannot be placed either way, and treating unknown origin as "another
machine" would stop every one of them from being cancelled or swept. They stay
on the existing path, which still has its own identity checks.

**A marker present but unreadable is refused, not ignored.** An
`isinstance(mode, str)` test at the call site collapses "never recorded" into
"recorded as something I cannot read", and it collapses them in the permissive
direction: a mode stored as a number or an object would read as absent, and the
row would then be treated as ordinary and local. The type check happens once, in
the helper, and returns a sentinel instead.

This is the first of two parts split out of #3237; it is self-contained and has
no dependency on the second, which carries the `li kill` and CLI-state callers.

## Tests

`tests/apps_studio_server/test_process_liveness.py` and
`test_adversarial_reapers.py` cover the foreign-host, missing-marker,
unreadable-marker and boot-time-drift cases.
