### PR TITLE
fix(engines): isolate transport failures in the verifier stages too

### DIFF
--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -70,6 +70,13 @@ _ISOLATED_ERRORS: tuple[type[BaseException], ...] = (ProviderError, *_TRANSPORT_
 # prompt that overflowed rather than of the run -- one verifier's oversized
 # prompt says nothing about the next one's, which is why the engine repairs it
 # instead of failing.
+_RUN_WIDE_REFUSALS: tuple[type[BaseException], ...] = (
+    ProviderAuthError,
+    ProviderQuotaError,
+    ProviderSafetyError,
+    ProviderUnsupportedModelError,
+)
+
 # What a review resolves to when it was asked for executed evidence and has
 # none. Not an approval and not a rejection: nothing was examined, so there is
 # no finding either way, and the honest report says which.
@@ -79,12 +86,10 @@ _EVIDENCE_EMPTY_REASON = (
     "the artifact; withheld as a pass rather than reported as one."
 )
 
-_RUN_WIDE_REFUSALS: tuple[type[BaseException], ...] = (
-    ProviderAuthError,
-    ProviderQuotaError,
-    ProviderSafetyError,
-    ProviderUnsupportedModelError,
-)
+
+def _is_approving(verdict: str) -> bool:
+    """Whether a decision reads as a pass, by the one spelling used throughout."""
+    return verdict.strip().upper().startswith("APPROVE")
 
 
 @lru_cache(maxsize=1)
@@ -439,6 +444,20 @@ class ReviewEngine(Engine):
         verdicts = run.by_type(ReviewVerdict)
         if not verdicts:
             return ""
+        # Exhaustion is not a way around the evidence check. The verdict this
+        # exports was emitted before the run was cut short, so it can be the
+        # same unbacked pass the ordinary path withholds, reached by a route
+        # that never runs the guard: the run ends inside synthesis, after the
+        # record exists and before anything has looked at it. Withheld here
+        # too, and before the text below is composed, so the record and the
+        # string it produces say the same thing.
+        unbacked = (
+            [v for v in verdicts if _is_approving(v.verdict)]
+            if self._evidence_is_empty(run)
+            else []
+        )
+        if unbacked:
+            self._withhold_emitted_approvals(run, unbacked)
         verdict = verdicts[-1]
         run.notify("verdict_emitted_on_exhaustion", verdict=verdict.verdict)
         status_header = (
@@ -689,18 +708,36 @@ class ReviewEngine(Engine):
         far side of a boundary is an assumption this package cannot check, and
         two callers do not have to share one.
         """
-        if not self.verify_clean or run.by_type(VerifyResult):
+        if not self._evidence_is_empty(run):
             return text
         emitted = run.by_type(ReviewVerdict)
-        approving = [v for v in emitted if v.verdict.strip().upper().startswith("APPROVE")]
+        approving = [v for v in emitted if _is_approving(v.verdict)]
         if emitted and not approving:
             return text
-        if not emitted and not text.strip().upper().startswith("APPROVE"):
+        if not emitted and not _is_approving(text):
             # Nothing structured to read and the prose does not open with a
             # pass. Refusing here would relabel a non-approval as a refusal,
             # which loses a real decision to guard against one that is not
             # being made.
             return text
+        self._withhold_emitted_approvals(run, approving)
+        return f"{_EVIDENCE_EMPTY_DECISION}: {_EVIDENCE_EMPTY_REASON}\n\n{text}"
+
+    def _evidence_is_empty(self, run: EngineRun) -> bool:
+        """True when this engine was asked for evidence and has none to show.
+
+        Split out because the exhaustion path has to ask the same question and
+        a second copy of the condition is a second thing to keep in step.
+        """
+        return bool(self.verify_clean) and not run.by_type(VerifyResult)
+
+    def _withhold_emitted_approvals(self, run: EngineRun, approving: list[ReviewVerdict]) -> None:
+        """Relabel emitted passes as inconclusive and record that it happened.
+
+        Callers decide whether to withhold; this performs it. Kept in one place
+        so the ordinary path and the exhaustion path cannot drift into
+        withholding different things or recording it differently.
+        """
         for verdict in approving:
             verdict.rationale = (
                 f"{_EVIDENCE_EMPTY_REASON} Withheld decision was {verdict.verdict!r}. "
@@ -711,4 +748,3 @@ class ReviewEngine(Engine):
         marker = "verdict (evidence-empty)"
         if marker not in run._emission_failures:
             run._emission_failures.append(marker)
-        return f"{_EVIDENCE_EMPTY_DECISION}: {_EVIDENCE_EMPTY_REASON}\n\n{text}"

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -19,7 +19,13 @@ from lionagi.ln.concurrency._compat import (
     get_exception_group_exceptions,
     is_exception_group,
 )
-from lionagi.providers._provider_errors import ProviderError
+from lionagi.providers._provider_errors import (
+    ProviderAuthError,
+    ProviderError,
+    ProviderQuotaError,
+    ProviderSafetyError,
+    ProviderUnsupportedModelError,
+)
 
 from .engine import Engine, EngineEvent, EngineRun
 
@@ -49,6 +55,27 @@ _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
 )
 
 _ISOLATED_ERRORS: tuple[type[BaseException], ...] = (ProviderError, *_TRANSPORT_ERRORS)
+
+# Refusals that describe the run rather than one attempt. The credentials, the
+# quota, the model and the safety policy are the same for every dimension, so a
+# refusal on any of those grounds recurs identically on the next dimension and
+# on any retry. They are ProviderError subclasses, so the isolated set above
+# already covers them, and covering them is wrong: isolating one records a
+# skipped dimension and lets the run reach a verdict, which turns a run-wide
+# misconfiguration into a quietly degraded pass over an artifact whose
+# dimensions were never actually read. A safety refusal is the sharpest case,
+# because the reason the content was not reviewed is the finding.
+#
+# Context overflow is deliberately not here. That is a property of the single
+# prompt that overflowed rather than of the run -- one verifier's oversized
+# prompt says nothing about the next one's, which is why the engine repairs it
+# instead of failing.
+_RUN_WIDE_REFUSALS: tuple[type[BaseException], ...] = (
+    ProviderAuthError,
+    ProviderQuotaError,
+    ProviderSafetyError,
+    ProviderUnsupportedModelError,
+)
 
 
 @lru_cache(maxsize=1)
@@ -156,6 +183,11 @@ def _is_transport_mcp_error(exc: BaseException) -> bool:
 
 def _is_all_isolated_failure(exc: BaseException) -> bool:
     """True iff every leaf is a per-dimension provider/transport failure, recursing into nested groups."""
+    if isinstance(exc, _RUN_WIDE_REFUSALS):
+        # Asked before the isolated set, not after. These derive from
+        # ProviderError, so the wider test answers True for all of them and
+        # this branch would never be reached from below it.
+        return False
     if isinstance(exc, _ISOLATED_ERRORS):
         return True
     if _is_transport_mcp_error(exc):
@@ -434,11 +466,14 @@ class ReviewEngine(Engine):
         # reaches here and ends the run.
         await run.wait_quiescence()
         # A clean or minor-only review spawns no issue verifiers, so it would
-        # reach the verdict with zero VerifyResult — and a downstream evidence
-        # floor then refuses the APPROVE as evidence-empty, structurally.
-        # Gate on zero VerifyResult (not zero issues) so both shapes instead
-        # carry one adversarial audit of the clean verdict itself: positive
-        # executed evidence rather than absence.
+        # reach the verdict with zero VerifyResult and ship an APPROVE backed
+        # by nothing executed. A consumer may well refuse that as
+        # evidence-empty, but whether any given one does is a property of that
+        # consumer's code and is not observable from this package, so it is not
+        # a guard this engine gets to count on. Gate on zero VerifyResult (not
+        # zero issues) so both shapes instead carry one adversarial audit of
+        # the clean verdict itself: positive executed evidence rather than
+        # absence, decided here where it can be seen.
         if self.verify_clean and not run.by_type(VerifyResult):
             await self._verify_clean_isolated(run, artifact, dims)
         return await self._verdict(run, artifact, dims)

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -428,7 +428,10 @@ class ReviewEngine(Engine):
             # background work mutates shared run state after _run exits.
             await run.cancel_active()
             raise
-        # Drain any adversarial verifiers spawned by high-severity issues.
+        # Drain any adversarial verifiers spawned by high-severity issues. Each
+        # was spawned already wrapped, so a dead verifier worker is recorded and
+        # the drain stays clean; anything the wrapper does not claim still
+        # reaches here and ends the run.
         await run.wait_quiescence()
         # A clean or minor-only review spawns no issue verifiers, so it would
         # reach the verdict with zero VerifyResult — and a downstream evidence
@@ -437,14 +440,14 @@ class ReviewEngine(Engine):
         # carry one adversarial audit of the clean verdict itself: positive
         # executed evidence rather than absence.
         if self.verify_clean and not run.by_type(VerifyResult):
-            await self._verify_clean(run, artifact, dims)
+            await self._verify_clean_isolated(run, artifact, dims)
         return await self._verdict(run, artifact, dims)
 
     # -- reactions ------------------------------------------------------------
 
     def _on_issue(self, run: EngineRun, issue: IssueFound) -> None:
         if issue.severity in self.verify_severities and not run.seen(_verify_key(issue)):
-            run.spawn(self._verify(run, issue))
+            run.spawn(self._verify_isolated(run, issue))
 
     # -- stages ---------------------------------------------------------------
 
@@ -476,6 +479,53 @@ class ReviewEngine(Engine):
             marker = f"review-{dimension} ({error_type})"
             if marker not in run._emission_failures:
                 run._emission_failures.append(marker)
+
+    def _isolate_verification_failure(
+        self, run: EngineRun, exc: BaseException, *, stage: str
+    ) -> bool:
+        """Record an isolated verification failure; False means the caller must re-raise.
+
+        Verification is discretionary work performed on evidence that already
+        exists: by the time a verifier runs, its dimension has reported and its
+        findings are on the run. A provider or transport failure here says the
+        worker died, not that the review is unsound, so it degrades the audit of
+        one finding rather than the run that produced it. The drain already
+        treats one failure this way — ``EngineBudgetError`` is swallowed as
+        discretionary work declined — and this extends the same reading to the
+        transport failures the dimension stage isolates.
+
+        The failure stays visible: the marker reaches the caller through
+        ``_emission_failures`` and is reported alongside the result, so a run
+        that verified less than it intended says so instead of presenting a
+        verdict as fully audited.
+        """
+        if not _is_all_isolated_failure(exc):
+            return False
+        error_type = _failure_label(exc)
+        run.notify("verification_failed", stage=stage, error_type=error_type)
+        marker = f"{stage} ({error_type})"
+        if marker not in run._emission_failures:
+            run._emission_failures.append(marker)
+        return True
+
+    async def _verify_isolated(self, run: EngineRun, issue: IssueFound) -> None:
+        try:
+            await self._verify(run, issue)
+        except Exception as exc:
+            # Spawned into the run's background set, so an escape does not fail
+            # this verifier alone: the drain collects it and re-raises, which
+            # discards a review whose dimensions have already succeeded.
+            if not self._isolate_verification_failure(run, exc, stage=f"verify-{issue.dimension}"):
+                raise
+
+    async def _verify_clean_isolated(
+        self, run: EngineRun, artifact: str, dimensions: tuple[str, ...]
+    ) -> None:
+        try:
+            await self._verify_clean(run, artifact, dimensions)
+        except Exception as exc:
+            if not self._isolate_verification_failure(run, exc, stage="verify-clean"):
+                raise
 
     async def _review_dimension(self, run: EngineRun, artifact: str, dimension: str) -> None:
         emits = (IssueFound, DimensionClean)

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -70,6 +70,15 @@ _ISOLATED_ERRORS: tuple[type[BaseException], ...] = (ProviderError, *_TRANSPORT_
 # prompt that overflowed rather than of the run -- one verifier's oversized
 # prompt says nothing about the next one's, which is why the engine repairs it
 # instead of failing.
+# What a review resolves to when it was asked for executed evidence and has
+# none. Not an approval and not a rejection: nothing was examined, so there is
+# no finding either way, and the honest report says which.
+_EVIDENCE_EMPTY_DECISION = "INCONCLUSIVE"
+_EVIDENCE_EMPTY_REASON = (
+    "every verifier this run spawned failed, so nothing was executed against "
+    "the artifact; withheld as a pass rather than reported as one."
+)
+
 _RUN_WIDE_REFUSALS: tuple[type[BaseException], ...] = (
     ProviderAuthError,
     ProviderQuotaError,
@@ -651,4 +660,55 @@ class ReviewEngine(Engine):
         res = await synth.operate(
             instruction=_verdict_instruction(artifact, dimensions, issues, verifications, clean)
         )
-        return str(res) if res is not None else ""
+        return self._refuse_unevidenced_approval(run, str(res) if res is not None else "")
+
+    def _refuse_unevidenced_approval(self, run: EngineRun, text: str) -> str:
+        """Withhold a pass that rests on nothing executed.
+
+        Reaching synthesis with no VerifyResult at all means every verifier
+        this run spawned died, because isolating a verifier failure records it
+        and carries on. Synthesis is handed counts, has no branch that can
+        refuse, and is not asked for one, so an absence of evidence arrives
+        looking like an absence of problems. That was survivable while a dead
+        verifier ended the run. Once it degrades instead, a quiet pass over an
+        unexamined artifact is what this engine hands its caller, and the
+        degraded flag beside it does not help a reader who keys on the
+        decision.
+
+        Only when the engine was configured to produce evidence. With
+        ``verify_clean`` off a review spawns no verifiers of its own, so having
+        none to show is the ordinary case and a clean verdict is the honest
+        answer rather than an unbacked one.
+
+        Both channels, because they have different readers: the emitted
+        ``ReviewVerdict`` carries the decision as a field, and the returned
+        string is what the run resolves to. Refusing in one leaves the other
+        still reading as a pass.
+
+        Decided here rather than left to whoever consumes this. A guard on the
+        far side of a boundary is an assumption this package cannot check, and
+        two callers do not have to share one.
+        """
+        if not self.verify_clean or run.by_type(VerifyResult):
+            return text
+        emitted = run.by_type(ReviewVerdict)
+        approving = [v for v in emitted if v.verdict.strip().upper().startswith("APPROVE")]
+        if emitted and not approving:
+            return text
+        if not emitted and not text.strip().upper().startswith("APPROVE"):
+            # Nothing structured to read and the prose does not open with a
+            # pass. Refusing here would relabel a non-approval as a refusal,
+            # which loses a real decision to guard against one that is not
+            # being made.
+            return text
+        for verdict in approving:
+            verdict.rationale = (
+                f"{_EVIDENCE_EMPTY_REASON} Withheld decision was {verdict.verdict!r}. "
+                f"{verdict.rationale}"
+            )
+            verdict.verdict = _EVIDENCE_EMPTY_DECISION
+        run.notify("verdict_refused", reason="evidence-empty")
+        marker = "verdict (evidence-empty)"
+        if marker not in run._emission_failures:
+            run._emission_failures.append(marker)
+        return f"{_EVIDENCE_EMPTY_DECISION}: {_EVIDENCE_EMPTY_REASON}\n\n{text}"

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -11,9 +11,14 @@ import anyio
 import pytest
 
 from lionagi.engines.engine import Engine, EngineBudgetError
-from lionagi.engines.review import ReviewEngine, _is_all_isolated_failure
+from lionagi.engines.review import (
+    DimensionClean,
+    IssueFound,
+    ReviewEngine,
+    _is_all_isolated_failure,
+)
 from lionagi.ln.concurrency._compat import ExceptionGroup
-from lionagi.providers._provider_errors import ProviderContextError
+from lionagi.providers._provider_errors import ProviderContextError, WorkerLivenessError
 
 
 class _StubEngine(Engine):
@@ -387,3 +392,162 @@ async def test_the_sdks_own_transport_failures_are_still_recognised(failure: str
                 task_group.cancel_scope.cancel()
 
     assert _is_all_isolated_failure(caught.value) is True
+
+
+# ---------------------------------------------------------------------------
+# Verifier-stage isolation.
+#
+# The dimension stage is only one of three places this engine does work. The
+# adversarial verifiers are spawned into the run's background set and drained by
+# wait_quiescence(), which re-raises everything except cancellation and budget
+# exhaustion; the clean-verify is awaited directly at the end of _run. A worker
+# that dies in either place therefore discarded a review whose dimensions had
+# already reported, throwing away findings that were already on the run.
+# ---------------------------------------------------------------------------
+
+
+class _DeadVerifierReview(ReviewEngine):
+    """The dimension reports a finding; the verifier that finding triggers dies."""
+
+    def __init__(self, failure: BaseException) -> None:
+        super().__init__(dimensions=("security",), verify_clean=False)
+        self._failure = failure
+        self.issues_at_verdict = -1
+
+    async def _review_dimension(self, run, artifact: str, dimension: str) -> None:
+        await run.emit(
+            IssueFound(
+                dimension=dimension,
+                description="a finding worth verifying",
+                severity="critical",
+            )
+        )
+
+    async def _verify(self, run, issue) -> None:
+        # The sleep is load-bearing, not scene-setting. A spawned task that
+        # finishes before the drain is entered removes itself from the active
+        # set via its done-callback, so wait_quiescence() finds nothing to
+        # collect and the exception is discarded. Failing while still in flight
+        # is what puts this arm on the isolation predicate rather than on that
+        # timing, and it is also what a real verifier does: it works, then dies.
+        await asyncio.sleep(0.05)
+        raise self._failure
+
+    async def _verdict(self, run, artifact: str, dimensions: tuple[str, ...]) -> str:
+        self.issues_at_verdict = len(run.by_type(IssueFound))
+        return "verdict reached"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("make_failure", "expected_label"),
+    [
+        # The class that actually took the lane down. It subclasses
+        # ProviderError, so it always qualified for isolation — it escaped
+        # because this path had no isolation to qualify for.
+        (
+            lambda: WorkerLivenessError("worker produced no first stream output"),
+            "WorkerLivenessError",
+        ),
+        (lambda: anyio.ClosedResourceError(), "ClosedResourceError"),
+        (lambda: ProviderContextError("provider context overflow"), "ProviderContextError"),
+        # Two verifiers dying together is the observed shape: the drain gathers
+        # every spawned failure and reports them as one group.
+        (
+            lambda: ExceptionGroup(
+                "unhandled errors in a TaskGroup",
+                [
+                    WorkerLivenessError("worker produced no first stream output"),
+                    WorkerLivenessError("worker produced no first stream output"),
+                ],
+            ),
+            "WorkerLivenessError",
+        ),
+    ],
+)
+async def test_a_dead_verifier_does_not_discard_a_review_whose_dimensions_succeeded(
+    make_failure, expected_label: str
+) -> None:
+    events: list[dict] = []
+    engine = _DeadVerifierReview(make_failure())
+
+    result = await engine.run("artifact", on_event=events.append)
+
+    assert result == "verdict reached"
+    # The evidence the dead verifier was auditing is still on the run. This is
+    # the whole point: the findings existed before the verifier was spawned.
+    assert engine.issues_at_verdict == 1
+    assert result.degraded is True
+    assert result.skipped == [f"verify-security ({expected_label})"]
+    # The marker has to reach the caller, not just the run: this string is what
+    # the CLI folds into the recorded error for the run, so a degraded review
+    # says which stage degraded rather than only that something did.
+    assert result.degrade_reason == f"emission_failure: verify-security ({expected_label})"
+    assert any(
+        event["type"] == "verification_failed"
+        and event["stage"] == "verify-security"
+        and event["error_type"] == expected_label
+        for event in events
+    )
+
+
+class _NonTransportVerifierReview(_DeadVerifierReview):
+    def __init__(self) -> None:
+        super().__init__(ValueError("a genuine defect in the verifier"))
+
+
+@pytest.mark.asyncio
+async def test_a_non_transport_verifier_failure_still_ends_the_run() -> None:
+    """Isolation is a claim about transport, not a blanket swallow.
+
+    Without this arm the fix reads identically whether the predicate is
+    consulted or the except clause simply discards everything.
+    """
+    engine = _NonTransportVerifierReview()
+
+    with pytest.raises(ValueError, match="a genuine defect in the verifier"):
+        await engine.run("artifact")
+
+
+class _DeadCleanVerifierReview(ReviewEngine):
+    """No issues, so the clean-verify runs — and its worker dies."""
+
+    def __init__(self, failure: BaseException) -> None:
+        super().__init__(dimensions=("security",), verify_clean=True)
+        self._failure = failure
+
+    async def _review_dimension(self, run, artifact: str, dimension: str) -> None:
+        await run.emit(DimensionClean(dimension=dimension, rationale="nothing found"))
+
+    async def _verify_clean(self, run, artifact: str, dimensions: tuple[str, ...]) -> None:
+        raise self._failure
+
+    async def _verdict(self, run, artifact: str, dimensions: tuple[str, ...]) -> str:
+        return "clean verdict reached"
+
+
+@pytest.mark.asyncio
+async def test_a_dead_clean_verifier_degrades_instead_of_killing_the_run() -> None:
+    events: list[dict] = []
+    engine = _DeadCleanVerifierReview(WorkerLivenessError("worker produced no first stream output"))
+
+    result = await engine.run("artifact", on_event=events.append)
+
+    assert result == "clean verdict reached"
+    assert result.degraded is True
+    assert result.skipped == ["verify-clean (WorkerLivenessError)"]
+    assert result.degrade_reason == "emission_failure: verify-clean (WorkerLivenessError)"
+    assert any(
+        event["type"] == "verification_failed"
+        and event["stage"] == "verify-clean"
+        and event["error_type"] == "WorkerLivenessError"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_non_transport_clean_verifier_failure_still_ends_the_run() -> None:
+    engine = _DeadCleanVerifierReview(ValueError("a genuine defect in the clean verifier"))
+
+    with pytest.raises(ValueError, match="a genuine defect in the clean verifier"):
+        await engine.run("artifact")

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -18,7 +18,14 @@ from lionagi.engines.review import (
     _is_all_isolated_failure,
 )
 from lionagi.ln.concurrency._compat import ExceptionGroup
-from lionagi.providers._provider_errors import ProviderContextError, WorkerLivenessError
+from lionagi.providers._provider_errors import (
+    ProviderAuthError,
+    ProviderContextError,
+    ProviderQuotaError,
+    ProviderSafetyError,
+    ProviderUnsupportedModelError,
+    WorkerLivenessError,
+)
 
 
 class _StubEngine(Engine):
@@ -550,4 +557,68 @@ async def test_a_non_transport_clean_verifier_failure_still_ends_the_run() -> No
     engine = _DeadCleanVerifierReview(ValueError("a genuine defect in the clean verifier"))
 
     with pytest.raises(ValueError, match="a genuine defect in the clean verifier"):
+        await engine.run("artifact")
+
+
+# -- run-wide refusals are not per-dimension blips ----------------------------
+# Every one of these derives from ProviderError, so the isolated set matched
+# them all and each was recorded as a skipped dimension. The run then reached a
+# verdict over an artifact whose dimensions were never read, and the reason was
+# a bad credential or a safety refusal rather than a dropped socket.
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ProviderAuthError("invalid api key"),
+        ProviderQuotaError("rate limit exceeded"),
+        ProviderSafetyError("content flagged by a safety filter"),
+        ProviderUnsupportedModelError("unknown model"),
+    ],
+    ids=lambda failure: type(failure).__name__,
+)
+def test_a_refusal_that_describes_the_run_is_not_isolated(failure: BaseException) -> None:
+    assert _is_all_isolated_failure(failure) is False
+
+
+def test_the_neighbouring_provider_failures_are_still_isolated() -> None:
+    """The control for the exclusion: it must not widen into ProviderError itself.
+
+    Without this arm, deleting the whole isolated set passes every assertion
+    above, because refusing everything satisfies a suite that only ever asks
+    what is refused.
+    """
+    assert _is_all_isolated_failure(ProviderContextError("provider context overflow")) is True
+    assert _is_all_isolated_failure(WorkerLivenessError("no first stream output")) is True
+    assert _is_all_isolated_failure(anyio.ClosedResourceError()) is True
+
+
+def test_a_group_of_transport_failures_carrying_one_refusal_is_not_isolated() -> None:
+    # The shape that hides it: several dimensions die of transport at once and
+    # one dies of a bad credential. Judged as a group, the majority reads as an
+    # ordinary blip.
+    group = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [
+            anyio.ClosedResourceError(),
+            WorkerLivenessError("no first stream output"),
+            ProviderAuthError("invalid api key"),
+        ],
+    )
+
+    assert _is_all_isolated_failure(group) is False
+
+
+@pytest.mark.asyncio
+async def test_a_clean_verifier_refused_for_credentials_ends_the_run() -> None:
+    """The end-to-end arm: the predicate is consulted where it decides a run.
+
+    Its control is the WorkerLivenessError case above, which takes the same
+    path with the same engine and degrades to a verdict. One failure class
+    reaches a result and the other does not, so this cannot pass by the engine
+    having stopped isolating anything.
+    """
+    engine = _DeadCleanVerifierReview(ProviderAuthError("invalid api key"))
+
+    with pytest.raises(ProviderAuthError, match="invalid api key"):
         await engine.run("artifact")

--- a/tests/engines/test_review.py
+++ b/tests/engines/test_review.py
@@ -261,8 +261,9 @@ def test_verify_instruction_names_the_ref_field():
 
 # -- clean-verdict audit ------------------------------------------------------
 # A clean or minor-only review spawns no issue verifiers, so it used to reach
-# the verdict with zero VerifyResult — and a downstream evidence floor then
-# refused the APPROVE as evidence-empty, structurally, on every clean run.
+# the verdict with zero VerifyResult and ship an APPROVE backed by nothing
+# executed. Whether a consumer refuses that as evidence-empty is the consumer's
+# own code and is not observable from here, so it is not what these tests pin.
 # The engine now audits its own clean verdict: one adversarial verifier that
 # must execute a real check and emit a VerifyResult carrying the run's clean
 # ref, so a clean verdict ships positive evidence instead of absence.

--- a/tests/engines/test_review.py
+++ b/tests/engines/test_review.py
@@ -11,6 +11,7 @@ from lionagi.engines.review import (
     DimensionClean,
     IssueFound,
     ReviewEngine,
+    ReviewVerdict,
     VerifyResult,
     _clean_ref,
     _verdict_instruction,
@@ -432,3 +433,75 @@ def test_verdict_instruction_inverts_polarity_for_refuted_clean_audit():
     without_audit = _verdict_instruction("ART", dims, [issue], [ordinary], [])
     assert "Clean-verdict audit" not in without_audit
     assert "weigh that AGAINST approval" not in without_audit
+
+
+# -- withholding a pass that rests on nothing executed ------------------------
+
+
+class _ApprovingSynth:
+    """Synthesis that emits an APPROVE, the way a real one does on a clean run."""
+
+    name = "verdict"
+
+    def __init__(self, run):
+        self._run = run
+
+    async def operate(self, *, instruction):
+        await self._run.emit(ReviewVerdict(verdict="APPROVE", rationale="nothing found"))
+        return "APPROVE: nothing found"
+
+
+def _synth_factory(run):
+    async def fake_make(role, **kw):
+        return _ApprovingSynth(run)
+
+    return fake_make
+
+
+@pytest.mark.asyncio
+async def test_an_approval_with_no_executed_evidence_is_withheld():
+    """Isolating a dead verifier records it and carries on, so a run whose
+    verifiers all died reaches synthesis with no VerifyResult. Synthesis is
+    handed counts and has no branch that can refuse, so the absence of evidence
+    arrives looking like an absence of problems."""
+    eng = ReviewEngine(verify_clean=True)
+    run = eng.new_run()
+    run.make_agent = _synth_factory(run)
+
+    out = await eng._verdict(run, "ART", ("security",))
+
+    assert out.startswith("INCONCLUSIVE"), out
+    emitted = run.by_type(ReviewVerdict)[0]
+    assert emitted.verdict == "INCONCLUSIVE"
+    # The withheld decision is kept rather than erased: a reader has to be able
+    # to see what was refused, or the refusal is unauditable.
+    assert "APPROVE" in emitted.rationale
+
+
+@pytest.mark.asyncio
+async def test_an_approval_backed_by_a_verification_is_left_alone():
+    """The control that keeps the guard from reading as 'never approve'."""
+    eng = ReviewEngine(verify_clean=True)
+    run = eng.new_run()
+    await run.emit(VerifyResult(issue="sqli", holds=False, rationale="boundary test refutes"))
+    run.make_agent = _synth_factory(run)
+
+    out = await eng._verdict(run, "ART", ("security",))
+
+    assert out == "APPROVE: nothing found"
+    assert run.by_type(ReviewVerdict)[0].verdict == "APPROVE"
+
+
+@pytest.mark.asyncio
+async def test_a_review_that_was_never_asked_for_evidence_still_approves():
+    """With verify_clean off no verifier is spawned at all, so having no
+    VerifyResult is the ordinary case rather than the failed one. Withholding
+    here would refuse every clean review the engine was configured to do."""
+    eng = ReviewEngine(verify_clean=False)
+    run = eng.new_run()
+    run.make_agent = _synth_factory(run)
+
+    out = await eng._verdict(run, "ART", ("security",))
+
+    assert out == "APPROVE: nothing found"
+    assert run.by_type(ReviewVerdict)[0].verdict == "APPROVE"

--- a/tests/engines/test_review.py
+++ b/tests/engines/test_review.py
@@ -493,6 +493,59 @@ async def test_an_approval_backed_by_a_verification_is_left_alone():
 
 
 @pytest.mark.asyncio
+async def test_exhaustion_cannot_export_an_approval_with_no_executed_evidence():
+    """The deadline path reads the emitted verdict and returns it directly.
+
+    A run can end inside synthesis, after the verdict record exists and before
+    anything has looked at it, and the export then hands back exactly the
+    unbacked pass the ordinary path withholds. Reached by a different route,
+    so a guard sitting on the ordinary return does not cover it.
+    """
+    eng = ReviewEngine(verify_clean=True)
+    run = eng.new_run()
+    await run.emit(ReviewVerdict(verdict="APPROVE", rationale="nothing found"))
+
+    out = await eng._partial_export(run, "ART")
+
+    assert "INCONCLUSIVE:" in out, out
+    assert run.by_type(ReviewVerdict)[0].verdict == "INCONCLUSIVE"
+    assert "APPROVE" in run.by_type(ReviewVerdict)[0].rationale
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_exports_an_approval_that_evidence_backs():
+    """Control: the export withholds because evidence is missing, not always."""
+    eng = ReviewEngine(verify_clean=True)
+    run = eng.new_run()
+    await run.emit(VerifyResult(issue="sqli", holds=False, rationale="boundary test refutes"))
+    await run.emit(ReviewVerdict(verdict="APPROVE", rationale="nothing found"))
+
+    out = await eng._partial_export(run, "ART")
+
+    assert "APPROVE: nothing found" in out
+    assert run.by_type(ReviewVerdict)[0].verdict == "APPROVE"
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_does_not_record_a_refusal_it_did_not_make():
+    """A verdict that was never a pass has nothing to withhold.
+
+    Marking one anyway would put an evidence-empty refusal in the run's record
+    for a run that refused nothing, and the marker is what a reader consults to
+    find out whether a decision was withheld.
+    """
+    eng = ReviewEngine(verify_clean=True)
+    run = eng.new_run()
+    await run.emit(ReviewVerdict(verdict="REQUEST-CHANGES", rationale="sqli in the handler"))
+
+    out = await eng._partial_export(run, "ART")
+
+    assert "REQUEST-CHANGES: sqli in the handler" in out
+    assert run.by_type(ReviewVerdict)[0].verdict == "REQUEST-CHANGES"
+    assert not [m for m in run._emission_failures if "evidence-empty" in m]
+
+
+@pytest.mark.asyncio
 async def test_a_review_that_was_never_asked_for_evidence_still_approves():
     """With verify_clean off no verifier is spawned at all, so having no
     VerifyResult is the ordinary case rather than the failed one. Withholding


### PR DESCRIPTION
The review engine isolates ordinary provider and transport failures per review dimension, so one dead worker degrades one dimension instead of ending the run. That isolation covered one of the three places the engine does work.

The adversarial verifiers are spawned into the run background set and drained by `wait_quiescence()`, which re-raises everything except cancellation and budget exhaustion. The clean-verify is awaited directly at the end of the run. Neither carried the wrapper, so a verifier whose worker died discarded the entire review, including dimension findings that were already recorded and were not themselves in question.

The error class was never the gap. `WorkerLivenessError` subclasses `ProviderError` and therefore always qualified for isolation; it escaped because this path had no isolation to qualify for.

## What changed

Both verifier paths now run through the same predicate and the same failure recording the dimension stage uses, with distinct markers naming which stage degraded (`verify-<dimension>` and `verify-clean`).

Verification is discretionary work performed on evidence that already exists: by the time a verifier runs, its dimension has reported. A provider or transport failure there says the worker died, not that the review is unsound. The drain already reads one failure this way, swallowing `EngineBudgetError` as discretionary work declined.

The failure stays visible rather than vanishing behind a result. The marker reaches the caller through the recorded skip list and the degrade reason, so a run that verified less than it intended reports that, naming the stage.

Anything the predicate does not claim is re-raised unchanged, and the dimension stage is untouched.

## Tests

Seven cases. A verifier worker dying mid-run must leave the verdict standing, the findings intact, the result degraded, and the degrade reason naming the stage: covered for `WorkerLivenessError`, `ClosedResourceError`, `ProviderContextError`, and for the exception-group shape two dying verifiers produce. The clean-verify path gets the same. Two negative cases assert a non-transport failure in either verifier still ends the run, so the isolation is a claim about transport rather than a blanket swallow.

Reverting the source change while keeping the tests reddens exactly the five cases that assert degradation and leaves the two negative cases green, which is the expected split since those two do not discriminate.