### PR TITLE
test(dispatch): freeze legacy dispatcher profiles and failure semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- ADR-0120 Phase 0 now freezes the distinct HookBus, Broadcaster,
+  SessionObserver, message-callback, scheduler-signal, terminal-callback, and
+  service-hook dispatch profiles before any shared-kernel migration.
 - Resuming a flow whose checkpoint recorded any operation as failed now refuses
   and names those operations, instead of replaying them as terminal state.
   Replaying a failed operation as terminal marks it failed without running it,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Changed
 
 - ADR-0120 Phase 0 now freezes the distinct HookBus, Broadcaster,
-  SessionObserver, message-callback, scheduler-signal, terminal-callback, and
-  service-hook dispatch profiles before any shared-kernel migration.
+  SessionObserver, message-callback, scheduler-signal, and terminal-callback
+  dispatch profiles before any shared-kernel migration. Service-hook invocation
+  and streaming are characterized alongside them, but that profile's matrix is
+  frozen in Phase 1, not here.
 - Resuming a flow whose checkpoint recorded any operation as failed now refuses
   and names those operations, instead of replaying them as terminal state.
   Replaying a failed operation as terminal marks it failed without running it,

--- a/docs/adr/ADR-0120-interception-observation-and-durable-delivery-planes.md
+++ b/docs/adr/ADR-0120-interception-observation-and-durable-delivery-planes.md
@@ -608,7 +608,14 @@ uses it as migration evidence.
 
 ### Phase 0 — truth and behavior matrix
 
-Amend ADR-0047/0048 and add one matrix covering every current dispatcher:
+Amend ADR-0047/0048 and add one matrix covering every current dispatcher except the service
+HookRegistry/HookedEvent profile, whose invoke and stream-teardown matrix Phase 1 freezes
+separately for the reason given in D2: it is an interceptor with one handler per hook or chunk
+key, and the fan-out rows below — registration and invocation order across several handlers,
+single-versus-grouped error surfaces, sequential versus concurrent completion — have no subject
+there. Characterizing it under this matrix would produce rows describing a shape it does not
+have. Phase 1's merge gate covers it, so it is deferred rather than exempt, and the deferral is
+stated here so that "every current dispatcher" is not read as a claim this phase does not make:
 
 - registration and invocation order;
 - sync and async handlers;

--- a/docs/adr/ADR-0120-interception-observation-and-durable-delivery-planes.md
+++ b/docs/adr/ADR-0120-interception-observation-and-durable-delivery-planes.md
@@ -2,7 +2,7 @@
 
 - **Status**: Accepted
 - **Kind**: Aspirational
-- **Implementation-status**: not-started
+- **Implementation-status**: partial — Phase 0 compatibility profiles characterized
 - **Area**: hooks
 - **Date**: 2026-08-16
 - **Relations**: extends ADR-0047 (hook mechanism scopes), ADR-0048 (external hooks),

--- a/tests/apps_studio_server/test_signals_sse.py
+++ b/tests/apps_studio_server/test_signals_sse.py
@@ -668,6 +668,65 @@ async def test_payload_sanitizer_hook_signal_non_json_kwargs(tmp_path):
     assert len(rows) == 1, "HookSignal with non-JSON kwargs was dropped"
 
 
+async def test_hook_signal_full_payload_is_preserved_through_persistence_and_sse(
+    patched_signals_db,
+):
+    pytest.importorskip("fastapi", reason="studio extra not installed")
+    from lionagi.hooks.bus import HookPoint, HookSignal
+    from lionagi.session.session import Session
+    from lionagi.studio.services.sessions import stream_signals
+
+    _svc, db_path = patched_signals_db
+    session_id = "hook-sse-contract"
+    signal = HookSignal(
+        point=HookPoint.SESSION_START,
+        kwargs={"session_id": session_id, "status": "running"},
+        created_at=1234.5,
+        metadata={"source": "profile-freeze"},
+    )
+    expected_payload = {
+        "created_at": signal.created_at,
+        "metadata": {"source": "profile-freeze"},
+        "schema_version": 1,
+        "point": HookPoint.SESSION_START.value,
+        "kwargs": {"session_id": session_id, "status": "running"},
+    }
+
+    async with StateDB(db_path) as db:
+        progression_id = f"{session_id}-prog"
+        await db.create_progression(progression_id)
+        await db.create_session(
+            {
+                "id": session_id,
+                "created_at": 100.0,
+                "progression_id": progression_id,
+                "name": "hook-sse-contract",
+                "status": "running",
+                "invocation_kind": "agent",
+            }
+        )
+        observer = Session(name="hook-sse-contract").observer
+        observer.bind_db_persistence(session_id, db=db)
+        await observer.emit(signal)
+        rows = await db.get_session_signals_after(session_id, 0)
+
+    assert len(rows) == 1
+    persisted = rows[0]
+    assert persisted["kind"] == "HookSignal"
+    assert persisted["op_id"] == ""
+    assert persisted["payload"] == expected_payload
+
+    response = await stream_signals(session_id)
+    iterator = response.body_iterator
+    try:
+        frame = await asyncio.wait_for(anext(iterator), timeout=2.0)
+        streamed = json.loads(frame.removeprefix("data: ").strip())
+    finally:
+        await iterator.aclose()
+
+    assert streamed == persisted
+
+
 async def test_payload_sanitizer_large_payload_truncated(tmp_path):
     """A payload exceeding _PAYLOAD_BYTE_CAP is stored with truncated=true marker."""
     from lionagi.session.observer import _PAYLOAD_BYTE_CAP, _sanitize_signal_payload

--- a/tests/docs/test_adr_0120_dispatch_profile_matrix.py
+++ b/tests/docs/test_adr_0120_dispatch_profile_matrix.py
@@ -114,6 +114,38 @@ def test_normative_profile_table_is_exact_and_closed() -> None:
     assert dict(rows) == EXPECTED_PROFILES
 
 
+def test_phase_0_scope_admits_the_profile_it_defers() -> None:
+    """The scope sentence and the deferral it makes must not contradict.
+
+    Phase 0 introduces the matrix by naming what it covers, and D2 separately
+    hands the service HookRegistry profile to Phase 1. Read alone each is
+    correct, and together they said the matrix covers every dispatcher and also
+    does not cover that one. A reader with only the scope sentence concludes
+    the profile is characterized here and finds no row for it, which is exactly
+    the belief this record is supposed to prevent, since Phase 1's merge gate
+    is stated as a condition on rows that exist.
+
+    Matched on the two claims rather than on prose, so rewording either one is
+    free and dropping the exception is not.
+    """
+    text = ADR_PATH.read_text(encoding="utf-8")
+
+    defers_to_phase_1 = "Phase 1 freezes its invoke and stream-teardown matrix separately." in text
+    assert defers_to_phase_1, (
+        "the D2 deferral this test guards is gone; if that is deliberate, this "
+        "test and the Phase 0 exception below it both need revisiting"
+    )
+
+    start = text.index("### Phase 0 — truth and behavior matrix")
+    scope = text[start : text.index("### Phase 1", start)]
+    assert "covering every current dispatcher" in scope, "Phase 0's scope sentence moved or changed"
+    assert "except the service" in scope, (
+        "Phase 0 claims to cover every current dispatcher while D2 defers the "
+        "service HookRegistry profile to Phase 1; the scope sentence has to "
+        "name the exception it makes"
+    )
+
+
 def test_public_import_paths_resolve_to_their_pre_migration_modules() -> None:
     """Pin both halves of the façade contract: the path and what is behind it.
 

--- a/tests/docs/test_adr_0120_dispatch_profile_matrix.py
+++ b/tests/docs/test_adr_0120_dispatch_profile_matrix.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Freeze ADR-0120's legacy dispatcher compatibility profiles."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+ADR_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "docs/adr/ADR-0120-interception-observation-and-durable-delivery-planes.md"
+)
+
+EXPECTED_PROFILES = {
+    "HookBus blocking points": (
+        "sequential; declaration-owned interceptor",
+        "raise first ordinary failure",
+        "emitter cancellation propagates; no deadline",
+        "no predicate; await handler result",
+    ),
+    "HookBus observational points": (
+        "sequential; declaration-owned interceptor",
+        "isolate/log; `StopHook` ends the chain",
+        "emitter cancellation propagates; no deadline",
+        "no predicate; await handler result",
+    ),
+    "Broadcaster": (
+        "async entry; sequential; invoke first and classify only `asyncio.iscoroutine()` results",
+        "isolate/log ordinary `Exception`",
+        "handler/emitter cancellation propagates; no deadline",
+        "type mismatch raises before dispatch; non-coroutine awaitables are not awaited",
+    ),
+    "SessionObserver legacy observation": (
+        "async entry; invoke every handler inline/sequentially, classify by returned value, then gather returned awaitables",
+        "invocation/filter failure stops immediately; only after all invocations succeed, returned-awaitable failures unwrap one or raise a group and cancel remaining awaitables",
+        "emitter cancellation propagates; no deadline",
+        "filter/route failure propagates; `GATHER_AFTER_INVOCATIONS`",
+    ),
+    "message-added sync": (
+        "sync preflight rejects declared async before mutation; sequential drain",
+        "unwrap one failure, group several `BaseException` values",
+        "caught handler failure surfaced after drain; no deadline",
+        "no predicate; sync returned awaitable is discarded (deprecated compatibility)",
+    ),
+    "message-added async": (
+        "declaration classification; sequential drain; declared async awaited",
+        "unwrap one failure, group several `BaseException` values",
+        "caught handler failure surfaced after drain; no deadline",
+        "no predicate; sync returned awaitable is discarded (deprecated compatibility)",
+    ),
+    "SchedulerSignalBus": (
+        "async entry; concurrent invocation; classify/await returned values in each task",
+        "`RAISE_GROUP` even for one ordinary failure",
+        "handler cancellation wins and becomes `SchedulerHandlerCancelled`; if ordinary errors also exist their `ExceptionGroup` is its cause; emitter cancellation propagates; no deadline",
+        "predicate failure joins the ordinary-error group",
+    ),
+    "TerminalCallbackRegistry": (
+        "async entry; declaration classification; concurrent; declared sync offloaded",
+        "ordinary failure log/isolate",
+        "handler cancellation is re-raised inside the task group; emitter cancellation propagates; shared-budget expiry silently cancels async work and returns; abandoned sync thread work may continue",
+        "registration filter cannot execute user code; returned awaitable is awaited",
+    ),
+}
+
+PUBLIC_IMPORTS = (
+    ("lionagi", "Broadcaster", "lionagi.service.broadcaster"),
+    ("lionagi", "HookedEvent", "lionagi.service.hooks.hooked_event"),
+    ("lionagi", "HookRegistry", "lionagi.service.hooks.hook_registry"),
+    ("lionagi.hooks", "HookBus", "lionagi.hooks.bus"),
+    ("lionagi.protocols.types", "MessageManager", "lionagi.protocols.messages.manager"),
+    ("lionagi.session.observer", "SessionObserver", "lionagi.session.observer"),
+    (
+        "lionagi.state.lifecycle",
+        "TerminalCallbackRegistry",
+        "lionagi.state.lifecycle.callbacks",
+    ),
+    (
+        "lionagi.studio.scheduler.signals",
+        "SchedulerSignalBus",
+        "lionagi.studio.scheduler.signals",
+    ),
+)
+
+
+def _profile_rows() -> tuple[tuple[str, tuple[str, ...]], ...]:
+    text = ADR_PATH.read_text(encoding="utf-8")
+    start = text.index("| Named profile |")
+    end = text.index("\n\nThe Scheduler constructor", start)
+    rows: list[tuple[str, tuple[str, ...]]] = []
+    for line in text[start:end].splitlines()[2:]:
+        cells = tuple(cell.strip() for cell in line.strip().strip("|").split("|"))
+        if cells:
+            rows.append((cells[0], cells[1:]))
+    return tuple(rows)
+
+
+def test_normative_profile_table_is_exact_and_closed() -> None:
+    rows = _profile_rows()
+    names = tuple(name for name, _profile in rows)
+
+    assert names == tuple(EXPECTED_PROFILES)
+    assert len(names) == len(set(names))
+    assert dict(rows) == EXPECTED_PROFILES
+
+
+def test_profile_facade_import_paths_remain_available() -> None:
+    for module_name, symbol, owner_module in PUBLIC_IMPORTS:
+        value = getattr(importlib.import_module(module_name), symbol)
+        assert value.__module__ == owner_module

--- a/tests/docs/test_adr_0120_dispatch_profile_matrix.py
+++ b/tests/docs/test_adr_0120_dispatch_profile_matrix.py
@@ -1,6 +1,16 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Freeze ADR-0120's legacy dispatcher compatibility profiles."""
+"""Freeze ADR-0120's legacy dispatcher compatibility profiles.
+
+The table is duplicated here in full and matched against the document by exact
+prose. That is the mechanism, not an oversight: a comparison loose enough to
+survive rewording is also loose enough to let a profile's meaning drift while
+the test stays green, and the whole point of freezing these rows is that they
+are the record a later migration will be checked against. Editing a row is
+meant to require editing it in both places, so that changing what the system
+promises cannot happen quietly. Reflowing the table will fail this test; the
+answer is to reflow the copy here too, not to loosen the match.
+"""
 
 from __future__ import annotations
 
@@ -104,7 +114,16 @@ def test_normative_profile_table_is_exact_and_closed() -> None:
     assert dict(rows) == EXPECTED_PROFILES
 
 
-def test_profile_facade_import_paths_remain_available() -> None:
+def test_public_import_paths_resolve_to_their_pre_migration_modules() -> None:
+    """Pin both halves of the façade contract: the path and what is behind it.
+
+    The import is one assertion and the owning module is the other. Pinning the
+    owner is the point rather than a side effect: the migration moves mechanics
+    behind these façades while the public path stays stable, so the public path
+    alone cannot tell a completed move from a pending one. A failure here means
+    an implementation changed modules, which is a thing to do deliberately and
+    to record, not a thing to discover afterwards.
+    """
     for module_name, symbol, owner_module in PUBLIC_IMPORTS:
         value = getattr(importlib.import_module(module_name), symbol)
         assert value.__module__ == owner_module

--- a/tests/hooks/test_bus.py
+++ b/tests/hooks/test_bus.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
+
 import pytest
 
 from lionagi.hooks import HookBus, HookPoint, StopHook, hook
@@ -68,7 +71,54 @@ async def test_sync_handler_runs_without_await():
     assert calls == [1]
 
 
-async def test_handler_exception_is_logged_and_swallowed():
+@pytest.mark.parametrize(
+    "point",
+    (HookPoint.SESSION_START, HookPoint.TOOL_PRE),
+)
+async def test_sync_handler_custom_awaitable_is_awaited_for_both_profiles(point):
+    bus = HookBus()
+
+    class TrackingAwaitable:
+        def __init__(self):
+            self.awaited = False
+
+        def __await__(self):
+            self.awaited = True
+            if False:  # pragma: no cover - makes this a generator-based awaitable
+                yield None
+            return None
+
+    returned = TrackingAwaitable()
+    bus.on(point, lambda **_kwargs: returned)
+
+    await bus.emit(point)
+
+    assert returned.awaited is True
+
+
+@pytest.mark.parametrize(
+    "point",
+    (HookPoint.TOOL_PRE, HookPoint.USER_PROMPT_SUBMIT),
+)
+async def test_blocking_profile_raises_first_failure_without_draining_later_handlers(point):
+    bus = HookBus()
+    later_calls: list[str] = []
+
+    async def deny(**_kwargs):
+        raise PermissionError("denied")
+
+    async def later(**_kwargs):
+        later_calls.append("later")
+
+    bus.on(point, deny)
+    bus.on(point, later)
+
+    with pytest.raises(PermissionError, match="denied"):
+        await bus.emit(point)
+    assert later_calls == []
+
+
+async def test_handler_exception_is_logged_and_swallowed(caplog):
     bus = HookBus()
     fired_after: list[str] = []
 
@@ -81,12 +131,16 @@ async def test_handler_exception_is_logged_and_swallowed():
     bus.on(HookPoint.MESSAGE_ADD, boom)
     bus.on(HookPoint.MESSAGE_ADD, after)
     # No exception should propagate.
-    await bus.emit(HookPoint.MESSAGE_ADD, message={}, session_id="s")
+    with caplog.at_level(logging.ERROR, logger="lionagi.hooks"):
+        await bus.emit(HookPoint.MESSAGE_ADD, message={}, session_id="s")
     # Subsequent handlers still ran.
     assert fired_after == ["after"]
+    record = next(item for item in caplog.records if item.name == "lionagi.hooks")
+    assert record.getMessage() == "Hook failed: message.add"
+    assert record.exc_info is not None
 
 
-async def test_sync_handler_exception_is_also_swallowed():
+async def test_sync_handler_exception_is_logged_and_swallowed(caplog):
     bus = HookBus()
     fired_after: list[str] = []
 
@@ -98,8 +152,12 @@ async def test_sync_handler_exception_is_also_swallowed():
 
     bus.on(HookPoint.MESSAGE_ADD, boom)
     bus.on(HookPoint.MESSAGE_ADD, after)
-    await bus.emit(HookPoint.MESSAGE_ADD, message={}, session_id="s")
+    with caplog.at_level(logging.ERROR, logger="lionagi.hooks"):
+        await bus.emit(HookPoint.MESSAGE_ADD, message={}, session_id="s")
     assert fired_after == ["after"]
+    record = next(item for item in caplog.records if item.name == "lionagi.hooks")
+    assert record.getMessage() == "Hook failed: message.add"
+    assert record.exc_info is not None
 
 
 async def test_stop_hook_aborts_siblings_but_not_operation():
@@ -371,3 +429,56 @@ async def test_emit_handler_registered_during_emit_does_not_fire():
     # On the NEXT emit, "late" should fire.
     await bus.emit(HookPoint.SESSION_START, session_id="s")
     assert "late" in calls
+
+
+@pytest.mark.parametrize(
+    "point",
+    (HookPoint.SESSION_START, HookPoint.TOOL_PRE),
+)
+async def test_emitter_cancellation_propagates_for_both_hook_profiles(point):
+    bus = HookBus()
+    started = asyncio.Event()
+    later_calls: list[str] = []
+
+    async def slow(**_kwargs):
+        started.set()
+        await asyncio.Event().wait()
+
+    async def later(**_kwargs):  # pragma: no cover - cancellation stops the chain
+        later_calls.append("later")
+
+    bus.on(point, slow)
+    bus.on(point, later)
+    task = asyncio.create_task(bus.emit(point))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert later_calls == []
+
+
+@pytest.mark.parametrize(
+    "point",
+    (HookPoint.SESSION_START, HookPoint.TOOL_PRE),
+)
+async def test_handler_cancellation_is_not_misclassified_as_an_ordinary_failure(point):
+    bus = HookBus()
+    later_calls: list[str] = []
+
+    async def cancel(**_kwargs):
+        raise asyncio.CancelledError("handler cancelled")
+
+    async def later(**_kwargs):  # pragma: no cover - cancellation stops the chain
+        later_calls.append("later")
+
+    bus.on(point, cancel)
+    bus.on(point, later)
+
+    try:
+        await bus.emit(point)
+    except asyncio.CancelledError as exc:
+        assert str(exc) == "handler cancelled"
+    else:  # pragma: no cover - the profile must propagate handler cancellation
+        pytest.fail("HookBus swallowed handler cancellation")
+    assert later_calls == []

--- a/tests/protocols/messages/test_manager_hooks.py
+++ b/tests/protocols/messages/test_manager_hooks.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 
 import pytest
@@ -194,6 +195,44 @@ def test_one_failing_sync_hook_does_not_prevent_others(mm: MessageManager):
     assert len(fired_b) == 1
 
 
+def test_sync_path_delays_callback_cancellation_until_later_callbacks_drain(
+    mm: MessageManager,
+):
+    later_calls: list[str] = []
+
+    def cancel(_message):
+        raise asyncio.CancelledError("callback cancelled")
+
+    def later(_message):
+        later_calls.append("later")
+
+    mm._on_message_added.extend((cancel, later))
+
+    with pytest.raises(asyncio.CancelledError, match="callback cancelled"):
+        mm.add_message(instruction="cancel", sender="u", recipient="x")
+    assert later_calls == ["later"]
+
+
+def test_sync_path_groups_callback_cancellation_with_ordinary_failure(
+    mm: MessageManager,
+):
+    def cancel(_message):
+        raise asyncio.CancelledError("callback cancelled")
+
+    def fail(_message):
+        raise RuntimeError("callback failed")
+
+    mm._on_message_added.extend((cancel, fail))
+
+    with pytest.raises(_ExcGroup) as excinfo:
+        mm.add_message(instruction="mixed", sender="u", recipient="x")
+
+    assert [type(exc) for exc in excinfo.value.exceptions] == [
+        asyncio.CancelledError,
+        RuntimeError,
+    ]
+
+
 def test_sync_preflight_rejects_async_hook_before_pile_mutation(
     mm: MessageManager,
 ):
@@ -248,3 +287,119 @@ async def test_a_add_message_safe_when_hook_calls_a_add_message(
     contents = [m.content.instruction for _, m in fired]
     assert "trigger" in contents
     assert "echo" in contents
+
+
+class _TrackingAwaitable:
+    def __init__(self):
+        self.awaited = False
+
+    def __await__(self):
+        self.awaited = True
+        if False:  # pragma: no cover - makes this a generator-based awaitable
+            yield None
+        return None
+
+
+@pytest.mark.parametrize("async_path", (False, True))
+async def test_sync_callback_returned_awaitable_is_discarded(
+    mm: MessageManager,
+    async_path: bool,
+):
+    returned = _TrackingAwaitable()
+    mm._on_message_added.append(lambda _message: returned)
+
+    kwargs = {"instruction": "discard", "sender": "u", "recipient": "x"}
+    if async_path:
+        await mm.a_add_message(**kwargs)
+    else:
+        mm.add_message(**kwargs)
+
+    assert returned.awaited is False
+
+
+async def test_async_path_delays_callback_cancellation_until_later_callbacks_drain(
+    mm: MessageManager,
+):
+    later_calls: list[str] = []
+
+    async def cancel(_message):
+        raise asyncio.CancelledError("callback cancelled")
+
+    async def later(_message):
+        later_calls.append("later")
+
+    mm._on_message_added.extend((cancel, later))
+
+    with pytest.raises(asyncio.CancelledError, match="callback cancelled"):
+        await mm.a_add_message(instruction="cancel", sender="u", recipient="x")
+    assert later_calls == ["later"]
+
+
+async def test_async_path_groups_callback_cancellation_with_ordinary_failure(
+    mm: MessageManager,
+):
+    async def cancel(_message):
+        raise asyncio.CancelledError("callback cancelled")
+
+    async def fail(_message):
+        raise RuntimeError("callback failed")
+
+    mm._on_message_added.extend((cancel, fail))
+
+    with pytest.raises(_ExcGroup) as excinfo:
+        await mm.a_add_message(instruction="mixed", sender="u", recipient="x")
+
+    assert [type(exc) for exc in excinfo.value.exceptions] == [
+        asyncio.CancelledError,
+        RuntimeError,
+    ]
+
+
+async def test_async_path_drains_and_groups_failures_from_sync_callbacks(
+    mm: MessageManager,
+):
+    calls: list[str] = []
+
+    def cancel(_message):
+        calls.append("cancel")
+        raise asyncio.CancelledError("sync callback cancelled")
+
+    def fail(_message):
+        calls.append("fail")
+        raise RuntimeError("sync callback failed")
+
+    mm._on_message_added.extend((cancel, fail))
+
+    with pytest.raises(_ExcGroup) as excinfo:
+        await mm.a_add_message(instruction="mixed-sync", sender="u", recipient="x")
+
+    assert calls == ["cancel", "fail"]
+    assert [type(exc) for exc in excinfo.value.exceptions] == [
+        asyncio.CancelledError,
+        RuntimeError,
+    ]
+
+
+async def test_async_path_delays_emitter_cancellation_until_callbacks_drain(
+    mm: MessageManager,
+):
+    started = asyncio.Event()
+    later_calls: list[str] = []
+
+    async def slow(_message):
+        started.set()
+        await asyncio.Event().wait()
+
+    def later(_message):
+        later_calls.append("later")
+
+    mm._on_message_added.extend((slow, later))
+    task = asyncio.create_task(
+        mm.a_add_message(instruction="emitter-cancel", sender="u", recipient="x")
+    )
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert later_calls == ["later"]

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -72,6 +72,84 @@ async def test_invoke_no_hooks_core_error_propagates():
 
 
 @pytest.mark.asyncio
+async def test_public_invoke_signals_precreated_completion_event_on_success():
+    event = SimpleHooked()
+    done = event.completion_event
+
+    await event.invoke()
+
+    assert event.status is EventStatus.COMPLETED
+    assert done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_public_invoke_late_completion_event_access_is_already_signalled():
+    event = SimpleHooked()
+
+    await event.invoke()
+
+    assert event.status is EventStatus.COMPLETED
+    assert event.completion_event.is_set()
+
+
+@pytest.mark.parametrize(
+    ("status", "signals_completion"),
+    (
+        (EventStatus.PENDING, False),
+        (EventStatus.PROCESSING, False),
+        (EventStatus.COMPLETED, True),
+        (EventStatus.FAILED, True),
+        (EventStatus.SKIPPED, True),
+        (EventStatus.CANCELLED, True),
+        (EventStatus.ABORTED, True),
+    ),
+)
+def test_completion_event_terminal_status_vocabulary_is_exact(status, signals_completion):
+    event = SimpleHooked()
+    done = event.completion_event
+
+    event.status = status
+
+    assert done.is_set() is signals_completion
+
+
+@pytest.mark.asyncio
+async def test_public_invoke_signals_precreated_completion_event_on_failure():
+    event = FailingHooked()
+    done = event.completion_event
+
+    await event.invoke()
+
+    assert event.status is EventStatus.FAILED
+    assert done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_exhausted_public_stream_signals_precreated_completion_event():
+    event = SimpleHooked()
+    done = event.completion_event
+
+    chunks = [chunk async for chunk in event.stream()]
+
+    assert chunks == ["chunk1", "chunk2"]
+    assert event.status is EventStatus.COMPLETED
+    assert done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_closed_public_stream_signals_precreated_completion_event():
+    event = SlowStream()
+    done = event.completion_event
+    stream = event.stream()
+
+    assert await anext(stream) == "chunk1"
+    await stream.aclose()
+
+    assert event.status is EventStatus.CANCELLED
+    assert done.is_set()
+
+
+@pytest.mark.asyncio
 async def test_invoke_pre_hook_completed_runs_core():
     """COMPLETED pre-hook runs; core result is returned."""
     h = SimpleHooked()

--- a/tests/service/test_broadcaster.py
+++ b/tests/service/test_broadcaster.py
@@ -1,6 +1,7 @@
 """Tests for lionagi.service.broadcaster module."""
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -143,7 +144,7 @@ class TestBroadcaster:
         callback.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_broadcast_handles_callback_exception(self):
+    async def test_broadcast_handles_callback_exception(self, caplog):
         class TestBroadcaster(Broadcaster):
             _event_type = SampleEvent
 
@@ -154,14 +155,18 @@ class TestBroadcaster:
         TestBroadcaster.subscribe(failing_callback)
         TestBroadcaster.subscribe(successful_callback)
 
-        await TestBroadcaster.broadcast(event)
+        with caplog.at_level(logging.ERROR, logger="lionagi.service.broadcaster"):
+            await TestBroadcaster.broadcast(event)
 
         # Both callbacks should be attempted
         failing_callback.assert_called_once_with(event)
         successful_callback.assert_called_once_with(event)
+        record = next(item for item in caplog.records if item.name == "lionagi.service.broadcaster")
+        assert record.getMessage() == "Error in subscriber callback: Callback error"
+        assert record.exc_info is not None
 
     @pytest.mark.asyncio
-    async def test_broadcast_handles_async_callback_exception(self):
+    async def test_broadcast_handles_async_callback_exception(self, caplog):
         class TestBroadcaster(Broadcaster):
             _event_type = SampleEvent
 
@@ -172,11 +177,15 @@ class TestBroadcaster:
         TestBroadcaster.subscribe(failing_callback)
         TestBroadcaster.subscribe(successful_callback)
 
-        await TestBroadcaster.broadcast(event)
+        with caplog.at_level(logging.ERROR, logger="lionagi.service.broadcaster"):
+            await TestBroadcaster.broadcast(event)
 
         # Both callbacks should be attempted
         assert failing_callback.await_count == 1
         successful_callback.assert_awaited_once_with(event)
+        record = next(item for item in caplog.records if item.name == "lionagi.service.broadcaster")
+        assert record.getMessage() == "Error in subscriber callback: Async callback error"
+        assert record.exc_info is not None
 
     @pytest.mark.asyncio
     async def test_broadcast_with_no_subscribers(self):
@@ -304,6 +313,28 @@ class TestBroadcasterCoroutineOnlyRegression:
         assert task_completed == [True]
 
     @pytest.mark.asyncio
+    async def test_sync_subscriber_returning_bare_coroutine_is_awaited(self):
+        calls: list[str] = []
+        returned: list = []
+
+        async def inner():
+            calls.append("awaited")
+
+        def sync_callback(_event):
+            coroutine = inner()
+            returned.append(coroutine)
+            return coroutine
+
+        self.TaskBroadcaster.subscribe(sync_callback)
+        try:
+            await self.TaskBroadcaster.broadcast(SampleEvent())
+            assert calls == ["awaited"]
+        finally:
+            for coroutine in returned:
+                if coroutine.cr_frame is not None:
+                    coroutine.close()
+
+    @pytest.mark.asyncio
     async def test_async_subscriber_coroutine_is_still_awaited(self):
         """Async subscriber's coroutine must still be awaited (regression safety net)."""
         results = []
@@ -316,3 +347,59 @@ class TestBroadcasterCoroutineOnlyRegression:
         await self.TaskBroadcaster.broadcast(event)
 
         assert results == ["done"], "async subscriber coroutine was not awaited"
+
+    @pytest.mark.asyncio
+    async def test_handler_cancellation_propagates_and_stops_sequential_dispatch(self):
+        later_calls: list[str] = []
+
+        def cancel(_event):
+            raise asyncio.CancelledError("subscriber cancelled")
+
+        def later(_event):  # pragma: no cover - cancellation stops the chain
+            later_calls.append("later")
+
+        self.TaskBroadcaster.subscribe(cancel)
+        self.TaskBroadcaster.subscribe(later)
+
+        with pytest.raises(asyncio.CancelledError, match="subscriber cancelled"):
+            await self.TaskBroadcaster.broadcast(SampleEvent())
+        assert later_calls == []
+
+    @pytest.mark.asyncio
+    async def test_async_handler_cancellation_propagates_and_stops_dispatch(self):
+        later_calls: list[str] = []
+
+        async def cancel(_event):
+            raise asyncio.CancelledError("async subscriber cancelled")
+
+        def later(_event):  # pragma: no cover - cancellation stops the chain
+            later_calls.append("later")
+
+        self.TaskBroadcaster.subscribe(cancel)
+        self.TaskBroadcaster.subscribe(later)
+
+        with pytest.raises(asyncio.CancelledError, match="async subscriber cancelled"):
+            await self.TaskBroadcaster.broadcast(SampleEvent())
+        assert later_calls == []
+
+    @pytest.mark.asyncio
+    async def test_emitter_cancellation_propagates_and_stops_sequential_dispatch(self):
+        started = asyncio.Event()
+        later_calls: list[str] = []
+
+        async def slow(_event):
+            started.set()
+            await asyncio.Event().wait()
+
+        def later(_event):  # pragma: no cover - cancellation stops the chain
+            later_calls.append("later")
+
+        self.TaskBroadcaster.subscribe(slow)
+        self.TaskBroadcaster.subscribe(later)
+        task = asyncio.create_task(self.TaskBroadcaster.broadcast(SampleEvent()))
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert later_calls == []

--- a/tests/session/test_session_observer.py
+++ b/tests/session/test_session_observer.py
@@ -7,8 +7,12 @@ and the observer→operation composition that makes a Session a useful orchestra
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
+from lionagi.ln.concurrency._compat import BaseExceptionGroup
+from lionagi.ln.types import Filter
 from lionagi.protocols.generic.event import Event
 from lionagi.session.session import Session
 
@@ -104,6 +108,21 @@ async def test_route_condition_stream():
     assert streamed == ["a"]
 
 
+async def test_route_failure_propagates_before_subscriber_invocation():
+    session = Session()
+    subscriber_calls: list[str] = []
+
+    def fail_route(_event):
+        raise LookupError("route failed")
+
+    session.route(fail_route, into="never")
+    session.observe(Noticed, handler=lambda _event, _session: subscriber_calls.append("called"))
+
+    with pytest.raises(LookupError, match="route failed"):
+        await session.emit(Noticed(note="route failure"))
+    assert subscriber_calls == []
+
+
 async def test_observer_triggers_operation():
     """The synthesis: an observed event drives a registered operation."""
     s = Session()
@@ -134,3 +153,150 @@ async def test_multiple_handlers_same_event():
 
     await s.emit(Noticed(note="x"))
     assert calls == ["first", "second"]
+
+
+class _TrackingAwaitable:
+    def __init__(self, events: list[str], marker: str):
+        self.events = events
+        self.marker = marker
+        self.awaited = False
+
+    def __await__(self):
+        self.awaited = True
+        self.events.append(self.marker)
+        if False:  # pragma: no cover - makes this a generator-based awaitable
+            yield None
+        return self.marker
+
+
+class _RaisingFilter(Filter):
+    def matches(self, _payload):
+        raise LookupError("filter failed")
+
+
+async def test_profile_invokes_every_handler_before_gathering_returned_awaitables():
+    s = Session()
+    events: list[str] = []
+
+    def first(_event, _session):
+        events.append("invoke-first")
+        return _TrackingAwaitable(events, "await-first")
+
+    def second(_event, _session):
+        events.append("invoke-second")
+        return "second-result"
+
+    s.observe(Noticed, handler=first)
+    s.observe(Noticed, handler=second)
+
+    assert await s.emit(Noticed(note="x")) == ["second-result", "await-first"]
+    assert events == ["invoke-first", "invoke-second", "await-first"]
+
+
+async def test_profile_filter_failure_stops_before_gather_and_leaves_prior_awaitable_unrun():
+    s = Session()
+    events: list[str] = []
+    pending = _TrackingAwaitable(events, "must-not-await")
+
+    s.observe(Noticed, handler=lambda _event, _session: pending)
+    s.observe(_RaisingFilter(), handler=lambda _event, _session: None)
+
+    with pytest.raises(LookupError, match="filter failed"):
+        await s.emit(Noticed(note="x"))
+    assert pending.awaited is False
+    assert events == []
+
+
+async def test_profile_sync_invocation_failure_stops_and_leaves_prior_awaitable_unrun():
+    session = Session()
+    events: list[str] = []
+    pending = _TrackingAwaitable(events, "must-not-await")
+    later_calls: list[str] = []
+
+    session.observe(Noticed, handler=lambda _event, _session: pending)
+
+    def fail(_event, _session):
+        raise LookupError("invocation failed")
+
+    session.observe(Noticed, handler=fail)
+    session.observe(
+        Noticed,
+        handler=lambda _event, _session: later_calls.append("later"),
+    )
+
+    with pytest.raises(LookupError, match="invocation failed"):
+        await session.emit(Noticed(note="x"))
+    assert pending.awaited is False
+    assert events == []
+    assert later_calls == []
+
+
+async def test_profile_unwraps_one_returned_awaitable_failure_and_groups_many():
+    async def runtime_failure(_event, _session):
+        raise RuntimeError("one")
+
+    one = Session()
+    one.observe(Noticed, handler=runtime_failure)
+    with pytest.raises(RuntimeError, match="one"):
+        await one.emit(Noticed(note="one"))
+
+    async def value_failure(_event, _session):
+        raise ValueError("two")
+
+    many = Session()
+    many.observe(Noticed, handler=runtime_failure)
+    many.observe(Noticed, handler=value_failure)
+    with pytest.raises(BaseExceptionGroup) as excinfo:
+        await many.emit(Noticed(note="many"))
+
+    assert sorted(type(exc).__name__ for exc in excinfo.value.exceptions) == [
+        "RuntimeError",
+        "ValueError",
+    ]
+
+
+async def test_profile_returns_handler_cancellation_and_cancelled_sibling_results():
+    s = Session()
+    sibling_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+
+    async def cancel_self(_event, _session):
+        await sibling_started.wait()
+        raise asyncio.CancelledError("handler cancelled")
+
+    async def sibling(_event, _session):
+        sibling_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            sibling_cancelled.set()
+
+    s.observe(Noticed, handler=cancel_self)
+    s.observe(Noticed, handler=sibling)
+    results = await asyncio.wait_for(s.emit(Noticed(note="cancel")), timeout=1.0)
+
+    assert len(results) == 2
+    assert all(isinstance(result, asyncio.CancelledError) for result in results)
+    assert sibling_cancelled.is_set()
+
+
+async def test_profile_emitter_cancellation_propagates_and_cleans_up_handler_work():
+    session = Session()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def slow(_event, _session):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    session.observe(Noticed, handler=slow)
+    task = asyncio.create_task(session.emit(Noticed(note="cancel emitter")))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled.is_set()

--- a/tests/state/lifecycle/test_terminal_callbacks.py
+++ b/tests/state/lifecycle/test_terminal_callbacks.py
@@ -8,6 +8,8 @@ reconciliation ledger."""
 from __future__ import annotations
 
 import asyncio
+import logging
+import threading
 import time
 import uuid
 
@@ -168,6 +170,65 @@ async def test_registry_swallows_handler_exception_and_still_runs_others():
 
 
 @pytest.mark.asyncio
+async def test_registry_logs_ordinary_handler_failure_with_event_and_entity(caplog):
+    registry = TerminalCallbackRegistry()
+
+    def _boom(_envelope):
+        raise ValueError("ordinary failure")
+
+    registry.register("boom", _boom)
+    envelope = RunTerminalEnvelope(
+        event_id="ev-log",
+        entity=EntityRef(kind="session", id="session-log"),
+        previous_status="running",
+        terminal_status="completed",
+        reason_code="run.completed.ok",
+        occurred_at=time.time(),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="lionagi.state.lifecycle.callbacks"):
+        await registry.emit(envelope)
+
+    record = next(
+        item for item in caplog.records if item.name == "lionagi.state.lifecycle.callbacks"
+    )
+    assert record.getMessage() == (
+        "terminal callback handler 'boom' raised for event ev-log (entity session/session-log)"
+    )
+    assert record.exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_registry_logs_ordinary_async_handler_failure(caplog):
+    registry = TerminalCallbackRegistry()
+
+    async def _boom(_envelope):
+        raise ValueError("ordinary async failure")
+
+    registry.register("async-boom", _boom)
+    envelope = RunTerminalEnvelope(
+        event_id="ev-async-log",
+        entity=EntityRef(kind="session", id="session-async-log"),
+        previous_status="running",
+        terminal_status="completed",
+        reason_code="run.completed.ok",
+        occurred_at=time.time(),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="lionagi.state.lifecycle.callbacks"):
+        await registry.emit(envelope)
+
+    record = next(
+        item for item in caplog.records if item.name == "lionagi.state.lifecycle.callbacks"
+    )
+    assert record.getMessage() == (
+        "terminal callback handler 'async-boom' raised for event ev-async-log "
+        "(entity session/session-async-log)"
+    )
+    assert record.exc_info is not None
+
+
+@pytest.mark.asyncio
 async def test_override_registration_replaces_matching_handler_for_its_own_scope():
     # An override registration (the flow/play `--notify` scoped sugar) must
     # win outright for any envelope it matches -- an unscoped, non-override
@@ -322,6 +383,160 @@ async def test_fast_sync_handler_still_runs_and_error_handling_is_unchanged():
     # like the existing async/sync-on-loop behavior.
     await registry.emit(envelope)
     assert ran == ["ok-sync"]
+
+
+@pytest.mark.asyncio
+async def test_sync_handler_custom_awaitable_is_awaited_after_thread_offload():
+    registry = TerminalCallbackRegistry()
+
+    class TrackingAwaitable:
+        def __init__(self):
+            self.awaited = False
+
+        def __await__(self):
+            self.awaited = True
+            if False:  # pragma: no cover - makes this a generator-based awaitable
+                yield None
+            return None
+
+    returned = TrackingAwaitable()
+    registry.register("custom-awaitable", lambda _env: returned)
+    envelope = RunTerminalEnvelope(
+        event_id="ev-custom-awaitable",
+        entity=EntityRef(kind="session", id="s"),
+        previous_status="running",
+        terminal_status="completed",
+        reason_code="run.completed.ok",
+        occurred_at=time.time(),
+    )
+
+    await registry.emit(envelope)
+
+    assert returned.awaited is True
+
+
+@pytest.mark.asyncio
+async def test_matching_handlers_start_concurrently():
+    registry = TerminalCallbackRegistry(budget_seconds=1.0)
+    started: list[str] = []
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def _handler(name: str) -> None:
+        started.append(name)
+        own = first_started if name == "first" else second_started
+        peer = second_started if name == "first" else first_started
+        own.set()
+        await peer.wait()
+
+    registry.register("first", lambda _env: _handler("first"))
+    registry.register("second", lambda _env: _handler("second"))
+
+    envelope = RunTerminalEnvelope(
+        event_id="ev-concurrent",
+        entity=EntityRef(kind="session", id="s"),
+        previous_status="running",
+        terminal_status="completed",
+        reason_code="run.completed.ok",
+        occurred_at=time.time(),
+    )
+    await asyncio.wait_for(registry.emit(envelope), timeout=2.0)
+
+    assert sorted(started) == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_handler_cancellation_is_not_logged_as_an_ordinary_failure(caplog):
+    registry = TerminalCallbackRegistry(budget_seconds=5.0)
+    sibling_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+
+    async def _cancel(_env):
+        await sibling_started.wait()
+        raise asyncio.CancelledError("handler cancelled")
+
+    async def _sibling(_env):
+        sibling_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            sibling_cancelled.set()
+
+    registry.register("cancel", _cancel)
+    registry.register("sibling", _sibling)
+
+    envelope = RunTerminalEnvelope(
+        event_id="ev-handler-cancel",
+        entity=EntityRef(kind="session", id="s"),
+        previous_status="running",
+        terminal_status="completed",
+        reason_code="run.completed.ok",
+        occurred_at=time.time(),
+    )
+    await asyncio.wait_for(registry.emit(envelope), timeout=1.0)
+
+    assert sibling_cancelled.is_set()
+    assert "terminal callback handler" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_emitter_cancellation_propagates_and_cancels_handler_work():
+    registry = TerminalCallbackRegistry()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _slow(_env):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    registry.register("slow", _slow)
+    envelope = RunTerminalEnvelope(
+        event_id="ev-emitter-cancel",
+        entity=EntityRef(kind="session", id="s"),
+        previous_status="running",
+        terminal_status="completed",
+        reason_code="run.completed.ok",
+        occurred_at=time.time(),
+    )
+    task = asyncio.create_task(registry.emit(envelope))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_budget_return_leaves_abandoned_sync_offload_outcome_unknown():
+    registry = TerminalCallbackRegistry(budget_seconds=0.5)
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def _blocking(_env):
+        started.set()
+        release.wait(timeout=2.0)
+        finished.set()
+
+    registry.register("blocking", _blocking)
+    envelope = RunTerminalEnvelope(
+        event_id="ev-abandoned-sync",
+        entity=EntityRef(kind="session", id="s"),
+        previous_status="running",
+        terminal_status="completed",
+        reason_code="run.completed.ok",
+        occurred_at=time.time(),
+    )
+    await registry.emit(envelope)
+
+    assert started.is_set()
+    assert not finished.is_set()
+    release.set()
+    assert await asyncio.to_thread(finished.wait, 1.0)
 
 
 # Lifecycle-service integration (D1 hook point)

--- a/tests/studio/test_scheduler_signals.py
+++ b/tests/studio/test_scheduler_signals.py
@@ -17,6 +17,7 @@ import pytest
 
 from lionagi.state.reasons import RunReasons
 from lionagi.studio.scheduler.signals import (
+    SchedulerHandlerCancelled,
     SchedulerSignalBus,
     ScheduleRunCancelled,
     ScheduleRunFailed,
@@ -145,6 +146,90 @@ async def test_bus_sync_and_async_handlers_both_run():
 
     assert sync_calls == [sig]
     assert async_calls == [sig]
+
+
+@pytest.mark.asyncio
+async def test_bus_starts_matching_handlers_concurrently_and_keeps_registration_order():
+    bus = SchedulerSignalBus()
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def first(_signal):
+        first_started.set()
+        await second_started.wait()
+        return "first"
+
+    async def second(_signal):
+        second_started.set()
+        await first_started.wait()
+        return "second"
+
+    bus.observe(ScheduleRunSucceeded, handler=first)
+    bus.observe(ScheduleRunSucceeded, handler=second)
+    signal = ScheduleRunSucceeded(
+        run_id="r-concurrent",
+        schedule_id="s1",
+        reason_code=RunReasons.COMPLETED_OK,
+    )
+
+    results = await asyncio.wait_for(bus.emit(signal), timeout=1.0)
+
+    assert first_started.is_set()
+    assert second_started.is_set()
+    assert results == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_bus_awaits_custom_awaitable_returned_by_sync_handler():
+    bus = SchedulerSignalBus()
+
+    class TrackingAwaitable:
+        def __init__(self):
+            self.awaited = False
+
+        def __await__(self):
+            self.awaited = True
+            if False:  # pragma: no cover - makes this a generator-based awaitable
+                yield None
+            return "awaited"
+
+    returned = TrackingAwaitable()
+    bus.observe(ScheduleRunSucceeded, handler=lambda _signal: returned)
+    signal = ScheduleRunSucceeded(
+        run_id="r-awaitable",
+        schedule_id="s1",
+        reason_code=RunReasons.COMPLETED_OK,
+    )
+
+    assert await bus.emit(signal) == ["awaited"]
+    assert returned.awaited is True
+
+
+@pytest.mark.asyncio
+async def test_bus_groups_failure_raised_by_returned_custom_awaitable():
+    from lionagi.ln.concurrency import ExceptionGroup
+
+    bus = SchedulerSignalBus()
+
+    class FailingAwaitable:
+        def __await__(self):
+            if False:  # pragma: no cover - makes this a generator-based awaitable
+                yield None
+            raise RuntimeError("returned awaitable failed")
+
+    bus.observe(ScheduleRunSucceeded, handler=lambda _signal: FailingAwaitable())
+    signal = ScheduleRunSucceeded(
+        run_id="r-failing-awaitable",
+        schedule_id="s1",
+        reason_code=RunReasons.COMPLETED_OK,
+    )
+
+    with pytest.raises(ExceptionGroup) as excinfo:
+        await bus.emit(signal)
+
+    assert len(excinfo.value.exceptions) == 1
+    assert type(excinfo.value.exceptions[0]) is RuntimeError
+    assert str(excinfo.value.exceptions[0]) == "returned awaitable failed"
 
 
 def test_bus_has_no_topic_or_route_stream_machinery():
@@ -453,8 +538,8 @@ async def test_emit_predicate_exception_does_not_abort_sibling_dispatch():
 async def test_emit_reraises_cancellation_without_nesting_baseexception():
     """gather(return_exceptions=True) can return a raw CancelledError.
     Folding that into ExceptionGroup would raise TypeError ("cannot nest
-    BaseExceptions") -- cancellation must propagate as itself instead of
-    being wrapped or swallowed, and sibling handlers must still run."""
+    BaseExceptions") -- handler cancellation must become the named scheduler
+    cancellation rather than an ordinary failure, and siblings still run."""
     bus = SchedulerSignalBus()
     ran: list = []
 
@@ -468,7 +553,7 @@ async def test_emit_reraises_cancellation_without_nesting_baseexception():
     bus.observe(ScheduleRunSucceeded, handler=_good)
 
     sig = ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(SchedulerHandlerCancelled):
         await bus.emit(sig)
 
     assert ran == [sig]
@@ -478,8 +563,8 @@ async def test_emit_reraises_cancellation_without_nesting_baseexception():
 async def test_emit_reraises_cancellation_even_with_other_handler_failures():
     """A genuine handler bug alongside a cancellation must not turn into a
     TypeError from ExceptionGroup nesting a BaseException -- cancellation
-    still wins and propagates, with the handler failure chained for
-    visibility rather than silently dropped."""
+    still wins as the named scheduler cancellation, with the handler failure
+    chained for visibility rather than silently dropped."""
     from lionagi.ln.concurrency import ExceptionGroup
 
     bus = SchedulerSignalBus()
@@ -494,7 +579,7 @@ async def test_emit_reraises_cancellation_even_with_other_handler_failures():
     bus.observe(ScheduleRunSucceeded, handler=_boom)
 
     sig = ScheduleRunSucceeded(run_id="r1", schedule_id="s1", reason_code=RunReasons.COMPLETED_OK)
-    with pytest.raises(asyncio.CancelledError) as exc_info:
+    with pytest.raises(SchedulerHandlerCancelled) as exc_info:
         await bus.emit(sig)
 
     assert isinstance(exc_info.value.__cause__, ExceptionGroup)


### PR DESCRIPTION
## Summary

- freeze all eight pre-migration dispatcher profiles from ADR-0120 without changing production code
- characterize ordering, classification, returned-awaitable behavior, stop/deny/replace semantics, one-vs-group failures, handler/emitter cancellation, deadlines, completion signaling, and persistence/SSE projection
- make the ADR table itself a closed, mutation-sensitive contract and record Phase 0 as implemented

## Regression guards

- every previously surviving cancellation, logging, raise/drain, concurrency, awaitable-classification, and completion-event mutation now has a targeted RED gate
- async waits on cancellation and SSE paths are bounded so a behavior mismatch fails promptly instead of consuming the suite timeout
- production module hashes were restored exactly after mutation proofs; this PR changes tests/docs/changelog only

## Validation

- 368 focused tests passed serially (two pre-existing slow-timing cases deselected)
- Python 3.10 and 3.14 focused suites passed
- HookSignal persistence/SSE contract passed with the Studio extra
- Ruff check/format, markdown pre-commit hooks, and git diff check passed
- independent review: APPROVE, no P0/P1/P2

Closes #3263