### PR TITLE
fix(studio): count causes, not rows, in the failed-session threshold

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -4698,7 +4698,7 @@ class StateDB:
         # construction. Grouping by (invocation, reason) makes the observed
         # value the number of distinct things that went wrong.
         #
-        # Both columns are COALESCEd to the session id rather than grouped on
+        # Both columns fall back to the session id rather than grouping on
         # NULL, and that is the whole correctness of this query. NULL is not a
         # shared value: rows without an invocation are rows whose grouping is
         # unknown, and letting SQL treat them as equal merges unrelated
@@ -4707,10 +4707,23 @@ class StateDB:
         # reason and the alarm stops being able to fire. Falling back to a
         # unique per-row value keeps unknown groupings apart, which errs
         # toward alerting.
+        #
+        # The fallback is tagged rather than bare, because a bare one puts two
+        # different namespaces in one column and lets a value from either side
+        # answer for the other: a session with no invocation whose id happens
+        # to equal some other session's invocation_id would share a grouping
+        # key with it, and two distinct causes carrying the same reason would
+        # then count once. That is the direction that suppresses an alert, so
+        # it is the one worth spending a prefix on. Every value now says which
+        # namespace it came from, and no value in one can equal a value in the
+        # other, since the two prefixes differ at their first character.
         "failed_sessions": (
             "SELECT COUNT(*) AS n FROM ("
-            "SELECT DISTINCT COALESCE(invocation_id, id) AS cause_group, "
-            "COALESCE(status_reason_code, id) AS cause_class FROM sessions "
+            "SELECT DISTINCT CASE WHEN invocation_id IS NULL "
+            "THEN 'session:' || id ELSE 'invocation:' || invocation_id END AS cause_group, "
+            "CASE WHEN status_reason_code IS NULL "
+            "THEN 'session:' || id ELSE 'reason:' || status_reason_code END AS cause_class "
+            "FROM sessions "
             "WHERE status IN ('failed', 'timed_out') "
             "AND COALESCE(ended_at, started_at, created_at) >= :window_start"
             # PostgreSQL requires a name for a subquery in FROM; SQLite does

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -4691,10 +4691,33 @@ class StateDB:
     # every VALID_METRICS member is answered somewhere in metric_value, not
     # that it is answered here.
     _THRESHOLD_METRIC_QUERIES: dict[str, str] = {
+        # Counts distinct CAUSES, not rows. A fan-out spawns one session per
+        # worker, so a single wall -- a provider refusing every worker of one
+        # invocation -- lands as many rows carrying one cause, and a fan-out
+        # wider than the threshold would breach it on that single cause by
+        # construction. Grouping by (invocation, reason) makes the observed
+        # value the number of distinct things that went wrong.
+        #
+        # Both columns are COALESCEd to the session id rather than grouped on
+        # NULL, and that is the whole correctness of this query. NULL is not a
+        # shared value: rows without an invocation are rows whose grouping is
+        # unknown, and letting SQL treat them as equal merges unrelated
+        # failures into one. Most failed sessions carry no invocation id, so
+        # the naive form collapses nearly the whole population to one row per
+        # reason and the alarm stops being able to fire. Falling back to a
+        # unique per-row value keeps unknown groupings apart, which errs
+        # toward alerting.
         "failed_sessions": (
-            "SELECT COUNT(*) AS n FROM sessions "
+            "SELECT COUNT(*) AS n FROM ("
+            "SELECT DISTINCT COALESCE(invocation_id, id) AS cause_group, "
+            "COALESCE(status_reason_code, id) AS cause_class FROM sessions "
             "WHERE status IN ('failed', 'timed_out') "
             "AND COALESCE(ended_at, started_at, created_at) >= :window_start"
+            # PostgreSQL requires a name for a subquery in FROM; SQLite does
+            # not, so an unaliased form runs here and fails only on the other
+            # dialect, where the dual-backend suite needs a live server to
+            # catch it.
+            ") AS causes"
         ),
         "total_cost_usd": (
             "SELECT COALESCE(SUM(total_cost_usd), 0) AS n FROM sessions "

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -1321,8 +1321,6 @@ async def _make_failed(
     are created running and then transitioned, which is what puts a real
     reason code on them.
     """
-    import contextlib
-
     prog_id = f"prog-{sess_id}"
     await state.create_progression(prog_id)
     await state.create_session(
@@ -1335,11 +1333,14 @@ async def _make_failed(
     )
     if invocation_id is not None:
         # invocation_id is a foreign key, so the invocation has to exist. The
-        # same id is shared deliberately across a fan-out's sessions.
-        with contextlib.suppress(Exception):
-            await state.create_invocation(
-                {"id": invocation_id, "skill": "test", "started_at": ended_at - 2}
-            )
+        # same id is shared deliberately across a fan-out's sessions, and
+        # create_invocation is ON CONFLICT DO NOTHING, so the repeated calls
+        # that come with it are already no-ops. Nothing is caught here on
+        # purpose: a fixture that swallows its own database errors reports
+        # them later as a wrong count somewhere else.
+        await state.create_invocation(
+            {"id": invocation_id, "skill": "test", "started_at": ended_at - 2}
+        )
         await state.update_session(sess_id, invocation_id=invocation_id)
     await state.update_status(
         "session",
@@ -1414,6 +1415,40 @@ async def test_one_invocation_meeting_two_different_walls_is_two_causes():
     )
     await _make_failed(
         state, "c", ended_at=102.0, invocation_id="shared", reason="run.failed.exception"
+    )
+
+    assert await state.metric_value("failed_sessions", window_start=50.0) == 2.0
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_a_session_id_cannot_answer_for_another_sessions_invocation_id():
+    """The fallback and the real column are different namespaces.
+
+    A session with no invocation falls back to its own id for grouping. If
+    that value is compared against invocation ids as though they were the same
+    namespace, a session whose id happens to equal another session's
+    invocation_id shares a grouping key with it, and when the two also share a
+    reason they count once instead of twice. The error runs toward reporting
+    fewer causes than there are, which is the direction that holds an alert
+    below its threshold, so it fails quietly rather than loudly.
+
+    Nothing stops the two id spaces from overlapping: they are separate tables
+    with separately assigned ids, and equality between them carries no meaning
+    at all.
+    """
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    # No invocation, so this row groups under its own id.
+    await _make_failed(state, "shared", ended_at=100.0, reason="run.failed.exception")
+    # A different failure that really does belong to an invocation, whose id
+    # collides with the session id above. Same reason, so the grouping key is
+    # the only thing keeping these two apart.
+    await _make_failed(
+        state, "other", ended_at=101.0, invocation_id="shared", reason="run.failed.exception"
     )
 
     assert await state.metric_value("failed_sessions", window_start=50.0) == 2.0

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -1300,3 +1300,156 @@ async def test_a_failed_watermark_write_gives_back_the_cooldown_reservation():
     ):
         await engine._maybe_fire(schedule, now=1100.0)
     assert fire.call_count == 1
+
+
+# failed_sessions counts distinct causes, not rows
+
+
+async def _make_failed(
+    state,
+    sess_id: str,
+    *,
+    ended_at: float,
+    invocation_id: str | None = None,
+    reason: str | None = None,
+    status: str = "failed",
+):
+    """Create a session and drive it to *status* the way production does.
+
+    status_reason_code is written by the lifecycle transition, not as a plain
+    column, so a session that is born terminal never carries one. These rows
+    are created running and then transitioned, which is what puts a real
+    reason code on them.
+    """
+    import contextlib
+
+    prog_id = f"prog-{sess_id}"
+    await state.create_progression(prog_id)
+    await state.create_session(
+        {
+            "id": sess_id,
+            "progression_id": prog_id,
+            "status": "running",
+            "started_at": ended_at - 1,
+        }
+    )
+    if invocation_id is not None:
+        # invocation_id is a foreign key, so the invocation has to exist. The
+        # same id is shared deliberately across a fan-out's sessions.
+        with contextlib.suppress(Exception):
+            await state.create_invocation(
+                {"id": invocation_id, "skill": "test", "started_at": ended_at - 2}
+            )
+        await state.update_session(sess_id, invocation_id=invocation_id)
+    await state.update_status(
+        "session",
+        sess_id,
+        new_status=status,
+        reason_code=reason or "run.failed.exception",
+    )
+    await state.update_session(sess_id, ended_at=ended_at)
+
+
+@pytest.mark.asyncio
+async def test_a_fanout_sharing_one_invocation_and_one_wall_is_one_cause():
+    """A wide fan-out meeting a single wall must not breach a threshold by width.
+
+    One invocation spawns a session per worker. When a provider refuses all of
+    them, that is one thing going wrong reported many times, and counting rows
+    makes any fan-out wider than the threshold breach it by construction.
+    """
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    for i in range(24):
+        await _make_failed(
+            state,
+            f"worker-{i}",
+            ended_at=100.0 + i,
+            invocation_id="one-fanout",
+            reason="run.failed.provider_retryable",
+        )
+
+    assert await state.metric_value("failed_sessions", window_start=50.0) == 1.0
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_failures_carrying_no_invocation_are_not_merged_together():
+    """NULL is an unknown grouping, not a shared one.
+
+    Most failed sessions carry no invocation id. Grouping on the raw column
+    lets SQL treat those NULLs as equal and collapses unrelated failures into
+    a single row, which silently disables the alarm for the bulk of the
+    population. Unknown groupings stay apart.
+    """
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    for i in range(3):
+        await _make_failed(
+            state, f"orphan-{i}", ended_at=100.0 + i, reason="run.failed.provider_nonretryable"
+        )
+
+    assert await state.metric_value("failed_sessions", window_start=50.0) == 3.0
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_one_invocation_meeting_two_different_walls_is_two_causes():
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await _make_failed(
+        state, "a", ended_at=100.0, invocation_id="shared", reason="run.failed.provider_retryable"
+    )
+    await _make_failed(
+        state, "b", ended_at=101.0, invocation_id="shared", reason="run.failed.provider_retryable"
+    )
+    await _make_failed(
+        state, "c", ended_at=102.0, invocation_id="shared", reason="run.failed.exception"
+    )
+
+    assert await state.metric_value("failed_sessions", window_start=50.0) == 2.0
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_cause_counting_still_respects_the_window_and_the_status_filter():
+    """The grouping change must not widen or narrow what is eligible to count."""
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await _make_failed(
+        state, "in-failed", ended_at=100.0, invocation_id="i1", reason="run.failed.exception"
+    )
+    await _make_failed(
+        state,
+        "in-timed-out",
+        ended_at=110.0,
+        invocation_id="i2",
+        reason="run.timed_out.deadline",
+        status="timed_out",
+    )
+    await _make_failed(
+        state,
+        "in-completed",
+        ended_at=120.0,
+        invocation_id="i3",
+        reason="run.completed.ok",
+        status="completed",
+    )
+    await _make_failed(
+        state, "before-window", ended_at=10.0, invocation_id="i4", reason="run.failed.exception"
+    )
+
+    assert await state.metric_value("failed_sessions", window_start=50.0) == 2.0
+    await state.close()


### PR DESCRIPTION
A fan-out spawns one session per worker, so a single wall — a provider refusing every worker of one invocation — lands as many failed rows carrying one cause. Counting rows made any fan-out wider than the threshold breach it *by construction*, and the alert could not distinguish "one thing broke during a wide fan-out" from "twenty-four things broke".

Observed: 24 sessions from one invocation failed inside 80 seconds against a single provider usage limit. Against a threshold of 20 failed sessions per 60 minutes, that is a breach on one cause.

## What changed

The metric counts distinct `(invocation, reason)` pairs, so the observed value is the number of distinct things that went wrong.

Both columns are coalesced to the session id rather than grouped on NULL, and that is the whole correctness of the change. NULL is not a shared value: rows without an invocation have an *unknown* grouping, and letting SQL treat them as equal merges unrelated failures into one. Most failed sessions carry no invocation id, so the naive form collapses nearly the whole population to one row per reason and the alarm stops being able to fire at all. Falling back to a unique per-row value keeps unknown groupings apart, which errs toward alerting.

Measured on a real store: over 30 days, 363 of 480 failed sessions carried no invocation id. On a recent 2-hour window the three rules give 28 (rows), 5 (this change), and 2 (the naive grouping).

## Tests

Four cases: a 24-wide fan-out sharing one invocation and one reason counts as one cause; failures carrying no invocation are not merged with each other; one invocation meeting two different walls counts as two; and the window and status filters are unchanged by the regrouping. The pre-existing window test is untouched and still passes, since its rows have distinct causes either way.

Two mutation arms, each predicted before running and reconciled after. Reverting to the row count reddens the fan-out and two-walls cases and leaves the other two green, which is the expected split since those two do not discriminate. Removing the coalesce reddens only the no-invocation case, which returns 1 where the truth is 3.

## Scope

`tests/studio` and `tests/state`: 2016 passed. The dual-backend PostgreSQL cases skip locally without a container, so the subquery alias is reasoned from the dialect requirement rather than executed against PostgreSQL.