### PR TITLE
perf(studio): seek the primary key when paging prune candidates

### DIFF
--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -270,10 +270,25 @@ async def _candidate_chunks(
     a chunk can legitimately delete nothing: `_prune_session_chunk` re-checks
     each row under the write lock and skips one that stopped being terminal.
     Re-asking the same question would hand that row back forever.
+
+    The primary key index is named explicitly because leaving the choice to the
+    planner makes this loop quadratic. Left alone, and with no collected
+    statistics -- which is the permanent state here, since nothing runs ANALYZE
+    -- SQLite prefers the narrower status/time index and then sorts for the
+    ORDER BY, so every page re-reads and re-sorts the whole remaining eligible
+    backlog instead of seeking past the ids it already returned. Measured on a
+    240k-row store, walking the backlog took 43.8s that way against 0.12s
+    seeking the primary key. Naming the index turns each page back into a
+    forward seek, and asking for one that does not exist is a prepare-time
+    error, so a schema change that removes it fails loudly rather than
+    silently restoring the quadratic plan.
     """
     after = ""
     while True:
-        sql = f"SELECT id FROM {table} WHERE ({where_sql}) AND id > ? ORDER BY id LIMIT ?"  # noqa: S608
+        sql = (
+            f"SELECT id FROM {table} INDEXED BY sqlite_autoindex_{table}_1 "  # noqa: S608
+            f"WHERE ({where_sql}) AND id > ? ORDER BY id LIMIT ?"
+        )
         async with db.transaction() as conn:
             rows = (await conn.execute(*_q(sql, (*params, after, size)))).fetchall()
         ids = sorted({r[0] for r in rows})

--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -282,11 +282,20 @@ async def _candidate_chunks(
     forward seek, and asking for one that does not exist is a prepare-time
     error, so a schema change that removes it fails loudly rather than
     silently restoring the quadratic plan.
+
+    The hint is SQLite's syntax and SQLite's problem, so it is only emitted for
+    that dialect. PostgreSQL keeps its own table statistics and plans this as a
+    forward seek without being told, and it has no `INDEXED BY` clause at all --
+    emitting one unconditionally would turn every prune pass on a Postgres-backed
+    store into a syntax error at prepare time.
     """
+    # Built once rather than per page: `table` and the dialect are both fixed
+    # for the life of the scan.
+    indexed_by = f" INDEXED BY sqlite_autoindex_{table}_1" if db.dialect == "sqlite" else ""
     after = ""
     while True:
         sql = (
-            f"SELECT id FROM {table} INDEXED BY sqlite_autoindex_{table}_1 "  # noqa: S608
+            f"SELECT id FROM {table}{indexed_by} "  # noqa: S608
             f"WHERE ({where_sql}) AND id > ? ORDER BY id LIMIT ?"
         )
         async with db.transaction() as conn:

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -1051,11 +1051,18 @@ def test_run_chunk_archive_failure_aborts_dispatch_and_keeps_session_deletes(tmp
 # ── candidate paging keeps a forward seek ─────────────────────────────────────
 
 
-def _captured_chunk_sql(tmp_path, monkeypatch) -> tuple[Path, str, tuple]:
+def _captured_chunk_sql(
+    tmp_path, monkeypatch, dialect: str | None = None
+) -> tuple[Path, str, tuple]:
     """Drive `_candidate_chunks` and return the SQL it actually built.
 
     The statement is taken from the running code rather than restated here, so
     the plan assertions below fail if the source stops asking for the index.
+
+    `dialect` overrides what the scan believes it is talking to. The store
+    underneath stays SQLite either way, which is what makes the Postgres case
+    observable at all: the point is which SQL gets built, and a statement built
+    without the hint still runs here.
     """
     from lionagi.studio.services import db_maintenance as maint
 
@@ -1077,6 +1084,11 @@ def _captured_chunk_sql(tmp_path, monkeypatch) -> tuple[Path, str, tuple]:
         async with StateDB() as db:
             for _ in range(3):
                 await _make_session(db, status="completed", started_at=old)
+            if dialect is not None:
+                assert db.dialect != dialect, (
+                    f"the override is a no-op: the store already reports {dialect}"
+                )
+                db.dialect = dialect
             where_sql, params = maint._session_retention_predicate(time.time() - 30 * 86400)
             async for _chunk in maint._candidate_chunks(
                 db, table="sessions", where_sql=where_sql, params=params, size=2
@@ -1114,6 +1126,30 @@ def test_the_candidate_paging_query_seeks_rather_than_sorting(tmp_path, monkeypa
     )
     assert "sqlite_autoindex_sessions_1" in rendered, (
         f"the paging query is not walking the primary key: {rendered}"
+    )
+
+
+def test_the_paging_query_does_not_carry_sqlite_syntax_to_postgres(tmp_path, monkeypatch):
+    """`INDEXED BY` is SQLite-only, and the prune also runs on Postgres.
+
+    Nothing gates `prune_old_data` by dialect: the scheduler tick and the admin
+    route both call it against whatever `StateDB` resolves to. PostgreSQL has
+    no `INDEXED BY` clause, so emitting one unconditionally would fail every
+    pass at prepare time rather than merely planning it badly. It also does not
+    need the hint, keeping its own statistics.
+
+    The failure this guards is invisible to the SQLite suite by construction,
+    which is why it is asserted on the built statement rather than on a result.
+    """
+    _, sql, _ = _captured_chunk_sql(tmp_path, monkeypatch, dialect="postgresql")
+
+    assert "INDEXED BY" not in sql.upper(), (
+        f"the paging query carries SQLite-only syntax to Postgres: {sql}"
+    )
+    assert "sqlite_autoindex" not in sql, f"SQLite index name leaked into a Postgres query: {sql}"
+    # Still the same scan, not a differently-shaped one.
+    assert "ORDER BY id" in sql and "id > ?" in sql, (
+        f"the Postgres form is not a forward seek: {sql}"
     )
 
 

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import time
 import uuid
 from pathlib import Path
@@ -1045,3 +1046,101 @@ def test_run_chunk_archive_failure_aborts_dispatch_and_keeps_session_deletes(tmp
     assert list(archive_dir.glob("run-*.zip")) == []
     assert list(archive_dir.glob("dispatch-*.zip")) == []
     assert len(list(archive_dir.glob("prune-*.zip"))) == 1
+
+
+# ── candidate paging keeps a forward seek ─────────────────────────────────────
+
+
+def _captured_chunk_sql(tmp_path, monkeypatch) -> tuple[Path, str, tuple]:
+    """Drive `_candidate_chunks` and return the SQL it actually built.
+
+    The statement is taken from the running code rather than restated here, so
+    the plan assertions below fail if the source stops asking for the index.
+    """
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+
+    seen: list[tuple[str, tuple]] = []
+    real_q = maint._q
+
+    def capture(sql, params):
+        seen.append((sql, tuple(params)))
+        return real_q(sql, params)
+
+    monkeypatch.setattr(maint, "_q", capture)
+
+    old = time.time() - 90 * 86400
+
+    async def drive() -> None:
+        async with StateDB() as db:
+            for _ in range(3):
+                await _make_session(db, status="completed", started_at=old)
+            where_sql, params = maint._session_retention_predicate(time.time() - 30 * 86400)
+            async for _chunk in maint._candidate_chunks(
+                db, table="sessions", where_sql=where_sql, params=params, size=2
+            ):
+                pass
+
+    run_async(drive())
+
+    selects = [(s, p) for s, p in seen if s.lstrip().upper().startswith("SELECT ID FROM SESSIONS")]
+    assert selects, f"no candidate SELECT captured; saw {[s[:60] for s, _ in seen]}"
+    sql, params = selects[0]
+    return db_path, sql, params
+
+
+def test_the_candidate_paging_query_seeks_rather_than_sorting(tmp_path, monkeypatch):
+    """Each page must be a forward seek on the primary key, not a re-sort.
+
+    Left to the planner with no collected statistics, SQLite prefers the
+    status/time index and adds a temporary sort for ORDER BY id, which makes
+    every page re-read and re-sort the whole remaining backlog. That is
+    invisible to a correctness test -- the ids come out identical either way --
+    so the plan itself is what has to be asserted.
+    """
+    db_path, sql, params = _captured_chunk_sql(tmp_path, monkeypatch)
+
+    con = sqlite3.connect(db_path)
+    try:
+        plan = [row[-1] for row in con.execute("EXPLAIN QUERY PLAN " + sql, params)]
+    finally:
+        con.close()
+
+    rendered = " | ".join(plan)
+    assert "TEMP B-TREE" not in rendered.upper(), (
+        f"the paging query sorts instead of seeking, which is the quadratic plan: {rendered}"
+    )
+    assert "sqlite_autoindex_sessions_1" in rendered, (
+        f"the paging query is not walking the primary key: {rendered}"
+    )
+
+
+def test_every_paged_table_has_the_primary_key_index_the_query_names(tmp_path, monkeypatch):
+    """The paging query names `sqlite_autoindex_<table>_1` for three tables.
+
+    That name exists because each table declares `id TEXT PRIMARY KEY`. If a
+    schema change removes or renames it the prune fails at prepare time, so
+    this pins the assumption where it is cheap to read rather than leaving it
+    to be discovered during a retention pass.
+    """
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+
+    async def touch() -> None:
+        async with StateDB() as db:
+            await _make_session(db, status="completed", started_at=time.time())
+
+    run_async(touch())
+
+    con = sqlite3.connect(db_path)
+    try:
+        for table in ("sessions", "schedule_runs", "dispatch_outbox"):
+            name = f"sqlite_autoindex_{table}_1"
+            indexes = {row[1] for row in con.execute(f"PRAGMA index_list({table})")}
+            assert name in indexes, f"{table} has no {name}; found {sorted(indexes)}"
+            columns = [row[2] for row in con.execute(f"PRAGMA index_info({name})")]
+            assert columns == ["id"], f"{name} covers {columns}, not the id the query seeks on"
+    finally:
+        con.close()

--- a/tests/apps_studio_server/test_retention_archive.py
+++ b/tests/apps_studio_server/test_retention_archive.py
@@ -419,7 +419,10 @@ def test_candidate_selection_is_read_one_chunk_at_a_time(tmp_path, monkeypatch):
     # The pass still prunes everything; only how it reads changed.
     assert result["sessions_pruned"] == len(ids) == 5
 
-    candidate_reads = [(s, p) for s, p in issued if s.startswith("SELECT id FROM sessions WHERE")]
+    # Matched up to the table name only: the paged read carries an INDEXED BY
+    # clause between the table and the WHERE, so a prefix reaching as far as
+    # WHERE silently selects the per-chunk rechecks and none of the pages.
+    candidate_reads = [(s, p) for s, p in issued if s.startswith("SELECT id FROM sessions")]
     assert candidate_reads, "the pass issued no candidate selection at all"
     paged = [(s, p) for s, p in candidate_reads if s.endswith("ORDER BY id LIMIT ?")]
     # Five candidates at two per read cannot be covered by one read, so this


### PR DESCRIPTION
The chunked candidate scan orders by id so the cursor can make forward
progress, but nothing told SQLite which index to walk. With no collected
statistics, and nothing in the tree runs `ANALYZE`, the planner prefers the
narrower status/time index and then adds a temporary sort for the `ORDER BY`.
Every page then re-reads and re-sorts the whole remaining eligible backlog
instead of seeking past the ids it already returned, so the cost of a pass
grows with the square of the backlog it exists to drain.

Measured on a store built from this schema, walking the full backlog:

| rows | eligible | time |
|---|---|---|
| 60,000 | 35,779 | 2.180s |
| 240,000 | 143,694 | 43.772s |

Four times the rows for twenty times the time. Naming the primary key index
turns each page back into a forward seek and the 240,000-row walk into 0.121s.

## The hint is SQLite-only, so it is gated

`INDEXED BY` does not exist in PostgreSQL, and nothing gates the prune by
dialect: the scheduler tick and the admin route both call `prune_old_data()`
against whatever `StateDB` resolves to, which is sqlite or postgresql. Emitting
the clause unconditionally would fail every pass on a Postgres-backed store at
prepare time, which is a worse outcome than the bad plan it fixes. PostgreSQL
also does not need it, keeping its own table statistics.

## Why the tests assert a query plan

The ids a pass selects are unchanged; only the plan is. A correctness test
cannot see this in either direction, so the guard asserts the plan itself and
takes the statement from the running code rather than restating it. A second
test pins the primary key index each paged table relies on, so a schema change
that removes it fails where it is cheap to read. A third asserts the built
statement carries no SQLite syntax when the dialect is postgresql, since the
SQLite suite cannot observe that failure by construction.

Asking for an index that does not exist is a prepare-time error, so a schema
change that removes it fails loudly instead of quietly restoring the quadratic
plan.
