### PR TITLE
fix(state): fail closed on column inspection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   on POSIX. Cross-platform descendant containment remains out of scope and is
   tracked in #2576.
 
+### Fixed
+
+- Writable StateDB migration now fails closed when a table's columns cannot be
+  inspected, preserving the prior schema-version stamp instead of recording an
+  upgrade whose additive column reconciliation did not complete.
+
 ### Deprecated
 
 - `--resume-on-timeout` on `li o fanout` and `li o flow`. The flag is accepted

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -1042,8 +1042,14 @@ class StateDB:
                     existing = await conn.run_sync(
                         lambda c, t=table: [col["name"] for col in inspect(c).get_columns(t)]
                     )
-            except Exception:  # noqa: BLE001, S112
-                continue
+            except Exception as exc:  # noqa: BLE001
+                _log.error(
+                    "failed to inspect migration columns for table %r: %r",
+                    table,
+                    exc,
+                    exc_info=True,
+                )
+                raise
             for name, defn in columns:
                 if name not in existing:
                     add_column = f"ALTER TABLE {table} ADD COLUMN {name} {defn}"

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -408,6 +408,72 @@ async def test_open_upgrades_an_older_recorded_schema_version(tmp_path):
     assert _read_version(path) == SCHEMA_VERSION
 
 
+async def test_column_inspection_failure_does_not_advance_schema_version(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    import logging
+
+    import lionagi.state.db as db_mod
+
+    path = tmp_path / "inspection_failure.db"
+    async with StateDB(path=path):
+        pass
+    _stamp_version(path, "1")
+
+    real_inspect = db_mod.inspect
+    failure = RuntimeError("column inspection failed")
+    failed = False
+
+    class FailingInspector:
+        def __init__(self, inspector):
+            self._inspector = inspector
+
+        def has_table(self, name):
+            return self._inspector.has_table(name)
+
+        def get_columns(self, name):
+            nonlocal failed
+            if name == "sessions" and not failed:
+                failed = True
+                raise failure
+            return self._inspector.get_columns(name)
+
+    def inspect_once(bind):
+        inspector = real_inspect(bind)
+        return inspector if failed else FailingInspector(inspector)
+
+    monkeypatch.setattr(db_mod, "inspect", inspect_once)
+    state = StateDB(path=path)
+    state._MIGRATION_COLUMNS = {"sessions": [("inspection_probe", "TEXT")]}
+
+    with caplog.at_level(logging.ERROR, logger="lionagi.state.db"):
+        with pytest.raises(RuntimeError, match="column inspection failed") as excinfo:
+            async with state:
+                pass
+
+    assert excinfo.value is failure
+    assert failed is True
+    assert _read_version(path) == "1"
+    assert state._engine is None
+    records = [item for item in caplog.records if item.name == "lionagi.state.db"]
+    assert len(records) == 1
+    record = records[0]
+    assert record.getMessage() == (
+        "failed to inspect migration columns for table 'sessions': "
+        "RuntimeError('column inspection failed')"
+    )
+    assert record.exc_info is not None
+
+    await state.open()
+    try:
+        assert await state.schema_version() == SCHEMA_VERSION
+    finally:
+        await state.close()
+    assert _read_version(path) == SCHEMA_VERSION
+
+
 async def test_open_refuses_a_newer_recorded_schema_version(tmp_path):
     """A database stamped above SCHEMA_VERSION is refused, not downgraded.
 


### PR DESCRIPTION
## Summary

- stop writable schema migration immediately when live column inspection fails
- log the exact table and original exception with traceback, then re-raise the same exception object
- preserve the prior schema-version stamp so the next open retries the idempotent reconciliation instead of trusting an incomplete upgrade

## Compatibility

- absent tables remain a legitimate skip
- read-only opens are unchanged
- cancellation and the proven SQLite concurrent-ALTER winner path are unchanged
- no schema/version bump, transaction-boundary rewrite, or new public exception type

## Regression proof

The new SQLite fixture injects one get_columns(sessions) failure and proves:

- the exact exception object escapes
- the old version stamp remains 1
- exactly one diagnostic with traceback is recorded
- context-managed failure disposes the engine
- a retry succeeds and only then advances the stamp

## Validation

- 135 StateDB, migration, and rebuild-concurrency tests passed
- targeted multi-process reconciliation races passed
- Python 3.10 and 3.14 regression passed
- Ruff check/format, pre-commit hooks, and git diff check passed
- independent review: APPROVE, no P0/P1/P2

Closes #3206