### PR TITLE
[ADR-0119] Pin the legacy provider authority inventory

### DIFF
--- a/tests/contracts/data/provider_authority_inventory.json
+++ b/tests/contracts/data/provider_authority_inventory.json
@@ -1,0 +1,1545 @@
+{
+  "schema": "lionagi.provider-authority-inventory",
+  "version": 1,
+  "bootstrap_modules": [
+    "lionagi.providers.openai.chat",
+    "lionagi.providers.openai.codex",
+    "lionagi.providers.openai.audio",
+    "lionagi.providers.openai.batch",
+    "lionagi.providers.openai.images",
+    "lionagi.providers.openai.embed",
+    "lionagi.providers.openai.response",
+    "lionagi.providers.anthropic.messages",
+    "lionagi.providers.anthropic.claude_code",
+    "lionagi.providers.ollama.chat",
+    "lionagi.providers.ollama.embed",
+    "lionagi.providers.ollama.generate",
+    "lionagi.providers.tavily.search",
+    "lionagi.providers.exa.search",
+    "lionagi.providers.exa.contents",
+    "lionagi.providers.exa.find_similar",
+    "lionagi.providers.firecrawl.scrape",
+    "lionagi.providers.firecrawl.map",
+    "lionagi.providers.firecrawl.crawl",
+    "lionagi.providers.perplexity.chat",
+    "lionagi.providers.nvidia_nim.chat",
+    "lionagi.providers.nvidia_nim.embed",
+    "lionagi.providers.deepseek.chat",
+    "lionagi.providers.google.chat",
+    "lionagi.providers.google.gemini_code",
+    "lionagi.providers.groq.chat",
+    "lionagi.providers.groq.audio_transcription",
+    "lionagi.providers.pi.cli",
+    "lionagi.providers.openrouter.chat",
+    "lionagi.providers.ag2.groupchat",
+    "lionagi.providers.ag2.agent",
+    "lionagi.providers.ag2.nlip",
+    "lionagi.testing._endpoint"
+  ],
+  "optional_dependencies": {},
+  "endpoint_rows": [
+    {
+      "bootstrap_module": "lionagi.providers.openai.chat",
+      "provider": "openai",
+      "provider_aliases": [],
+      "endpoint": "chat/completions",
+      "endpoint_aliases": [
+        "chat"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai._chat_schemas:OpenAIChatCompletionsRequest",
+      "implementation_ref": "lionagi.providers.openai.chat:OpenaiChatEndpoint",
+      "base_url": "https://api.openai.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "OPENAI_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.openai.codex",
+      "provider": "codex",
+      "provider_aliases": [
+        "openai-codex"
+      ],
+      "endpoint": "query_cli",
+      "endpoint_aliases": [
+        "cli",
+        "code"
+      ],
+      "endpoint_type": "agentic",
+      "options_ref": "lionagi.providers.openai.codex:CodexCodeRequest",
+      "implementation_ref": "lionagi.providers.openai.codex:CodexCLIEndpoint",
+      "base_url": null,
+      "auth_type": null,
+      "content_type": "application/json",
+      "api_key_env": null
+    },
+    {
+      "bootstrap_module": "lionagi.providers.openai.audio",
+      "provider": "openai",
+      "provider_aliases": [],
+      "endpoint": "audio/speech",
+      "endpoint_aliases": [
+        "tts"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai._audio_schemas:AudioSpeechRequest",
+      "implementation_ref": "lionagi.providers.openai.audio:OpenaiAudioSpeechEndpoint",
+      "base_url": "https://api.openai.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "OPENAI_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.openai.audio",
+      "provider": "openai",
+      "provider_aliases": [],
+      "endpoint": "audio/transcriptions",
+      "endpoint_aliases": [
+        "stt",
+        "whisper"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai._audio_schemas:AudioTranscriptionRequest",
+      "implementation_ref": "lionagi.providers.openai.audio:OpenaiAudioTranscriptionEndpoint",
+      "base_url": "https://api.openai.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "OPENAI_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.openai.batch",
+      "provider": "openai",
+      "provider_aliases": [],
+      "endpoint": "batches",
+      "endpoint_aliases": [
+        "batch"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai.batch:OpenAIBatchRequest",
+      "implementation_ref": "lionagi.providers.openai.batch:OpenaiBatchEndpoint",
+      "base_url": "https://api.openai.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "OPENAI_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.openai.images",
+      "provider": "openai",
+      "provider_aliases": [],
+      "endpoint": "images/generations",
+      "endpoint_aliases": [
+        "dalle",
+        "image"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai.images:ImageGenerationRequest",
+      "implementation_ref": "lionagi.providers.openai.images:OpenaiImageGenerationEndpoint",
+      "base_url": "https://api.openai.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "OPENAI_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.openai.images",
+      "provider": "openai",
+      "provider_aliases": [],
+      "endpoint": "images/edits",
+      "endpoint_aliases": [
+        "image_edit"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai.images:ImageEditRequest",
+      "implementation_ref": "lionagi.providers.openai.images:OpenaiImageEditEndpoint",
+      "base_url": "https://api.openai.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "OPENAI_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.openai.embed",
+      "provider": "openai",
+      "provider_aliases": [],
+      "endpoint": "embeddings",
+      "endpoint_aliases": [
+        "embed"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai.embed:OpenAIEmbeddingRequest",
+      "implementation_ref": "lionagi.providers.openai.embed:OpenaiEmbedEndpoint",
+      "base_url": "https://api.openai.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "OPENAI_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.openai.response",
+      "provider": "openai",
+      "provider_aliases": [],
+      "endpoint": "responses",
+      "endpoint_aliases": [
+        "response"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai.response:OpenAIResponsesRequest",
+      "implementation_ref": "lionagi.providers.openai.response:OpenaiResponseEndpoint",
+      "base_url": "https://api.openai.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "OPENAI_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.anthropic.messages",
+      "provider": "anthropic",
+      "provider_aliases": [],
+      "endpoint": "messages",
+      "endpoint_aliases": [
+        "chat"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.anthropic.messages:CreateMessageRequest",
+      "implementation_ref": "lionagi.providers.anthropic.messages:AnthropicMessagesEndpoint",
+      "base_url": "https://api.anthropic.com/v1",
+      "auth_type": "x-api-key",
+      "content_type": "application/json",
+      "api_key_env": "ANTHROPIC_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.anthropic.claude_code",
+      "provider": "claude_code",
+      "provider_aliases": [
+        "claude-code",
+        "claude"
+      ],
+      "endpoint": "query_cli",
+      "endpoint_aliases": [
+        "cli",
+        "code"
+      ],
+      "endpoint_type": "agentic",
+      "options_ref": "lionagi.providers.anthropic.claude_code:ClaudeCodeRequest",
+      "implementation_ref": "lionagi.providers.anthropic.claude_code:ClaudeCodeCLIEndpoint",
+      "base_url": null,
+      "auth_type": null,
+      "content_type": "application/json",
+      "api_key_env": null
+    },
+    {
+      "bootstrap_module": "lionagi.providers.ollama.chat",
+      "provider": "ollama",
+      "provider_aliases": [],
+      "endpoint": "chat/completions",
+      "endpoint_aliases": [
+        "chat"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai._chat_schemas:OpenAIChatCompletionsRequest",
+      "implementation_ref": "lionagi.providers.ollama.chat:OllamaChatEndpoint",
+      "base_url": "http://localhost:11434/v1",
+      "auth_type": "none",
+      "content_type": "application/json",
+      "api_key_env": null
+    },
+    {
+      "bootstrap_module": "lionagi.providers.ollama.embed",
+      "provider": "ollama",
+      "provider_aliases": [],
+      "endpoint": "embeddings",
+      "endpoint_aliases": [
+        "embed"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.ollama.embed:OllamaEmbedRequest",
+      "implementation_ref": "lionagi.providers.ollama.embed:OllamaEmbedEndpoint",
+      "base_url": "http://localhost:11434/api",
+      "auth_type": "none",
+      "content_type": "application/json",
+      "api_key_env": null
+    },
+    {
+      "bootstrap_module": "lionagi.providers.ollama.generate",
+      "provider": "ollama",
+      "provider_aliases": [],
+      "endpoint": "generate",
+      "endpoint_aliases": [
+        "generate",
+        "completion"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.ollama.generate:OllamaGenerateRequest",
+      "implementation_ref": "lionagi.providers.ollama.generate:OllamaGenerateEndpoint",
+      "base_url": "http://localhost:11434/api",
+      "auth_type": "none",
+      "content_type": "application/json",
+      "api_key_env": null
+    },
+    {
+      "bootstrap_module": "lionagi.providers.tavily.search",
+      "provider": "tavily",
+      "provider_aliases": [],
+      "endpoint": "search",
+      "endpoint_aliases": [],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.tavily.search:TavilySearchRequest",
+      "implementation_ref": "lionagi.providers.tavily.search:TavilySearchEndpoint",
+      "base_url": "https://api.tavily.com",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "TAVILY_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.tavily.search",
+      "provider": "tavily",
+      "provider_aliases": [],
+      "endpoint": "extract",
+      "endpoint_aliases": [],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.tavily.search:TavilyExtractRequest",
+      "implementation_ref": "lionagi.providers.tavily.search:TavilyExtractEndpoint",
+      "base_url": "https://api.tavily.com",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "TAVILY_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.exa.search",
+      "provider": "exa",
+      "provider_aliases": [],
+      "endpoint": "search",
+      "endpoint_aliases": [],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.exa.search:ExaSearchRequest",
+      "implementation_ref": "lionagi.providers.exa.search:ExaSearchEndpoint",
+      "base_url": "https://api.exa.ai",
+      "auth_type": "x-api-key",
+      "content_type": "application/json",
+      "api_key_env": "EXA_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.exa.contents",
+      "provider": "exa",
+      "provider_aliases": [],
+      "endpoint": "contents",
+      "endpoint_aliases": [
+        "get_contents"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.exa.contents:ExaContentsRequest",
+      "implementation_ref": "lionagi.providers.exa.contents:ExaContentsEndpoint",
+      "base_url": "https://api.exa.ai",
+      "auth_type": "x-api-key",
+      "content_type": "application/json",
+      "api_key_env": "EXA_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.exa.find_similar",
+      "provider": "exa",
+      "provider_aliases": [],
+      "endpoint": "findSimilar",
+      "endpoint_aliases": [
+        "similar",
+        "find_similar"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.exa.find_similar:ExaFindSimilarRequest",
+      "implementation_ref": "lionagi.providers.exa.find_similar:ExaFindSimilarEndpoint",
+      "base_url": "https://api.exa.ai",
+      "auth_type": "x-api-key",
+      "content_type": "application/json",
+      "api_key_env": "EXA_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.firecrawl.scrape",
+      "provider": "firecrawl",
+      "provider_aliases": [],
+      "endpoint": "v1/scrape",
+      "endpoint_aliases": [
+        "scrape"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.firecrawl.scrape:FirecrawlScrapeRequest",
+      "implementation_ref": "lionagi.providers.firecrawl.scrape:FirecrawlScrapeEndpoint",
+      "base_url": "https://api.firecrawl.dev",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "FIRECRAWL_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.firecrawl.map",
+      "provider": "firecrawl",
+      "provider_aliases": [],
+      "endpoint": "v1/map",
+      "endpoint_aliases": [
+        "map"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.firecrawl.map:FirecrawlMapRequest",
+      "implementation_ref": "lionagi.providers.firecrawl.map:FirecrawlMapEndpoint",
+      "base_url": "https://api.firecrawl.dev",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "FIRECRAWL_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.firecrawl.crawl",
+      "provider": "firecrawl",
+      "provider_aliases": [],
+      "endpoint": "v1/crawl",
+      "endpoint_aliases": [
+        "crawl"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.firecrawl.crawl:FirecrawlCrawlRequest",
+      "implementation_ref": "lionagi.providers.firecrawl.crawl:FirecrawlCrawlEndpoint",
+      "base_url": "https://api.firecrawl.dev",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "FIRECRAWL_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.perplexity.chat",
+      "provider": "perplexity",
+      "provider_aliases": [],
+      "endpoint": "chat/completions",
+      "endpoint_aliases": [
+        "chat"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.perplexity.chat:PerplexityChatRequest",
+      "implementation_ref": "lionagi.providers.perplexity.chat:PerplexityChatEndpoint",
+      "base_url": "https://api.perplexity.ai",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "PERPLEXITY_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.nvidia_nim.chat",
+      "provider": "nvidia_nim",
+      "provider_aliases": [
+        "nvidia",
+        "nim"
+      ],
+      "endpoint": "chat/completions",
+      "endpoint_aliases": [
+        "chat"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai._chat_schemas:OpenAIChatCompletionsRequest",
+      "implementation_ref": "lionagi.providers.nvidia_nim.chat:NvidiaNimChatEndpoint",
+      "base_url": "https://integrate.api.nvidia.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "NVIDIA_NIM_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.nvidia_nim.embed",
+      "provider": "nvidia_nim",
+      "provider_aliases": [
+        "nvidia",
+        "nim"
+      ],
+      "endpoint": "embeddings",
+      "endpoint_aliases": [
+        "embed"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.nvidia_nim.embed:NvidiaNimEmbeddingRequest",
+      "implementation_ref": "lionagi.providers.nvidia_nim.embed:NvidiaNimEmbedEndpoint",
+      "base_url": "https://integrate.api.nvidia.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "NVIDIA_NIM_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.deepseek.chat",
+      "provider": "deepseek",
+      "provider_aliases": [],
+      "endpoint": "chat/completions",
+      "endpoint_aliases": [
+        "chat"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.deepseek.chat:DeepseekChatCompletionsRequest",
+      "implementation_ref": "lionagi.providers.deepseek.chat:DeepseekChatEndpoint",
+      "base_url": "https://api.deepseek.com/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "DEEPSEEK_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.google.chat",
+      "provider": "gemini",
+      "provider_aliases": [
+        "gemini-api"
+      ],
+      "endpoint": "chat/completions",
+      "endpoint_aliases": [
+        "chat"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai._chat_schemas:OpenAIChatCompletionsRequest",
+      "implementation_ref": "lionagi.providers.google.chat:GeminiChatEndpoint",
+      "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "GEMINI_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.google.gemini_code",
+      "provider": "gemini_code",
+      "provider_aliases": [
+        "gemini-code",
+        "gemini_cli",
+        "gemini-cli"
+      ],
+      "endpoint": "query_cli",
+      "endpoint_aliases": [
+        "cli"
+      ],
+      "endpoint_type": "agentic",
+      "options_ref": "lionagi.providers.google.gemini_code:GeminiCodeRequest",
+      "implementation_ref": "lionagi.providers.google.gemini_code:GeminiCLIEndpoint",
+      "base_url": null,
+      "auth_type": null,
+      "content_type": "application/json",
+      "api_key_env": null
+    },
+    {
+      "bootstrap_module": "lionagi.providers.groq.chat",
+      "provider": "groq",
+      "provider_aliases": [],
+      "endpoint": "chat/completions",
+      "endpoint_aliases": [
+        "chat"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai._chat_schemas:OpenAIChatCompletionsRequest",
+      "implementation_ref": "lionagi.providers.groq.chat:GroqChatEndpoint",
+      "base_url": "https://api.groq.com/openai/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "GROQ_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.groq.audio_transcription",
+      "provider": "groq",
+      "provider_aliases": [],
+      "endpoint": "audio/transcriptions",
+      "endpoint_aliases": [
+        "whisper",
+        "stt"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openai._audio_schemas:AudioTranscriptionRequest",
+      "implementation_ref": "lionagi.providers.groq.audio_transcription:GroqAudioTranscriptionEndpoint",
+      "base_url": "https://api.groq.com/openai/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "GROQ_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.pi.cli",
+      "provider": "pi",
+      "provider_aliases": [
+        "pi-code",
+        "pi_code"
+      ],
+      "endpoint": "query_cli",
+      "endpoint_aliases": [
+        "cli",
+        "code"
+      ],
+      "endpoint_type": "agentic",
+      "options_ref": "lionagi.providers.pi.cli:PiCodeRequest",
+      "implementation_ref": "lionagi.providers.pi.cli:PiCLIEndpoint",
+      "base_url": null,
+      "auth_type": null,
+      "content_type": "application/json",
+      "api_key_env": null
+    },
+    {
+      "bootstrap_module": "lionagi.providers.openrouter.chat",
+      "provider": "openrouter",
+      "provider_aliases": [
+        "open-router"
+      ],
+      "endpoint": "chat/completions",
+      "endpoint_aliases": [
+        "chat",
+        "chat/completions"
+      ],
+      "endpoint_type": "api",
+      "options_ref": "lionagi.providers.openrouter.chat:OpenRouterRequest",
+      "implementation_ref": "lionagi.providers.openrouter.chat:OpenRouterEndpoint",
+      "base_url": "https://openrouter.ai/api/v1",
+      "auth_type": "bearer",
+      "content_type": "application/json",
+      "api_key_env": "OPENROUTER_API_KEY"
+    },
+    {
+      "bootstrap_module": "lionagi.providers.ag2.groupchat",
+      "provider": "ag2",
+      "provider_aliases": [
+        "autogen"
+      ],
+      "endpoint": "group_chat",
+      "endpoint_aliases": [
+        "groupchat",
+        "chat"
+      ],
+      "endpoint_type": "agentic",
+      "options_ref": "lionagi.providers.ag2.groupchat:AG2GroupChatRequest",
+      "implementation_ref": "lionagi.providers.ag2.groupchat:AG2GroupChatEndpoint",
+      "base_url": null,
+      "auth_type": null,
+      "content_type": "application/json",
+      "api_key_env": null
+    },
+    {
+      "bootstrap_module": "lionagi.providers.ag2.agent",
+      "provider": "ag2",
+      "provider_aliases": [
+        "autogen"
+      ],
+      "endpoint": "agent",
+      "endpoint_aliases": [
+        "beta",
+        "ask"
+      ],
+      "endpoint_type": "agentic",
+      "options_ref": "lionagi.providers.ag2.agent:AG2AgentRequest",
+      "implementation_ref": "lionagi.providers.ag2.agent:AG2BetaEndpoint",
+      "base_url": null,
+      "auth_type": null,
+      "content_type": "application/json",
+      "api_key_env": null
+    },
+    {
+      "bootstrap_module": "lionagi.providers.ag2.nlip",
+      "provider": "ag2",
+      "provider_aliases": [
+        "autogen"
+      ],
+      "endpoint": "nlip",
+      "endpoint_aliases": [
+        "nlip_remote",
+        "remote"
+      ],
+      "endpoint_type": "agentic",
+      "options_ref": "lionagi.providers.ag2.nlip:AG2NlipRequest",
+      "implementation_ref": "lionagi.providers.ag2.nlip:AG2NlipEndpoint",
+      "base_url": null,
+      "auth_type": null,
+      "content_type": "application/json",
+      "api_key_env": null
+    },
+    {
+      "bootstrap_module": "lionagi.testing._endpoint",
+      "provider": "scripted",
+      "provider_aliases": [],
+      "endpoint": "chat/completions",
+      "endpoint_aliases": [
+        "chat",
+        "query_cli",
+        "cli"
+      ],
+      "endpoint_type": "agentic",
+      "options_ref": null,
+      "implementation_ref": "lionagi.testing._endpoint:ScriptedEndpoint",
+      "base_url": "internal",
+      "auth_type": "bearer",
+      "content_type": null,
+      "api_key_env": null
+    }
+  ],
+  "context_windows": [
+    {
+      "provider": "openai",
+      "source_module": "lionagi.providers.openai._config",
+      "entries": [
+        {
+          "model": "gpt-5.5",
+          "context_window": 1000000
+        },
+        {
+          "model": "gpt-5.4-mini",
+          "context_window": 1000000
+        },
+        {
+          "model": "gpt-5.4",
+          "context_window": 1048576
+        },
+        {
+          "model": "gpt-5",
+          "context_window": 1000000
+        },
+        {
+          "model": "gpt-4.1-mini",
+          "context_window": 1000000
+        },
+        {
+          "model": "gpt-4.1-nano",
+          "context_window": 1000000
+        },
+        {
+          "model": "gpt-4.1",
+          "context_window": 1000000
+        },
+        {
+          "model": "gpt-4o-mini",
+          "context_window": 128000
+        },
+        {
+          "model": "gpt-4o",
+          "context_window": 128000
+        },
+        {
+          "model": "gpt-4-turbo",
+          "context_window": 128000
+        },
+        {
+          "model": "gpt-4",
+          "context_window": 128000
+        },
+        {
+          "model": "o4-mini",
+          "context_window": 200000
+        },
+        {
+          "model": "o3-mini",
+          "context_window": 200000
+        },
+        {
+          "model": "o3",
+          "context_window": 200000
+        },
+        {
+          "model": "o1-pro",
+          "context_window": 200000
+        },
+        {
+          "model": "o1-mini",
+          "context_window": 128000
+        },
+        {
+          "model": "o1",
+          "context_window": 200000
+        }
+      ]
+    },
+    {
+      "provider": "anthropic",
+      "source_module": "lionagi.providers.anthropic.messages",
+      "entries": [
+        {
+          "model": "claude-opus-4-7",
+          "context_window": 1000000
+        },
+        {
+          "model": "claude-opus-4-6",
+          "context_window": 1000000
+        },
+        {
+          "model": "claude-sonnet-4-6",
+          "context_window": 1000000
+        },
+        {
+          "model": "claude-sonnet-4-5",
+          "context_window": 200000
+        },
+        {
+          "model": "claude-haiku-4-5",
+          "context_window": 200000
+        },
+        {
+          "model": "claude-3-5-sonnet",
+          "context_window": 200000
+        },
+        {
+          "model": "claude-3-5-haiku",
+          "context_window": 200000
+        },
+        {
+          "model": "claude-3-opus",
+          "context_window": 200000
+        }
+      ]
+    },
+    {
+      "provider": "claude_code",
+      "source_module": "lionagi.providers.anthropic.claude_code",
+      "entries": [
+        {
+          "model": "opus-4-7",
+          "context_window": 1000000
+        },
+        {
+          "model": "opus-4-6",
+          "context_window": 1000000
+        },
+        {
+          "model": "opus",
+          "context_window": 1000000
+        },
+        {
+          "model": "sonnet-5",
+          "context_window": 1000000
+        },
+        {
+          "model": "sonnet-4-6",
+          "context_window": 1000000
+        },
+        {
+          "model": "sonnet-4-5",
+          "context_window": 200000
+        },
+        {
+          "model": "sonnet",
+          "context_window": 1000000
+        },
+        {
+          "model": "haiku-4-5",
+          "context_window": 200000
+        },
+        {
+          "model": "haiku",
+          "context_window": 200000
+        },
+        {
+          "model": "fable-5",
+          "context_window": 1000000
+        },
+        {
+          "model": "fable",
+          "context_window": 1000000
+        }
+      ]
+    },
+    {
+      "provider": "codex",
+      "source_module": "lionagi.providers.openai.codex",
+      "entries": [
+        {
+          "model": "codex-mini",
+          "context_window": 200000
+        },
+        {
+          "model": "o4-mini",
+          "context_window": 200000
+        },
+        {
+          "model": "o3",
+          "context_window": 200000
+        }
+      ]
+    },
+    {
+      "provider": "deepseek",
+      "source_module": "lionagi.providers.deepseek.chat",
+      "entries": [
+        {
+          "model": "deepseek-v4-pro",
+          "context_window": 1000000
+        },
+        {
+          "model": "deepseek-v4-flash",
+          "context_window": 1000000
+        },
+        {
+          "model": "deepseek-v4",
+          "context_window": 1000000
+        },
+        {
+          "model": "deepseek-coder-v2",
+          "context_window": 128000
+        },
+        {
+          "model": "deepseek-chat",
+          "context_window": 1000000
+        },
+        {
+          "model": "deepseek-reasoner",
+          "context_window": 1000000
+        },
+        {
+          "model": "deepseek-v3",
+          "context_window": 128000
+        },
+        {
+          "model": "deepseek-r1",
+          "context_window": 64000
+        }
+      ]
+    },
+    {
+      "provider": "nvidia_nim",
+      "source_module": "lionagi.providers.nvidia_nim.chat",
+      "entries": [
+        {
+          "model": "nemotron-ultra",
+          "context_window": 131072
+        },
+        {
+          "model": "nemotron-super",
+          "context_window": 131072
+        },
+        {
+          "model": "llama-4-scout",
+          "context_window": 10485760
+        },
+        {
+          "model": "llama-4-maverick",
+          "context_window": 1048576
+        },
+        {
+          "model": "llama-3",
+          "context_window": 128000
+        }
+      ]
+    },
+    {
+      "provider": "perplexity",
+      "source_module": "lionagi.providers.perplexity.chat",
+      "entries": [
+        {
+          "model": "sonar-pro",
+          "context_window": 200000
+        },
+        {
+          "model": "sonar",
+          "context_window": 128000
+        }
+      ]
+    },
+    {
+      "provider": "gemini_code",
+      "source_module": "lionagi.providers.google.gemini_code",
+      "entries": [
+        {
+          "model": "gemini-3.6-flash",
+          "context_window": 1048576
+        },
+        {
+          "model": "gemini-3.5-flash",
+          "context_window": 1048576
+        },
+        {
+          "model": "gemini-3.1-pro",
+          "context_window": 1048576
+        },
+        {
+          "model": "gemini-3-flash-preview",
+          "context_window": 1048576
+        },
+        {
+          "model": "gemini-3-pro-preview",
+          "context_window": 1048576
+        },
+        {
+          "model": "gemini-2.5-flash",
+          "context_window": 1048576
+        },
+        {
+          "model": "gemini-2.5-pro",
+          "context_window": 2097152
+        }
+      ]
+    },
+    {
+      "provider": "pi",
+      "source_module": "lionagi.providers.pi.cli",
+      "entries": [
+        {
+          "model": "pi",
+          "context_window": 128000
+        }
+      ]
+    },
+    {
+      "provider": "groq",
+      "source_module": "lionagi.providers.groq.chat",
+      "entries": [
+        {
+          "model": "llama-3.3-70b-versatile",
+          "context_window": 128000
+        },
+        {
+          "model": "llama-3.1-8b-instant",
+          "context_window": 128000
+        },
+        {
+          "model": "mixtral-8x7b-32768",
+          "context_window": 32768
+        },
+        {
+          "model": "gemma2-9b-it",
+          "context_window": 8192
+        }
+      ]
+    },
+    {
+      "provider": "gemini",
+      "source_module": "lionagi.providers.google.chat",
+      "entries": [
+        {
+          "model": "gemini-2.5-flash",
+          "context_window": 1048576
+        },
+        {
+          "model": "gemini-2.5-pro",
+          "context_window": 1048576
+        },
+        {
+          "model": "gemini-2.0-flash",
+          "context_window": 1048576
+        }
+      ]
+    },
+    {
+      "provider": "openrouter",
+      "source_module": "lionagi.providers.openrouter.chat",
+      "entries": [
+        {
+          "model": "google/gemini-2.5-flash",
+          "context_window": 1048576
+        },
+        {
+          "model": "google/gemini-2.5-pro",
+          "context_window": 1048576
+        },
+        {
+          "model": "anthropic/claude-opus-4-5",
+          "context_window": 200000
+        },
+        {
+          "model": "anthropic/claude-sonnet-4-5",
+          "context_window": 200000
+        },
+        {
+          "model": "openai/gpt-4.1",
+          "context_window": 1000000
+        },
+        {
+          "model": "meta-llama/llama-3.3-70b-instruct",
+          "context_window": 128000
+        }
+      ]
+    }
+  ],
+  "documentation_surfaces": [
+    {
+      "path": "docs/reference/providers.md",
+      "anchor": "# Provider Reference",
+      "token_counts": {
+        "Canonical names and declared aliases match exactly": 1,
+        "trusted and enabled plugin providers are consulted": 1,
+        "generic OpenAI-compatible fallback": 1
+      }
+    },
+    {
+      "path": "docs/reference/providers.md",
+      "anchor": "## API providers",
+      "token_counts": {
+        "| OpenAI |": 1,
+        "| Anthropic |": 1,
+        "| Google Gemini |": 1,
+        "| Ollama (local) |": 1,
+        "| NVIDIA NIM |": 1,
+        "| Perplexity |": 1,
+        "| Groq |": 1,
+        "| OpenRouter |": 1,
+        "| DeepSeek |": 1
+      }
+    },
+    {
+      "path": "docs/reference/providers.md",
+      "anchor": "## CLI / agentic providers",
+      "token_counts": {
+        "| Claude Code |": 1,
+        "| Codex |": 1,
+        "| Gemini CLI |": 1,
+        "| Pi |": 1
+      }
+    },
+    {
+      "path": "docs/reference/providers.md",
+      "anchor": "## Search and scraping providers",
+      "token_counts": {
+        "| Exa |": 1,
+        "| Firecrawl |": 1,
+        "| Tavily |": 1
+      }
+    },
+    {
+      "path": "docs/reference/providers.md",
+      "anchor": "## AG2 (multi-agent)",
+      "token_counts": {
+        "| AG2 GroupChat |": 1,
+        "| AG2 beta Agent |": 1,
+        "| AG2 NLIP remote |": 1
+      }
+    },
+    {
+      "path": "docs/reference/providers.md",
+      "anchor": "## Adding a new provider",
+      "token_counts": {
+        "@MyProviderConfigs.CHAT.register": 1,
+        "_import_all_providers()": 2,
+        "plugin provider": 1
+      }
+    },
+    {
+      "path": "docs/reference/operations-service.md",
+      "anchor": "### Token Budget",
+      "token_counts": {
+        "provider longest-prefix lookup": 1,
+        "default (128k)": 1
+      }
+    },
+    {
+      "path": "docs/reference/operations-service.md",
+      "anchor": "### EndpointRegistry",
+      "token_counts": {
+        "`register_endpoint`": 1,
+        "`_ENDPOINT_META`": 1
+      }
+    },
+    {
+      "path": "docs/api/imodel.md",
+      "anchor": "### Fallback",
+      "token_counts": {
+        "ProviderNotFoundError": 1,
+        "openai_compatible=True": 1,
+        "registered provider": 1
+      }
+    },
+    {
+      "path": "docs/api/imodel.md",
+      "anchor": "## Endpoint matching",
+      "token_counts": {
+        "`EndpointRegistry`": 1,
+        "single-endpoint provider": 1,
+        "Built-in provider names win": 1,
+        "ProviderNotFoundError": 1
+      }
+    },
+    {
+      "path": "docs/migration/0.23.0-to-0.23.1.md",
+      "anchor": "## New: Provider registry",
+      "token_counts": {
+        "self-register via decorator at import time": 1,
+        "@register_endpoint(": 1
+      }
+    },
+    {
+      "path": "docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md",
+      "anchor": "### D2 — `EndpointRegistry` is the sole endpoint resolver",
+      "token_counts": {
+        "Provider classes register by decorator": 1,
+        "def register(": 1,
+        "_import_all_providers": 1
+      }
+    },
+    {
+      "path": "docs/adr/ADR-0052-supported-validation-and-testing-surfaces.md",
+      "anchor": "### D5 — The scripted endpoint uses normal discovery and no external request",
+      "token_counts": {
+        "standard decorator": 1,
+        "@register_endpoint(": 1,
+        "lionagi.testing._endpoint": 1
+      }
+    },
+    {
+      "path": "docs/adr/ADR-0088-plugin-system.md",
+      "anchor": "### D2 — Manifest schema: declarative, pure data",
+      "token_counts": {
+        "providers/searchapi.py": 1,
+        "self-registers": 1
+      }
+    },
+    {
+      "path": "docs/adr/ADR-0088-plugin-system.md",
+      "anchor": "### D3 — Lazy activation: manifests at first need, code at first use",
+      "token_counts": {
+        "self-registers at import time via the existing decorator": 1,
+        "declared provider module": 1
+      }
+    },
+    {
+      "path": "docs/adr/ADR-0088-plugin-system.md",
+      "anchor": "### D6 — Collisions: built-ins win; peers hard-fail",
+      "token_counts": {
+        "**Providers**": 1,
+        "activation trigger": 1,
+        "Two **enabled plugins**": 1
+      }
+    },
+    {
+      "path": "docs/adr/ADR-0088-plugin-system.md",
+      "anchor": "## Implementation status (2026-07-13)",
+      "token_counts": {
+        "match-miss interception": 1,
+        "`EndpointRegistry._reject_builtin_collisions`": 1
+      }
+    },
+    {
+      "path": "docs/internals/runtime.md",
+      "anchor": "### `connections/registry.py`",
+      "token_counts": {
+        "`_consult_plugin_providers()`": 1,
+        "declared provider module": 1,
+        "`PluginRegistry.activate_target`": 1
+      }
+    },
+    {
+      "path": "docs/internals/core.md",
+      "anchor": "### EndpointRegistry match",
+      "token_counts": {
+        "`register()`/`_claim_provider_identity`": 1,
+        "`ProviderNotFoundError`": 2,
+        "`openai_compatible=True`": 1
+      }
+    },
+    {
+      "path": "docs/internals/core.md",
+      "anchor": "### EndpointRegistry plugin revalidation",
+      "token_counts": {
+        "`_revalidate_plugin_entry`": 1,
+        "`PluginRegistry.activate_target()`": 1
+      }
+    }
+  ],
+  "public_authority": {
+    "registry_exports": [
+      "EndpointType",
+      "EndpointMeta",
+      "EndpointRegistry",
+      "ProviderAliasCollisionError",
+      "ProviderNotFoundError",
+      "register_endpoint"
+    ],
+    "compatibility_facades": [
+      {
+        "module": "lionagi.service.connections.registry",
+        "qualname": "EndpointRegistry.match",
+        "parameters": [
+          {
+            "name": "provider",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "endpoint",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "required": false,
+            "default": "''"
+          },
+          {
+            "name": "openai_compatible",
+            "kind": "keyword_only",
+            "annotation": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "return_annotation": "Any",
+        "var_keyword": "kwargs"
+      },
+      {
+        "module": "lionagi.service.connections.registry",
+        "qualname": "EndpointRegistry.list_providers",
+        "parameters": [],
+        "return_annotation": "list[dict[str, Any]]",
+        "var_keyword": null
+      },
+      {
+        "module": "lionagi.service.connections.match_endpoint",
+        "qualname": "match_endpoint",
+        "parameters": [
+          {
+            "name": "provider",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "endpoint",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "openai_compatible",
+            "kind": "keyword_only",
+            "annotation": "bool",
+            "required": false,
+            "default": "False"
+          }
+        ],
+        "return_annotation": "Endpoint",
+        "var_keyword": "kwargs"
+      },
+      {
+        "module": "lionagi.service.token_budget",
+        "qualname": "lookup_context_window",
+        "parameters": [
+          {
+            "name": "model_name",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "provider",
+            "kind": "positional_or_keyword",
+            "annotation": "str | None",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "return_annotation": "int",
+        "var_keyword": null
+      }
+    ],
+    "mutation_surfaces": [
+      {
+        "module": "lionagi.service.connections.registry",
+        "qualname": "EndpointRegistry.register",
+        "parameters": [
+          {
+            "name": "provider",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "endpoint",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "aliases",
+            "kind": "positional_or_keyword",
+            "annotation": "list[str] | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "endpoint_type",
+            "kind": "positional_or_keyword",
+            "annotation": "EndpointType",
+            "required": false,
+            "default": "EndpointType.API"
+          },
+          {
+            "name": "provider_aliases",
+            "kind": "positional_or_keyword",
+            "annotation": "list[str] | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "options",
+            "kind": "positional_or_keyword",
+            "annotation": "type[BaseModel] | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "base_url",
+            "kind": "positional_or_keyword",
+            "annotation": "str | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "auth_type",
+            "kind": "positional_or_keyword",
+            "annotation": "str | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "content_type",
+            "kind": "positional_or_keyword",
+            "annotation": "str | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "api_key_env",
+            "kind": "positional_or_keyword",
+            "annotation": "str | None",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "return_annotation": null,
+        "var_keyword": null
+      },
+      {
+        "module": "lionagi.service.connections.registry",
+        "qualname": "register_endpoint",
+        "parameters": [
+          {
+            "name": "provider",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "endpoint",
+            "kind": "positional_or_keyword",
+            "annotation": "str",
+            "required": true,
+            "default": null
+          },
+          {
+            "name": "aliases",
+            "kind": "positional_or_keyword",
+            "annotation": "list[str] | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "endpoint_type",
+            "kind": "positional_or_keyword",
+            "annotation": "EndpointType",
+            "required": false,
+            "default": "EndpointType.API"
+          },
+          {
+            "name": "provider_aliases",
+            "kind": "positional_or_keyword",
+            "annotation": "list[str] | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "options",
+            "kind": "positional_or_keyword",
+            "annotation": "type[BaseModel] | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "base_url",
+            "kind": "positional_or_keyword",
+            "annotation": "str | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "auth_type",
+            "kind": "positional_or_keyword",
+            "annotation": "str | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "content_type",
+            "kind": "positional_or_keyword",
+            "annotation": "str | None",
+            "required": false,
+            "default": "None"
+          },
+          {
+            "name": "api_key_env",
+            "kind": "positional_or_keyword",
+            "annotation": "str | None",
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "return_annotation": null,
+        "var_keyword": null
+      },
+      {
+        "module": "lionagi.service.connections.provider_config",
+        "qualname": "ProviderConfig.register",
+        "parameters": [
+          {
+            "name": "cls",
+            "kind": "positional_or_keyword",
+            "annotation": null,
+            "required": false,
+            "default": "None"
+          }
+        ],
+        "return_annotation": null,
+        "var_keyword": null
+      }
+    ]
+  },
+  "deletion_ledger": {
+    "authorities": [
+      {
+        "module": "lionagi.service.connections.registry",
+        "symbols": [
+          "EndpointRegistry._entries",
+          "EndpointRegistry._loaded",
+          "EndpointRegistry._lock",
+          "EndpointRegistry._plugin_registration",
+        "EndpointRegistry._alias_owners",
+        "EndpointRegistry.register",
+        "EndpointRegistry._claim_provider_identity",
+        "EndpointRegistry._remove_entries",
+        "EndpointRegistry._rebuild_alias_owners",
+        "EndpointRegistry._is_known_provider",
+        "EndpointRegistry._provider_not_found_error",
+        "EndpointRegistry._match_registered",
+        "EndpointRegistry._revalidate_plugin_entry",
+          "EndpointRegistry._plugin_entry_stat",
+          "EndpointRegistry._plugin_entry_digest",
+          "EndpointRegistry._consult_plugin_providers",
+          "EndpointRegistry._reject_builtin_collisions",
+          "EndpointRegistry._ensure_loaded",
+          "register_endpoint",
+          "_PROVIDER_OPTIONAL_DEPENDENCIES",
+          "_import_provider_module",
+          "_import_all_providers"
+        ]
+      },
+      {
+        "module": "lionagi.service.connections.provider_config",
+        "symbols": [
+          "ProviderConfig.register"
+        ]
+      },
+      {
+        "module": "lionagi.service.token_budget",
+        "symbols": [
+          "_provider_cache",
+          "_PROVIDER_MODULES",
+          "_get_provider_windows",
+          "_all_provider_windows"
+        ]
+      }
+    ],
+    "provider_registration_decorators": 36
+  },
+  "plugin_fail_soft": {
+    "builtin_collision": {
+      "activation_scope": "entry.plugin_name == plugin_name and entry.plugin_target == module",
+      "collision_predicate": "entry.meta.provider in builtin_names or any((alias in builtin_names for alias in entry.meta.provider_aliases))",
+    "rejection_guard": "is_this_activation and collides",
+    "append_call": "rejected.append(entry)",
+    "removal_call": "cls._remove_entries(rejected)",
+    "removal_after_append": true
+    },
+  "provider_alias_collision": {
+    "exception": "ProviderAliasCollisionError",
+    "handler_logs_warning": true,
+    "handler_continues": true
+  }
+  }
+}

--- a/tests/service/connections/_provider_inventory.py
+++ b/tests/service/connections/_provider_inventory.py
@@ -1,0 +1,797 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only AST collector for the checked provider-authority inventory."""
+
+from __future__ import annotations
+
+import ast
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+_SCHEMA = "lionagi.provider-authority-inventory"
+_VERSION = 1
+_REGISTRY_MODULE = "lionagi.service.connections.registry"
+_PROVIDER_CONFIG_MODULE = "lionagi.service.connections.provider_config"
+_MATCH_MODULE = "lionagi.service.connections.match_endpoint"
+_TOKEN_BUDGET_MODULE = "lionagi.service.token_budget"
+
+_COMPATIBILITY_FACADES = (
+    (_REGISTRY_MODULE, "EndpointRegistry.match"),
+    (_REGISTRY_MODULE, "EndpointRegistry.list_providers"),
+    (_MATCH_MODULE, "match_endpoint"),
+    (_TOKEN_BUDGET_MODULE, "lookup_context_window"),
+)
+_MUTATION_SURFACES = (
+    (_REGISTRY_MODULE, "EndpointRegistry.register"),
+    (_REGISTRY_MODULE, "register_endpoint"),
+    (_PROVIDER_CONFIG_MODULE, "ProviderConfig.register"),
+)
+_DELETION_SYMBOLS = {
+    _REGISTRY_MODULE: (
+        "EndpointRegistry._entries",
+        "EndpointRegistry._loaded",
+        "EndpointRegistry._lock",
+        "EndpointRegistry._plugin_registration",
+        "EndpointRegistry._alias_owners",
+        "EndpointRegistry.register",
+        "EndpointRegistry._claim_provider_identity",
+        "EndpointRegistry._remove_entries",
+        "EndpointRegistry._rebuild_alias_owners",
+        "EndpointRegistry._is_known_provider",
+        "EndpointRegistry._provider_not_found_error",
+        "EndpointRegistry._match_registered",
+        "EndpointRegistry._revalidate_plugin_entry",
+        "EndpointRegistry._plugin_entry_stat",
+        "EndpointRegistry._plugin_entry_digest",
+        "EndpointRegistry._consult_plugin_providers",
+        "EndpointRegistry._reject_builtin_collisions",
+        "EndpointRegistry._ensure_loaded",
+        "register_endpoint",
+        "_PROVIDER_OPTIONAL_DEPENDENCIES",
+        "_import_provider_module",
+        "_import_all_providers",
+    ),
+    _PROVIDER_CONFIG_MODULE: ("ProviderConfig.register",),
+    _TOKEN_BUDGET_MODULE: (
+        "_provider_cache",
+        "_PROVIDER_MODULES",
+        "_get_provider_windows",
+        "_all_provider_windows",
+    ),
+}
+_DOCUMENTATION_SURFACES = (
+    (
+        "docs/reference/providers.md",
+        "# Provider Reference",
+        (
+            "Canonical names and declared aliases match exactly",
+            "trusted and enabled plugin providers are consulted",
+            "generic OpenAI-compatible fallback",
+        ),
+    ),
+    (
+        "docs/reference/providers.md",
+        "## API providers",
+        (
+            "| OpenAI |",
+            "| Anthropic |",
+            "| Google Gemini |",
+            "| Ollama (local) |",
+            "| NVIDIA NIM |",
+            "| Perplexity |",
+            "| Groq |",
+            "| OpenRouter |",
+            "| DeepSeek |",
+        ),
+    ),
+    (
+        "docs/reference/providers.md",
+        "## CLI / agentic providers",
+        ("| Claude Code |", "| Codex |", "| Gemini CLI |", "| Pi |"),
+    ),
+    (
+        "docs/reference/providers.md",
+        "## Search and scraping providers",
+        ("| Exa |", "| Firecrawl |", "| Tavily |"),
+    ),
+    (
+        "docs/reference/providers.md",
+        "## AG2 (multi-agent)",
+        ("| AG2 GroupChat |", "| AG2 beta Agent |", "| AG2 NLIP remote |"),
+    ),
+    (
+        "docs/reference/providers.md",
+        "## Adding a new provider",
+        (
+            "@MyProviderConfigs.CHAT.register",
+            "_import_all_providers()",
+            "plugin provider",
+        ),
+    ),
+    (
+        "docs/reference/operations-service.md",
+        "### Token Budget",
+        ("provider longest-prefix lookup", "default (128k)"),
+    ),
+    (
+        "docs/reference/operations-service.md",
+        "### EndpointRegistry",
+        ("`register_endpoint`", "`_ENDPOINT_META`"),
+    ),
+    (
+        "docs/api/imodel.md",
+        "### Fallback",
+        ("ProviderNotFoundError", "openai_compatible=True", "registered provider"),
+    ),
+    (
+        "docs/api/imodel.md",
+        "## Endpoint matching",
+        (
+            "`EndpointRegistry`",
+            "single-endpoint provider",
+            "Built-in provider names win",
+            "ProviderNotFoundError",
+        ),
+    ),
+    (
+        "docs/migration/0.23.0-to-0.23.1.md",
+        "## New: Provider registry",
+        ("self-register via decorator at import time", "@register_endpoint("),
+    ),
+    (
+        "docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md",
+        "### D2 — `EndpointRegistry` is the sole endpoint resolver",
+        (
+            "Provider classes register by decorator",
+            "def register(",
+            "_import_all_providers",
+        ),
+    ),
+    (
+        "docs/adr/ADR-0052-supported-validation-and-testing-surfaces.md",
+        "### D5 — The scripted endpoint uses normal discovery and no external request",
+        ("standard decorator", "@register_endpoint(", "lionagi.testing._endpoint"),
+    ),
+    (
+        "docs/adr/ADR-0088-plugin-system.md",
+        "### D2 — Manifest schema: declarative, pure data",
+        ("providers/searchapi.py", "self-registers"),
+    ),
+    (
+        "docs/adr/ADR-0088-plugin-system.md",
+        "### D3 — Lazy activation: manifests at first need, code at first use",
+        (
+            "self-registers at import time via the existing decorator",
+            "declared provider module",
+        ),
+    ),
+    (
+        "docs/adr/ADR-0088-plugin-system.md",
+        "### D6 — Collisions: built-ins win; peers hard-fail",
+        ("**Providers**", "activation trigger", "Two **enabled plugins**"),
+    ),
+    (
+        "docs/adr/ADR-0088-plugin-system.md",
+        "## Implementation status (2026-07-13)",
+        ("match-miss interception", "`EndpointRegistry._reject_builtin_collisions`"),
+    ),
+    (
+        "docs/internals/runtime.md",
+        "### `connections/registry.py`",
+        (
+            "`_consult_plugin_providers()`",
+            "declared provider module",
+            "`PluginRegistry.activate_target`",
+        ),
+    ),
+    (
+        "docs/internals/core.md",
+        "### EndpointRegistry match",
+        (
+            "`register()`/`_claim_provider_identity`",
+            "`ProviderNotFoundError`",
+            "`openai_compatible=True`",
+        ),
+    ),
+    (
+        "docs/internals/core.md",
+        "### EndpointRegistry plugin revalidation",
+        ("`_revalidate_plugin_entry`", "`PluginRegistry.activate_target()`"),
+    ),
+)
+
+
+def load_checked_inventory(path: Path) -> dict[str, Any]:
+    """Load and minimally validate the independent checked artifact."""
+    if not path.is_file():
+        raise AssertionError(f"checked provider authority inventory is missing: {path}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError("checked provider authority inventory must be a JSON object")
+    if value.get("schema") != _SCHEMA or value.get("version") != _VERSION:
+        raise AssertionError(
+            "checked provider authority inventory has an unsupported schema or version"
+        )
+    return value
+
+
+class _Sources:
+    def __init__(self, root: Path, overrides: Mapping[str, str] | None) -> None:
+        self.root = root
+        self.overrides = dict(overrides or {})
+
+    def read(self, relative: str) -> str:
+        if relative in self.overrides:
+            return self.overrides[relative]
+        return (self.root / relative).read_text(encoding="utf-8")
+
+    def tree(self, relative: str) -> ast.Module:
+        return ast.parse(self.read(relative), filename=relative)
+
+    def module_tree(self, module: str) -> ast.Module:
+        return self.tree(_module_relative_path(module))
+
+
+def _module_relative_path(module: str) -> str:
+    return f"{module.replace('.', '/')}.py"
+
+
+def _assignment_name(node: ast.Assign | ast.AnnAssign) -> str | None:
+    targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+    if len(targets) == 1 and isinstance(targets[0], ast.Name):
+        return targets[0].id
+    return None
+
+
+def _assignment_value(node: ast.Assign | ast.AnnAssign) -> ast.expr | None:
+    return node.value
+
+
+def _top_level_value(tree: ast.Module, name: str) -> ast.expr:
+    for node in tree.body:
+        if isinstance(node, ast.Assign | ast.AnnAssign) and _assignment_name(node) == name:
+            value = _assignment_value(node)
+            if value is not None:
+                return value
+    raise AssertionError(f"missing top-level assignment {name!r}")
+
+
+def _function(tree: ast.Module, qualname: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    parts = qualname.split(".")
+    if len(parts) == 1:
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == parts[0]:
+                return node
+    elif len(parts) == 2:
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef) or node.name != parts[0]:
+                continue
+            for item in node.body:
+                if (
+                    isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef)
+                    and item.name == parts[1]
+                ):
+                    return item
+    raise AssertionError(f"missing function {qualname!r}")
+
+
+def _symbol_exists(tree: ast.Module, qualname: str) -> bool:
+    parts = qualname.split(".")
+    body: list[ast.stmt] = tree.body
+    if len(parts) == 2:
+        owner = next(
+            (
+                node
+                for node in tree.body
+                if isinstance(node, ast.ClassDef) and node.name == parts[0]
+            ),
+            None,
+        )
+        if owner is None:
+            return False
+        body = owner.body
+    target = parts[-1]
+    return any(
+        (
+            isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef)
+            and node.name == target
+        )
+        or (isinstance(node, ast.Assign | ast.AnnAssign) and _assignment_name(node) == target)
+        for node in body
+    )
+
+
+def _dotted_name(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        owner = _dotted_name(node.value)
+        return f"{owner}.{node.attr}" if owner else node.attr
+    return None
+
+
+def _static_value(node: ast.expr) -> Any:
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.List | ast.Tuple):
+        return [_static_value(item) for item in node.elts]
+    if isinstance(node, ast.Dict):
+        return {
+            _static_value(key): _static_value(value)
+            for key, value in zip(node.keys, node.values, strict=True)
+            if key is not None
+        }
+    if isinstance(node, ast.Attribute) and _dotted_name(node.value) == "EndpointType":
+        return node.attr.lower()
+    if isinstance(node, ast.Call) and _dotted_name(node.func) == "LazyType" and len(node.args) == 1:
+        return _static_value(node.args[0])
+    raise AssertionError(f"unsupported static provider expression: {ast.unparse(node)}")
+
+
+def _bootstrap_modules(registry_tree: ast.Module) -> list[str]:
+    loader = _function(registry_tree, "_import_all_providers")
+    for node in loader.body:
+        if isinstance(node, ast.Assign | ast.AnnAssign) and _assignment_name(node) == "_modules":
+            value = _assignment_value(node)
+            if value is None:
+                break
+            modules = _static_value(value)
+            if isinstance(modules, list) and all(isinstance(item, str) for item in modules):
+                return modules
+    raise AssertionError("_import_all_providers must declare a literal _modules list")
+
+
+def _relative_import_module(current_module: str, node: ast.ImportFrom) -> str:
+    if node.level == 0:
+        return node.module or ""
+    package = current_module.rsplit(".", 1)[0].split(".")
+    trim = node.level - 1
+    if trim:
+        package = package[:-trim]
+    if node.module:
+        package.extend(node.module.split("."))
+    return ".".join(package)
+
+
+def _imported_symbols(tree: ast.Module, module: str) -> dict[str, str]:
+    imported: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        source_module = _relative_import_module(module, node)
+        for alias in node.names:
+            imported[alias.asname or alias.name] = source_module
+    return imported
+
+
+def _class_attribute_values(tree: ast.Module, class_name: str) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign | ast.AnnAssign):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+        if len(targets) != 1 or not isinstance(targets[0], ast.Attribute):
+            continue
+        target = targets[0]
+        if not isinstance(target.value, ast.Name) or target.value.id != class_name:
+            continue
+        value = _assignment_value(node)
+        if value is not None:
+            values[target.attr] = _static_value(value)
+    return values
+
+
+def _config_member(tree: ast.Module, class_name: str, member_name: str) -> list[Any]:
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        for item in node.body:
+            if not isinstance(item, ast.Assign | ast.AnnAssign):
+                continue
+            if _assignment_name(item) != member_name:
+                continue
+            value = _assignment_value(item)
+            if value is None:
+                break
+            result = _static_value(value)
+            if isinstance(result, list):
+                return result
+    raise AssertionError(f"missing provider config member {class_name}.{member_name}")
+
+
+def _row_from_config(
+    sources: _Sources,
+    bootstrap_module: str,
+    implementation_name: str,
+    config_module: str,
+    config_class: str,
+    member_name: str,
+) -> dict[str, Any]:
+    config_tree = sources.module_tree(config_module)
+    attrs = _class_attribute_values(config_tree, config_class)
+    member = _config_member(config_tree, config_class, member_name)
+    provider = str(attrs["_PROVIDER"]).strip().lower()
+    provider_aliases = list(
+        dict.fromkeys(str(alias).strip().lower() for alias in attrs["_PROVIDER_ALIASES"])
+    )
+    return {
+        "bootstrap_module": bootstrap_module,
+        "provider": provider,
+        "provider_aliases": provider_aliases,
+        "endpoint": member[0],
+        "endpoint_aliases": member[1],
+        "endpoint_type": member[2],
+        "options_ref": member[3] if len(member) > 3 else None,
+        "implementation_ref": f"{bootstrap_module}:{implementation_name}",
+        "base_url": member[4] if len(member) > 4 else None,
+        "auth_type": member[5] if len(member) > 5 else None,
+        "content_type": member[6] if len(member) > 6 else "application/json",
+        "api_key_env": attrs.get("_API_KEY_ENV"),
+    }
+
+
+def _row_from_register_call(
+    bootstrap_module: str,
+    implementation_name: str,
+    decorator: ast.Call,
+) -> dict[str, Any]:
+    values = {keyword.arg: _static_value(keyword.value) for keyword in decorator.keywords}
+    provider = str(values["provider"]).strip().lower()
+    provider_aliases = list(
+        dict.fromkeys(str(alias).strip().lower() for alias in values.get("provider_aliases", []))
+    )
+    return {
+        "bootstrap_module": bootstrap_module,
+        "provider": provider,
+        "provider_aliases": provider_aliases,
+        "endpoint": values["endpoint"],
+        "endpoint_aliases": values.get("aliases", []),
+        "endpoint_type": values.get("endpoint_type", "api"),
+        "options_ref": values.get("options"),
+        "implementation_ref": f"{bootstrap_module}:{implementation_name}",
+        "base_url": values.get("base_url"),
+        "auth_type": values.get("auth_type"),
+        "content_type": values.get("content_type"),
+        "api_key_env": values.get("api_key_env"),
+    }
+
+
+def _endpoint_rows(sources: _Sources, modules: list[str]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for module in modules:
+        tree = sources.module_tree(module)
+        imported = _imported_symbols(tree, module)
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for decorator in node.decorator_list:
+                if (
+                    isinstance(decorator, ast.Attribute)
+                    and decorator.attr == "register"
+                    and isinstance(decorator.value, ast.Attribute)
+                    and isinstance(decorator.value.value, ast.Name)
+                ):
+                    config_class = decorator.value.value.id
+                    config_module = imported.get(config_class)
+                    if config_module is None:
+                        raise AssertionError(f"cannot resolve config class {config_class!r}")
+                    rows.append(
+                        _row_from_config(
+                            sources,
+                            module,
+                            node.name,
+                            config_module,
+                            config_class,
+                            decorator.value.attr,
+                        )
+                    )
+                elif (
+                    isinstance(decorator, ast.Call)
+                    and _dotted_name(decorator.func) == "register_endpoint"
+                ):
+                    rows.append(_row_from_register_call(module, node.name, decorator))
+    return rows
+
+
+def _ordered_string_mapping(node: ast.expr, *, name: str) -> list[tuple[str, Any]]:
+    if not isinstance(node, ast.Dict):
+        raise AssertionError(f"{name} must be a literal dict")
+    result: list[tuple[str, Any]] = []
+    for key, value in zip(node.keys, node.values, strict=True):
+        if key is None:
+            raise AssertionError(f"{name} cannot use dict unpacking")
+        parsed_key = _static_value(key)
+        if not isinstance(parsed_key, str):
+            raise AssertionError(f"{name} keys must be strings")
+        result.append((parsed_key, _static_value(value)))
+    return result
+
+
+def _context_windows(sources: _Sources) -> list[dict[str, Any]]:
+    token_tree = sources.module_tree(_TOKEN_BUDGET_MODULE)
+    provider_modules = _ordered_string_mapping(
+        _top_level_value(token_tree, "_PROVIDER_MODULES"), name="_PROVIDER_MODULES"
+    )
+    result: list[dict[str, Any]] = []
+    for provider, source_module in provider_modules:
+        if not isinstance(source_module, str):
+            raise AssertionError("_PROVIDER_MODULES values must be module names")
+        source_tree = sources.module_tree(source_module)
+        entries = _ordered_string_mapping(
+            _top_level_value(source_tree, "CONTEXT_WINDOWS"), name="CONTEXT_WINDOWS"
+        )
+        result.append(
+            {
+                "provider": provider,
+                "source_module": source_module,
+                "entries": [
+                    {"model": model, "context_window": context_window}
+                    for model, context_window in entries
+                ],
+            }
+        )
+    return result
+
+
+def _parameter(
+    argument: ast.arg,
+    *,
+    kind: str,
+    default: ast.expr | None,
+    required: bool,
+) -> dict[str, Any]:
+    return {
+        "name": argument.arg,
+        "kind": kind,
+        "annotation": ast.unparse(argument.annotation) if argument.annotation else None,
+        "required": required,
+        "default": ast.unparse(default) if default is not None else None,
+    }
+
+
+def _signature(sources: _Sources, module: str, qualname: str) -> dict[str, Any]:
+    node = _function(sources.module_tree(module), qualname)
+    positional = [*node.args.posonlyargs, *node.args.args]
+    if "." in qualname and positional and positional[0].arg in {"self", "cls"}:
+        positional = positional[1:]
+    default_offset = len(positional) - len(node.args.defaults)
+    parameters: list[dict[str, Any]] = []
+    positional_only_count = max(0, len(node.args.posonlyargs) - 1)
+    for index, argument in enumerate(positional):
+        default_index = index - default_offset
+        default = node.args.defaults[default_index] if default_index >= 0 else None
+        parameters.append(
+            _parameter(
+                argument,
+                kind="positional_only"
+                if index < positional_only_count
+                else "positional_or_keyword",
+                default=default,
+                required=default_index < 0,
+            )
+        )
+    for argument, default in zip(node.args.kwonlyargs, node.args.kw_defaults, strict=True):
+        parameters.append(
+            _parameter(
+                argument,
+                kind="keyword_only",
+                default=default,
+                required=default is None,
+            )
+        )
+    return {
+        "module": module,
+        "qualname": qualname,
+        "parameters": parameters,
+        "return_annotation": ast.unparse(node.returns) if node.returns else None,
+        "var_keyword": node.args.kwarg.arg if node.args.kwarg else None,
+    }
+
+
+def _public_authority(sources: _Sources) -> dict[str, Any]:
+    registry_exports = _static_value(
+        _top_level_value(sources.module_tree(_REGISTRY_MODULE), "__all__")
+    )
+    return {
+        "registry_exports": registry_exports,
+        "compatibility_facades": [
+            _signature(sources, module, qualname) for module, qualname in _COMPATIBILITY_FACADES
+        ],
+        "mutation_surfaces": [
+            _signature(sources, module, qualname) for module, qualname in _MUTATION_SURFACES
+        ],
+    }
+
+
+def _deletion_ledger(sources: _Sources, decorator_count: int) -> dict[str, Any]:
+    authorities = []
+    for module, symbols in _DELETION_SYMBOLS.items():
+        tree = sources.module_tree(module)
+        authorities.append(
+            {
+                "module": module,
+                "symbols": [symbol for symbol in symbols if _symbol_exists(tree, symbol)],
+            }
+        )
+    return {
+        "authorities": authorities,
+        "provider_registration_decorators": decorator_count,
+    }
+
+
+def _assignment_expression(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    name: str,
+) -> str | None:
+    for node in ast.walk(function):
+        if isinstance(node, ast.Assign | ast.AnnAssign) and _assignment_name(node) == name:
+            value = _assignment_value(node)
+            return ast.unparse(value) if value is not None else None
+    return None
+
+
+def _first_call_node(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    dotted_name: str,
+) -> ast.Call | None:
+    for node in ast.walk(function):
+        if isinstance(node, ast.Call) and _dotted_name(node.func) == dotted_name:
+            return node
+    return None
+
+
+def _plugin_fail_soft(sources: _Sources) -> dict[str, Any]:
+    tree = sources.module_tree(_REGISTRY_MODULE)
+    reject = _function(tree, "EndpointRegistry._reject_builtin_collisions")
+    consult = _function(tree, "EndpointRegistry._consult_plugin_providers")
+    rejection_guard = next(
+        (
+            ast.unparse(node.test)
+            for node in ast.walk(reject)
+            if isinstance(node, ast.If)
+            and "is_this_activation" in ast.unparse(node.test)
+            and "collides" in ast.unparse(node.test)
+        ),
+        None,
+    )
+    alias_handler = next(
+        (
+            handler
+            for handler in ast.walk(consult)
+            if isinstance(handler, ast.ExceptHandler)
+            and _dotted_name(handler.type) == "ProviderAliasCollisionError"
+        ),
+        None,
+    )
+    append_call = _first_call_node(reject, "rejected.append")
+    removal_call = _first_call_node(reject, "cls._remove_entries")
+    return {
+        "builtin_collision": {
+            "activation_scope": _assignment_expression(reject, "is_this_activation"),
+            "collision_predicate": _assignment_expression(reject, "collides"),
+            "rejection_guard": rejection_guard,
+            "append_call": ast.unparse(append_call) if append_call else None,
+            "removal_call": ast.unparse(removal_call) if removal_call else None,
+            "removal_after_append": bool(
+                append_call and removal_call and removal_call.lineno > append_call.lineno
+            ),
+        },
+        "provider_alias_collision": {
+            "exception": _dotted_name(alias_handler.type) if alias_handler else None,
+            "handler_logs_warning": bool(
+                alias_handler
+                and any(
+                    isinstance(node, ast.Call) and _dotted_name(node.func) == "logger.warning"
+                    for node in ast.walk(alias_handler)
+                )
+            ),
+            "handler_continues": bool(
+                alias_handler
+                and any(isinstance(node, ast.Continue) for node in ast.walk(alias_handler))
+            ),
+        },
+    }
+
+
+def _markdown_fence(line: str) -> tuple[str, int, str] | None:
+    candidate = line.lstrip(" ")
+    if len(line) - len(candidate) > 3 or not candidate:
+        return None
+    marker = candidate[0]
+    if marker not in {"`", "~"}:
+        return None
+    width = len(candidate) - len(candidate.lstrip(marker))
+    if width < 3:
+        return None
+    return marker, width, candidate[width:].strip()
+
+
+def _markdown_headings(source: str) -> list[tuple[int, int, str]]:
+    headings: list[tuple[int, int, str]] = []
+    fence_marker: str | None = None
+    fence_width = 0
+    for index, line in enumerate(source.splitlines(keepends=True)):
+        fence = _markdown_fence(line)
+        if fence_marker is not None:
+            if (
+                fence is not None
+                and fence[0] == fence_marker
+                and fence[1] >= fence_width
+                and not fence[2]
+            ):
+                fence_marker = None
+                fence_width = 0
+            continue
+        if fence is not None:
+            fence_marker, fence_width, _ = fence
+            continue
+
+        candidate = line.rstrip("\r\n").lstrip(" ")
+        indent = len(line.rstrip("\r\n")) - len(candidate)
+        if indent > 3 or not candidate.startswith("#"):
+            continue
+        level = len(candidate) - len(candidate.lstrip("#"))
+        if level > 6 or candidate[level : level + 1] not in {"", " "}:
+            continue
+        headings.append((index, level, candidate.rstrip()))
+    return headings
+
+
+def _markdown_section(source: str, *, path: str, anchor: str) -> str:
+    lines = source.splitlines(keepends=True)
+    headings = _markdown_headings(source)
+    matches = [(index, level) for index, level, heading in headings if heading == anchor]
+    if len(matches) != 1:
+        raise AssertionError(
+            f"documentation anchor must occur exactly once: "
+            f"path={path!r}, anchor={anchor!r}, occurrences={len(matches)}"
+        )
+    start, level = matches[0]
+    end = next(
+        (index for index, next_level, _ in headings if index > start and next_level <= level),
+        len(lines),
+    )
+    return "".join(lines[start:end])
+
+
+def _documentation_surfaces(sources: _Sources) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for path, anchor, tokens in _DOCUMENTATION_SURFACES:
+        section = _markdown_section(sources.read(path), path=path, anchor=anchor)
+        result.append(
+            {
+                "path": path,
+                "anchor": anchor,
+                "token_counts": {token: section.count(token) for token in tokens},
+            }
+        )
+    return result
+
+
+def collect_provider_authority_inventory(
+    root: Path,
+    *,
+    source_overrides: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Collect provider authority from source text without importing provider modules."""
+    sources = _Sources(root, source_overrides)
+    registry_tree = sources.module_tree(_REGISTRY_MODULE)
+    modules = _bootstrap_modules(registry_tree)
+    rows = _endpoint_rows(sources, modules)
+    return {
+        "schema": _SCHEMA,
+        "version": _VERSION,
+        "bootstrap_modules": modules,
+        "optional_dependencies": _static_value(
+            _top_level_value(registry_tree, "_PROVIDER_OPTIONAL_DEPENDENCIES")
+        ),
+        "endpoint_rows": rows,
+        "context_windows": _context_windows(sources),
+        "documentation_surfaces": _documentation_surfaces(sources),
+        "public_authority": _public_authority(sources),
+        "deletion_ledger": _deletion_ledger(sources, len(rows)),
+        "plugin_fail_soft": _plugin_fail_soft(sources),
+    }

--- a/tests/service/connections/test_plugin_provider_consumer.py
+++ b/tests/service/connections/test_plugin_provider_consumer.py
@@ -51,6 +51,20 @@ class PluginProviderEndpoint(Endpoint):
     pass
 """
 
+PROVIDER_ALIAS_MODULE = """\
+from lionagi.service.connections.registry import register_endpoint
+from lionagi.service.connections.endpoint import Endpoint
+
+
+@register_endpoint(
+    provider="{provider}",
+    endpoint="chat",
+    provider_aliases=["{provider_alias}"],
+)
+class PluginProviderEndpoint(Endpoint):
+    pass
+"""
+
 
 def _clear_plugin_modules() -> None:
     """Drop every ``sys.modules`` entry left by ``PluginRegistry.activate_target``.
@@ -82,10 +96,12 @@ def _isolate_endpoint_registry():
     EndpointRegistry._ensure_loaded()
     saved_entries = list(EndpointRegistry._entries)
     saved_loaded = EndpointRegistry._loaded
+    saved_alias_owners = dict(EndpointRegistry._alias_owners)
     _clear_plugin_modules()
     yield
     EndpointRegistry._entries = saved_entries
     EndpointRegistry._loaded = saved_loaded
+    EndpointRegistry._alias_owners = saved_alias_owners
     _clear_plugin_modules()
 
 
@@ -821,6 +837,10 @@ class TestPluginProviderBuiltinCollision:
 
         result = match_endpoint(provider="openai", endpoint="chat")
         assert isinstance(result, OpenaiChatEndpoint)
+        assert not any(
+            entry.plugin_name == "web-research" and entry.meta.provider == "openai"
+            for entry in EndpointRegistry._entries
+        )
 
     def test_sibling_noncolliding_provider_in_the_same_manifest_still_resolves(self, write_plugin):
         """A collision on one declared provider must not take down a sibling,
@@ -847,3 +867,80 @@ class TestPluginProviderBuiltinCollision:
 
         assert type(result).__name__ == "PluginProviderEndpoint"
         assert result.config.provider == "acme-llm"
+
+
+class TestPluginProviderPeerCollision:
+    def test_same_canonical_provider_coexists_and_first_activation_wins(self, write_plugin):
+        _write_provider_plugin(
+            write_plugin,
+            "a-first",
+            name="provider-first",
+            provider="shared-provider",
+        )
+        _write_provider_plugin(
+            write_plugin,
+            "z-second",
+            name="provider-second",
+            provider="shared-provider",
+        )
+
+        assert PluginRegistry.active_provider_targets() == [
+            ("provider-first", "providers/endpoint.py"),
+            ("provider-second", "providers/endpoint.py"),
+        ]
+
+        result = match_endpoint(provider="shared-provider", endpoint="chat")
+        peer_entries = [
+            entry for entry in EndpointRegistry._entries if entry.meta.provider == "shared-provider"
+        ]
+
+        assert [entry.plugin_name for entry in peer_entries] == [
+            "provider-first",
+            "provider-second",
+        ]
+        assert type(result).__module__ == _module_key("provider-first")
+        assert _module_key("provider-first") in sys.modules
+        assert _module_key("provider-second") in sys.modules
+
+    def test_shared_alias_rejects_later_canonical_provider_fail_soft(self, write_plugin, caplog):
+        import logging
+
+        for dir_name, plugin_name, provider in (
+            ("a-incumbent", "alias-incumbent", "canonical-incumbent"),
+            ("z-contender", "alias-contender", "canonical-contender"),
+        ):
+            write_plugin(
+                dir_name,
+                MANIFEST.format(name=plugin_name),
+                files={
+                    "providers/endpoint.py": PROVIDER_ALIAS_MODULE.format(
+                        provider=provider,
+                        provider_alias="shared-provider-alias",
+                    )
+                },
+            )
+            _trust(dir_name)
+
+        assert PluginRegistry.active_provider_targets() == [
+            ("alias-incumbent", "providers/endpoint.py"),
+            ("alias-contender", "providers/endpoint.py"),
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="lionagi.service.connections.registry"):
+            result = match_endpoint(provider="shared-provider-alias", endpoint="chat")
+
+        assert result.config.provider == "canonical-incumbent"
+        assert type(result).__module__ == _module_key("alias-incumbent")
+        assert [
+            entry.plugin_name
+            for entry in EndpointRegistry._entries
+            if entry.meta.provider in {"canonical-incumbent", "canonical-contender"}
+        ] == ["alias-incumbent"]
+        # PluginRegistry wraps the decorator collision as PluginActivationError,
+        # so the registry's ProviderAliasCollisionError warning handler is not
+        # reached in the current compatibility path.
+        assert "alias-contender" not in caplog.text
+        assert _module_key("alias-incumbent") in sys.modules
+        assert _module_key("alias-contender") not in sys.modules
+        with pytest.raises(ProviderNotFoundError, match="canonical-contender"):
+            match_endpoint(provider="canonical-contender", endpoint="chat")

--- a/tests/service/connections/test_provider_authority_inventory.py
+++ b/tests/service/connections/test_provider_authority_inventory.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Independent static contract for the production provider authority."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from ._provider_inventory import (
+    collect_provider_authority_inventory,
+    load_checked_inventory,
+)
+
+_ROOT = Path(__file__).resolve().parents[3]
+_INVENTORY = _ROOT / "tests" / "contracts" / "data" / "provider_authority_inventory.json"
+
+
+def _checked_inventory():
+    return load_checked_inventory(_INVENTORY)
+
+
+def _assert_inventory_matches(source_overrides: Mapping[str, str] | None = None) -> None:
+    expected = _checked_inventory()
+    actual = collect_provider_authority_inventory(_ROOT, source_overrides=source_overrides)
+    mismatched = [key for key in expected if actual.get(key) != expected[key]]
+    extra = [key for key in actual if key not in expected]
+    assert not mismatched and not extra, (
+        "provider authority inventory drift: "
+        f"mismatched={mismatched or 'none'}, extra={extra or 'none'}"
+    )
+
+
+def _mutate_source(relative: str, old: str, new: str) -> dict[str, str]:
+    source = (_ROOT / relative).read_text(encoding="utf-8")
+    assert old in source, f"mutation anchor missing from {relative}: {old!r}"
+    return {relative: source.replace(old, new, 1)}
+
+
+def test_checked_inventory_matches_static_production_sources():
+    _assert_inventory_matches()
+
+
+def test_checked_inventory_is_a_closed_literal():
+    inventory = _checked_inventory()
+    assert tuple(inventory) == (
+        "schema",
+        "version",
+        "bootstrap_modules",
+        "optional_dependencies",
+        "endpoint_rows",
+        "context_windows",
+        "documentation_surfaces",
+        "public_authority",
+        "deletion_ledger",
+        "plugin_fail_soft",
+    )
+    assert len(inventory["bootstrap_modules"]) == 33
+    assert inventory["optional_dependencies"] == {}
+    assert len(inventory["endpoint_rows"]) == 36
+    assert len(inventory["context_windows"]) == 12
+    assert len(inventory["documentation_surfaces"]) == 20
+    assert all(
+        tuple(row)
+        == (
+            "bootstrap_module",
+            "provider",
+            "provider_aliases",
+            "endpoint",
+            "endpoint_aliases",
+            "endpoint_type",
+            "options_ref",
+            "implementation_ref",
+            "base_url",
+            "auth_type",
+            "content_type",
+            "api_key_env",
+        )
+        for row in inventory["endpoint_rows"]
+    )
+    assert all(
+        tuple(context) == ("provider", "source_module", "entries")
+        and all(tuple(entry) == ("model", "context_window") for entry in context["entries"])
+        for context in inventory["context_windows"]
+    )
+    assert all(
+        tuple(surface) == ("path", "anchor", "token_counts")
+        and surface["anchor"].startswith("#")
+        and surface["token_counts"]
+        and all(count > 0 for count in surface["token_counts"].values())
+        for surface in inventory["documentation_surfaces"]
+    )
+    assert {surface["path"] for surface in inventory["documentation_surfaces"]} == {
+        "docs/api/imodel.md",
+        "docs/adr/ADR-0027-model-service-facade-and-endpoint-resolution.md",
+        "docs/adr/ADR-0052-supported-validation-and-testing-surfaces.md",
+        "docs/adr/ADR-0088-plugin-system.md",
+        "docs/internals/core.md",
+        "docs/internals/runtime.md",
+        "docs/migration/0.23.0-to-0.23.1.md",
+        "docs/reference/operations-service.md",
+        "docs/reference/providers.md",
+    }
+    assert sum(row["endpoint_type"] == "api" for row in inventory["endpoint_rows"]) == 28
+    assert sum(row["endpoint_type"] == "agentic" for row in inventory["endpoint_rows"]) == 8
+    assert {row["provider"] for row in inventory["endpoint_rows"]} == {
+        "ag2",
+        "anthropic",
+        "claude_code",
+        "codex",
+        "deepseek",
+        "exa",
+        "firecrawl",
+        "gemini",
+        "gemini_code",
+        "groq",
+        "nvidia_nim",
+        "ollama",
+        "openai",
+        "openrouter",
+        "perplexity",
+        "pi",
+        "scripted",
+        "tavily",
+    }
+    provider_aliases = {
+        alias for row in inventory["endpoint_rows"] for alias in row["provider_aliases"]
+    }
+    assert len(provider_aliases) == 13
+    accepted_provider_spellings = {
+        row["provider"] for row in inventory["endpoint_rows"]
+    } | provider_aliases
+    assert len(accepted_provider_spellings) == 31
+
+
+def test_collector_does_not_import_provider_implementations():
+    before = set(sys.modules)
+    collect_provider_authority_inventory(_ROOT)
+    imported = {
+        module
+        for module in set(sys.modules) - before
+        if module.startswith(("lionagi.providers.", "lionagi.testing._endpoint"))
+    }
+    assert imported == set()
+
+
+@pytest.mark.parametrize(
+    ("relative", "old", "new", "section"),
+    [
+        (
+            "lionagi/service/connections/registry.py",
+            '        "lionagi.providers.openai.chat",\n',
+            "",
+            "bootstrap_modules",
+        ),
+        (
+            "lionagi/service/connections/registry.py",
+            "    def _claim_provider_identity(",
+            "    def _removed_claim_provider_identity(",
+            "deletion_ledger",
+        ),
+        (
+            "lionagi/providers/google/_config.py",
+            '["gemini-code", "gemini_cli", "gemini-cli"]',
+            '["gemini-code", "gemini_clix", "gemini-cli"]',
+            "endpoint_rows",
+        ),
+        (
+            "lionagi/service/connections/registry.py",
+            "_PROVIDER_OPTIONAL_DEPENDENCIES: dict[str, tuple[str, ...]] = {}\n",
+            "_PROVIDER_OPTIONAL_DEPENDENCIES: dict[str, tuple[str, ...]] = "
+            '{"lionagi.providers.ollama.chat": ("ollama",)}\n',
+            "optional_dependencies",
+        ),
+        (
+            "lionagi/providers/google/gemini_code.py",
+            '    "gemini-2.5-pro": 2_097_152,\n',
+            '    "gemini-2.5-pro": 2_097_153,\n',
+            "context_windows",
+        ),
+        (
+            "lionagi/service/token_budget.py",
+            '    "openai": "lionagi.providers.openai._config",\n'
+            '    "anthropic": "lionagi.providers.anthropic.messages",\n',
+            '    "anthropic": "lionagi.providers.anthropic.messages",\n'
+            '    "openai": "lionagi.providers.openai._config",\n',
+            "context_windows",
+        ),
+        (
+            "lionagi/providers/openai/_config.py",
+            '    "gpt-5.5": 1_000_000,\n    "gpt-5.4-mini": 1_000_000,\n',
+            '    "gpt-5.4-mini": 1_000_000,\n    "gpt-5.5": 1_000_000,\n',
+            "context_windows",
+        ),
+        (
+            "docs/reference/operations-service.md",
+            "provider longest-prefix lookup",
+            "provider lookup",
+            "documentation_surfaces",
+        ),
+        (
+            "docs/reference/providers.md",
+            "| OpenAI |",
+            "| OpenAI API |",
+            "documentation_surfaces",
+        ),
+        (
+            "docs/api/imodel.md",
+            "`EndpointRegistry`",
+            "`LegacyEndpointRegistry`",
+            "documentation_surfaces",
+        ),
+        (
+            "lionagi/service/connections/registry.py",
+            "        rejected: list[_RegistryEntry] = []\n        for entry in cls._entries:\n",
+            "        rejected: list[_RegistryEntry] = []\n"
+            "        cls._remove_entries(rejected)\n"
+            "        for entry in cls._entries:\n",
+            "plugin_fail_soft",
+        ),
+        (
+            "lionagi/service/connections/registry.py",
+            "        cls._remove_entries(rejected)\n",
+            "        pass\n",
+            "plugin_fail_soft",
+        ),
+        (
+            "lionagi/service/connections/registry.py",
+            "                except ProviderAliasCollisionError as exc:\n",
+            "                except ValueError as exc:\n",
+            "plugin_fail_soft",
+        ),
+    ],
+    ids=(
+        "removed-bootstrap-module",
+        "removed-alias-claim-authority",
+        "changed-real-provider-alias",
+        "added-real-optional-dependency",
+        "changed-context-value",
+        "changed-context-provider-order",
+        "changed-context-entry-order",
+        "removed-documentation-token",
+        "changed-provider-catalog-doc-row",
+        "changed-imodel-matching-doc",
+        "moved-plugin-collision-removal-before-collection",
+        "removed-plugin-collision-removal",
+        "removed-plugin-alias-fail-soft-handler",
+    ),
+)
+def test_source_override_mutations_are_detected(
+    relative: str,
+    old: str,
+    new: str,
+    section: str,
+):
+    overrides = _mutate_source(relative, old, new)
+    with pytest.raises(AssertionError, match=section):
+        _assert_inventory_matches(overrides)

--- a/tests/service/connections/test_provider_authority_runtime_contract.py
+++ b/tests/service/connections/test_provider_authority_runtime_contract.py
@@ -1,0 +1,485 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Fresh-process characterization of the legacy provider runtime authority.
+
+The plugin filesystem/trust matrix remains owned by
+``test_plugin_provider_consumer.py``. In particular, its built-in-collision and
+noncolliding-sibling tests pin the current fail-soft behavior without repeating
+that heavyweight setup here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHECKED_INVENTORY = REPO_ROOT / "tests" / "contracts" / "data" / "provider_authority_inventory.json"
+
+
+def _run_fresh(
+    script: str,
+    tmp_path: Path,
+    *,
+    hash_seed: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    """Run one isolated interpreter rooted outside the repository."""
+    env = {key: value for key, value in os.environ.items() if not key.startswith("PYTHON")}
+    env.update(
+        {
+            "LIONAGI_HOME": str(tmp_path / ".lionagi"),
+            "PROVIDER_AUTHORITY_INVENTORY_PATH": str(CHECKED_INVENTORY),
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONHASHSEED": str(hash_seed),
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONPATH": str(REPO_ROOT),
+        }
+    )
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-B", "-c", textwrap.dedent(script)],
+        check=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+        text=True,
+    )
+
+
+def test_checked_inventory_runtime_seam_exists() -> None:
+    """The runtime contract has one checked, schema-versioned comparison seam."""
+    assert CHECKED_INVENTORY.is_file(), f"missing checked provider inventory: {CHECKED_INVENTORY}"
+    payload = json.loads(CHECKED_INVENTORY.read_text(encoding="utf-8"))
+
+    assert payload["schema"] == "lionagi.provider-authority-inventory"
+    assert payload["version"] == 1
+
+
+def test_fresh_runner_strips_parent_python_injection(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("PYTHONOPTIMIZE", "1")
+    monkeypatch.setenv("PYTHONPATH", "/tmp/parent-python-path")
+    monkeypatch.setenv("PYTHONUSERBASE", "/tmp/parent-python-user-base")
+
+    _run_fresh(
+        """
+        import os
+        import site
+        import sys
+        from pathlib import Path
+
+        assert sys.flags.optimize == 0
+        assert site.ENABLE_USER_SITE is False
+        inventory_path = Path(os.environ["PROVIDER_AUTHORITY_INVENTORY_PATH"])
+        assert os.environ["PYTHONPATH"] == str(inventory_path.parents[3])
+        assert "PYTHONUSERBASE" not in os.environ
+        """,
+        tmp_path,
+    )
+
+
+def test_config_import_is_inert_but_implementation_import_and_reload_append(
+    tmp_path: Path,
+) -> None:
+    _run_fresh(
+        """
+        import importlib
+
+        from lionagi.service.connections.registry import EndpointRegistry
+
+        assert EndpointRegistry._entries == []
+        assert EndpointRegistry._loaded is False
+
+        config = importlib.import_module("lionagi.providers.openai._config")
+        assert EndpointRegistry._entries == []
+        importlib.reload(config)
+        assert EndpointRegistry._entries == []
+
+        implementation = importlib.import_module("lionagi.providers.openai.chat")
+        assert len(EndpointRegistry._entries) == 1
+        first = EndpointRegistry._entries[0]
+        assert (first.meta.provider, first.meta.endpoint) == ("openai", "chat/completions")
+
+        importlib.reload(implementation)
+        assert len(EndpointRegistry._entries) == 2
+        second = EndpointRegistry._entries[1]
+        assert first.meta == second.meta
+        assert first.cls is not second.cls
+        assert EndpointRegistry._loaded is False
+        """,
+        tmp_path,
+    )
+
+
+def test_no_hint_context_lookup_imports_all_sources_and_mutates_registry(
+    tmp_path: Path,
+) -> None:
+    _run_fresh(
+        """
+        import sys
+
+        from lionagi.service.connections.registry import EndpointRegistry
+        from lionagi.service import token_budget
+
+        expected_modules = (
+            "lionagi.providers.openai._config",
+            "lionagi.providers.anthropic.messages",
+            "lionagi.providers.anthropic.claude_code",
+            "lionagi.providers.openai.codex",
+            "lionagi.providers.deepseek.chat",
+            "lionagi.providers.nvidia_nim.chat",
+            "lionagi.providers.perplexity.chat",
+            "lionagi.providers.google.gemini_code",
+            "lionagi.providers.pi.cli",
+            "lionagi.providers.groq.chat",
+            "lionagi.providers.google.chat",
+            "lionagi.providers.openrouter.chat",
+        )
+        assert tuple(token_budget._PROVIDER_MODULES.values()) == expected_modules
+        assert EndpointRegistry._entries == []
+        assert token_budget._provider_cache == {}
+
+        assert token_budget.lookup_context_window("totally-unknown-model") == 128_000
+
+        observed_modules = tuple(name for name in sys.modules if name in expected_modules)
+        assert observed_modules == expected_modules
+        assert tuple(token_budget._provider_cache) == tuple(token_budget._PROVIDER_MODULES)
+        assert EndpointRegistry._loaded is False
+        assert [(entry.meta.provider, entry.meta.endpoint) for entry in EndpointRegistry._entries] == [
+            ("anthropic", "messages"),
+            ("claude_code", "query_cli"),
+            ("codex", "query_cli"),
+            ("deepseek", "chat/completions"),
+            ("nvidia_nim", "chat/completions"),
+            ("perplexity", "chat/completions"),
+            ("gemini_code", "query_cli"),
+            ("pi", "query_cli"),
+            ("groq", "chat/completions"),
+            ("gemini", "chat/completions"),
+            ("openrouter", "chat/completions"),
+        ]
+        """,
+        tmp_path,
+    )
+
+
+def test_context_lookup_preserves_gemini_hint_and_global_precedence(tmp_path: Path) -> None:
+    _run_fresh(
+        """
+        from lionagi.service.token_budget import lookup_context_window
+
+        assert lookup_context_window("gemini-2.5-pro") == 2_097_152
+        assert lookup_context_window("gemini-2.5-pro", provider="gemini") == 1_048_576
+        assert lookup_context_window("gemini-2.5-pro", provider="gemini-api") == 2_097_152
+        """,
+        tmp_path,
+    )
+
+
+def test_public_provider_authority_imports_and_signatures_are_exact(tmp_path: Path) -> None:
+    _run_fresh(
+        """
+        import inspect
+
+        from lionagi import iModel as root_imodel
+        from lionagi.service.connections import (
+            EndpointRegistry,
+            match_endpoint,
+            register_endpoint,
+        )
+        from lionagi.service.connections.match_endpoint import match_endpoint as defined_match
+        from lionagi.service.connections.provider_config import ProviderConfig
+        from lionagi.service.connections.registry import (
+            EndpointRegistry as DefinedEndpointRegistry,
+        )
+        from lionagi.service.connections.registry import register_endpoint as defined_register
+        from lionagi.service.imodel import iModel
+        from lionagi.service.token_budget import get_context_window, lookup_context_window
+
+        assert EndpointRegistry is DefinedEndpointRegistry
+        assert register_endpoint is defined_register
+        assert match_endpoint is defined_match
+        assert root_imodel is iModel
+
+        register_signature = (
+            "(provider: 'str', endpoint: 'str', aliases: 'list[str] | None' = None, "
+            "endpoint_type: 'EndpointType' = <EndpointType.API: 'api'>, "
+            "provider_aliases: 'list[str] | None' = None, "
+            "options: 'type[BaseModel] | None' = None, base_url: 'str | None' = None, "
+            "auth_type: 'str | None' = None, content_type: 'str | None' = None, "
+            "api_key_env: 'str | None' = None)"
+        )
+        assert str(inspect.signature(EndpointRegistry.register)) == register_signature
+        assert str(inspect.signature(register_endpoint)) == register_signature
+        assert str(inspect.signature(EndpointRegistry.match)) == (
+            "(provider: 'str', endpoint: 'str' = '', *, "
+            "openai_compatible: 'bool' = False, **kwargs) -> 'Any'"
+        )
+        assert str(inspect.signature(EndpointRegistry.list_providers)) == (
+            "() -> 'list[dict[str, Any]]'"
+        )
+        assert str(inspect.signature(ProviderConfig.register)) == "(self, cls=None)"
+        assert str(inspect.signature(match_endpoint)) == (
+            "(provider: str, endpoint: str, *, openai_compatible: bool = False, **kwargs) "
+            "-> lionagi.service.connections.endpoint.Endpoint"
+        )
+        assert str(inspect.signature(iModel.__init__)) == (
+            "(self, provider: 'str | None' = None, base_url: 'str | None' = None, "
+            "endpoint: 'str | Endpoint' = 'chat', api_key: 'str | None' = None, "
+            "queue_capacity: 'int | None' = None, capacity_refresh_time: 'float' = 60, "
+            "interval: 'float | None' = None, limit_requests: 'int | None' = None, "
+            "limit_tokens: 'int | None' = None, concurrency_limit: 'int | None' = None, "
+            "streaming_process_func: 'Callable | None' = None, "
+            "provider_metadata: 'dict | None' = None, "
+            "hook_registry: 'HookRegistry | dict | None' = None, exit_hook: 'bool' = False, "
+            "id: 'UUID | str | None' = None, created_at: 'float | None' = None, "
+            "**kwargs) -> 'None'"
+        )
+        assert str(inspect.signature(lookup_context_window)) == (
+            "(model_name: 'str', provider: 'str | None' = None) -> 'int'"
+        )
+        assert str(inspect.signature(get_context_window)) == "(branch: 'Branch') -> 'int'"
+        assert EndpointRegistry._entries == []
+        assert EndpointRegistry._loaded is False
+        """,
+        tmp_path,
+    )
+
+
+def test_list_providers_has_exact_legacy_projection_and_stable_order(tmp_path: Path) -> None:
+    script = """
+        import json
+        import os
+        from pathlib import Path
+
+        from lionagi.service.connections.registry import EndpointRegistry
+
+        inventory = json.loads(
+            Path(os.environ["PROVIDER_AUTHORITY_INVENTORY_PATH"]).read_text(encoding="utf-8")
+        )
+        expected_rows = [
+            {
+                "provider": row["provider"],
+                "endpoint": row["endpoint"],
+                "aliases": row["endpoint_aliases"],
+                "type": row["endpoint_type"],
+                "class": row["implementation_ref"].rsplit(":", 1)[-1],
+                "options": (
+                    row["options_ref"].rsplit(":", 1)[-1]
+                    if row["options_ref"] is not None
+                    else None
+                ),
+            }
+            for row in inventory["endpoint_rows"]
+        ]
+        rows = EndpointRegistry.list_providers()
+        assert len(rows) == 36
+        assert len({row["provider"] for row in rows}) == 18
+        assert all(
+            tuple(row) == ("provider", "endpoint", "aliases", "type", "class", "options")
+            for row in rows
+        )
+        assert rows == expected_rows
+        assert EndpointRegistry._loaded is True
+        print(json.dumps(rows, separators=(",", ":")))
+    """
+    first = _run_fresh(script, tmp_path, hash_seed=0)
+    second = _run_fresh(script, tmp_path, hash_seed=1)
+
+    assert first.stdout == second.stdout
+
+
+def test_full_runtime_match_matrix_selects_inventory_rows_without_provider_construction(
+    tmp_path: Path,
+) -> None:
+    _run_fresh(
+        """
+        import json
+        import os
+        from pathlib import Path
+
+        from lionagi.plugins import PluginRegistry
+        from lionagi.service.connections.endpoint import Endpoint
+        from lionagi.service.connections.registry import EndpointRegistry
+
+        PluginRegistry.active_provider_targets = classmethod(lambda cls: [])
+        inventory = json.loads(
+            Path(os.environ["PROVIDER_AUTHORITY_INVENTORY_PATH"]).read_text(encoding="utf-8")
+        )
+        rows = inventory["endpoint_rows"]
+
+        EndpointRegistry._ensure_loaded()
+        assert len(EndpointRegistry._entries) == len(rows) == 36
+
+        def marker(index):
+            def construct(_config=None, **_kwargs):
+                return index
+
+            return construct
+
+        def qualified_ref(value):
+            if value is None:
+                return None
+            return f"{value.__module__}:{value.__qualname__}"
+
+        for index, (entry, row) in enumerate(zip(EndpointRegistry._entries, rows, strict=True)):
+            assert {
+                "provider": entry.meta.provider,
+                "provider_aliases": list(entry.meta.provider_aliases),
+                "endpoint": entry.meta.endpoint,
+                "endpoint_aliases": list(entry.meta.aliases),
+                "endpoint_type": entry.meta.endpoint_type.value,
+                "options_ref": qualified_ref(entry.meta.options),
+                "implementation_ref": qualified_ref(entry.cls),
+                "base_url": entry.meta.base_url,
+                "auth_type": entry.meta.auth_type,
+                "content_type": entry.meta.content_type,
+                "api_key_env": entry.meta.api_key_env,
+            } == {key: row[key] for key in (
+                "provider",
+                "provider_aliases",
+                "endpoint",
+                "endpoint_aliases",
+                "endpoint_type",
+                "options_ref",
+                "implementation_ref",
+                "base_url",
+                "auth_type",
+                "content_type",
+                "api_key_env",
+            )}
+            entry.cls = marker(index)
+
+        provider_spellings = []
+        provider_rows = {}
+        for index, row in enumerate(rows):
+            provider_rows.setdefault(row["provider"], []).append(index)
+            for spelling in (row["provider"], *row["provider_aliases"]):
+                if spelling not in provider_spellings:
+                    provider_spellings.append(spelling)
+                for endpoint in (row["endpoint"], *row["endpoint_aliases"]):
+                    assert EndpointRegistry.match(spelling, endpoint) == index
+
+        assert len(provider_spellings) == 31
+        for spelling in provider_spellings:
+            matching_indices = [
+                index
+                for index, row in enumerate(rows)
+                if spelling == row["provider"] or spelling in row["provider_aliases"]
+            ]
+            assert EndpointRegistry.match(spelling, "") == matching_indices[0]
+
+            missing = EndpointRegistry.match(spelling, "__missing_endpoint__")
+            if len(provider_rows[rows[matching_indices[0]]["provider"]]) == 1:
+                assert missing == matching_indices[0]
+            else:
+                assert type(missing) is Endpoint
+                assert missing.config.endpoint == "__missing_endpoint__"
+                assert missing.config.openai_compatible is True
+        """,
+        tmp_path,
+    )
+
+
+def test_registered_matching_preserves_legacy_case_empty_and_miss_quirks(
+    tmp_path: Path,
+) -> None:
+    _run_fresh(
+        """
+        from lionagi.providers.openai.chat import OpenaiChatEndpoint
+        from lionagi.providers.openai.codex import CodexCLIEndpoint
+        from lionagi.plugins import PluginRegistry
+        from lionagi.service.connections.endpoint import Endpoint
+        from lionagi.service.connections.match_endpoint import match_endpoint
+
+        PluginRegistry.active_provider_targets = classmethod(lambda cls: [])
+
+        assert isinstance(match_endpoint("OPENAI", "chat"), OpenaiChatEndpoint)
+
+        endpoint_case_miss = match_endpoint("openai", "CHAT")
+        assert type(endpoint_case_miss) is Endpoint
+        assert endpoint_case_miss.config.endpoint == "CHAT"
+        assert endpoint_case_miss.config.openai_compatible is True
+
+        provider_whitespace_miss = match_endpoint(" openai ", "chat")
+        assert type(provider_whitespace_miss) is Endpoint
+        assert provider_whitespace_miss.config.provider == "openai"
+
+        empty_endpoint = match_endpoint("openai", "")
+        assert isinstance(empty_endpoint, OpenaiChatEndpoint)
+        assert empty_endpoint.config.endpoint == "chat/completions"
+
+        arbitrary_single_endpoint = match_endpoint("codex", "not-a-real-endpoint")
+        assert isinstance(arbitrary_single_endpoint, CodexCLIEndpoint)
+        assert arbitrary_single_endpoint.config.endpoint == "query_cli"
+
+        known_provider_miss = match_endpoint("openai", "not-a-real-endpoint")
+        assert type(known_provider_miss) is Endpoint
+        assert known_provider_miss.config.provider == "openai"
+        assert known_provider_miss.config.endpoint == "not-a-real-endpoint"
+        assert known_provider_miss.config.openai_compatible is True
+        """,
+        tmp_path,
+    )
+
+
+def test_unknown_provider_error_and_compatible_fallback_are_exact(tmp_path: Path) -> None:
+    _run_fresh(
+        """
+        import warnings
+
+        from lionagi.plugins import PluginRegistry
+        from lionagi.service.connections.endpoint import Endpoint
+        from lionagi.service.connections.match_endpoint import match_endpoint
+        from lionagi.service.connections.registry import ProviderNotFoundError
+
+        PluginRegistry.active_provider_targets = classmethod(lambda cls: [])
+
+        expected_error = (
+            "no endpoint registered for provider 'unknown-provider'; registered providers: "
+            "ag2, anthropic, autogen, claude, claude-code, claude_code, codex, deepseek, "
+            "exa, firecrawl, gemini, gemini-api, gemini-cli, gemini-code, gemini_cli, "
+            "gemini_code, groq, nim, nvidia, nvidia_nim, ollama, open-router, openai, "
+            "openai-codex, openrouter, perplexity, pi, pi-code, pi_code, scripted, tavily. "
+            "Pass openai_compatible=True to route unrecognized providers to the generic "
+            "OpenAI-compatible endpoint explicitly."
+        )
+        try:
+            match_endpoint("unknown-provider", "chat")
+        except ProviderNotFoundError as exc:
+            assert type(exc) is ProviderNotFoundError
+            assert str(exc) == expected_error
+        else:
+            raise AssertionError("unknown provider unexpectedly resolved")
+
+        explicit = match_endpoint(
+            "unknown-provider",
+            "chat",
+            openai_compatible=True,
+        )
+        assert type(explicit) is Endpoint
+        assert explicit.config.provider == "unknown-provider"
+        assert explicit.config.endpoint == "chat"
+        assert explicit.config.openai_compatible is True
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            implicit = match_endpoint(
+                "unknown-provider",
+                "chat",
+                base_url="https://example.invalid/v1",
+            )
+        assert type(implicit) is Endpoint
+        assert len(caught) == 1
+        assert caught[0].category is DeprecationWarning
+        assert str(caught[0].message) == (
+            "provider 'unknown-provider' is not registered; routing to the generic "
+            "OpenAI-compatible endpoint because base_url= was given. This implicit fallback "
+            "is deprecated -- pass openai_compatible=True explicitly (e.g. "
+            "match_endpoint(..., openai_compatible=True)) to silence this warning."
+        )
+        """,
+        tmp_path,
+    )


### PR DESCRIPTION
## Summary

- check in a schema-versioned, machine-readable inventory of the legacy provider authority
- capture the exact 33-module bootstrap order, 36 endpoint rows (28 API / 8 agentic), 18 canonical providers, 13 aliases, 12 context-window sources, optional-dependency map, public compatibility surfaces, deletion ledger, and migration-document anchors
- add a read-only AST collector plus mutation tests that fail on bootstrap, alias, transport metadata, context order/value, plugin collision, deletion-ledger, and documentation drift
- pin fresh-process runtime behavior, including import/reload side effects, matching and fallback quirks, full endpoint metadata/type references, hash-seed order, and context-window precedence
- characterize the current plugin peer-collision rules: same-provider contributions coexist with first activation winning, while a later cross-provider alias collision is rejected fail-soft

## Why

This is the characterization prerequisite for the endpoint-catalog migration tracked by #3336 and its follow-up #3337. The current authority is split across import-time decorators, a fixed bootstrap list, token-budget import probes, plugin activation side effects, compatibility facades, and documentation. Freezing that behavior independently prevents the immutable-catalog migration from silently changing order, aliases, fallback behavior, transport configuration, or plugin collision semantics.

This PR is tests-only and does not change runtime behavior.

## Validation

- 51 focused inventory/runtime/plugin tests passed
- the broader provider/service suite passed with the unavailable `jsonschema` and `ollama` optional-dependency nodes excluded
- Ruff check and format check passed
- Pyright: 0 errors, 0 warnings on the new collector/contracts
- JSON validation and `git diff --check` passed
- pre-commit hooks passed during commit
- the original mutation and isolation gaps were falsified and closed

## Stacking

This draft targets `codex/adr0119-immutable-registry`, the immutable Registry prerequisite branch. It should be rebased or retargeted to the default branch after that prerequisite merges.

Closes #3336

Refs-only: #3337

