### PR TITLE
test: trim the first exact-duplicate assertion batch

### DIFF
--- a/tests/libs/test_to_list.py
+++ b/tests/libs/test_to_list.py
@@ -316,13 +316,6 @@ class TestToListCombinations:
         result = to_list(data, flatten=True, dropna=True, unique=True)
         assert result == [1, 2, 3, 4]
 
-    def test_use_values_with_dict(self):
-        # use_values works on the top-level input, not nested dicts in a list
-        # When top-level is a dict with use_values=True, extract values
-        d = {"a": 1, "b": 2, "c": 3}
-        result = to_list(d, use_values=True)
-        assert set(result) == {1, 2, 3}
-
     def test_complex_nested_structure(self):
         data = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
         result = to_list(data, flatten=True)

--- a/tests/protocols/messages/test_instruction.py
+++ b/tests/protocols/messages/test_instruction.py
@@ -295,15 +295,6 @@ def test_from_dict_response_format_overrides_auto_derive():
     assert content.response_format == rf  # Should use explicit, not auto-derived
 
 
-def test_from_dict_invalid_response_schema_type():
-    """from_dict silently ignores invalid response_format type (fuzzy handling)"""
-    data = {"instruction": "Test", "response_format": "invalid"}
-
-    # Fuzzy handling: invalid types are silently ignored
-    content = InstructionContent.from_dict(data)
-    assert content.response_format is None
-
-
 def test_from_dict_invalid_response_format_type():
     """from_dict silently ignores invalid response_format type (fuzzy handling)"""
     data = {"instruction": "Test", "response_format": "invalid"}

--- a/tests/protocols/messages/test_message.py
+++ b/tests/protocols/messages/test_message.py
@@ -233,19 +233,6 @@ def test_roled_message_sender_recipient_validation():
     assert message.recipient == MessageRole.ASSISTANT
 
 
-def test_roled_message_sender_recipient_string():
-    """Sender and recipient with string values."""
-    message = _MockMessage(
-        role=MessageRole.USER,
-        content=_MockContent(text="test"),
-        sender="user",
-        recipient="assistant",
-    )
-
-    assert message.sender == MessageRole.USER
-    assert message.recipient == MessageRole.ASSISTANT
-
-
 def test_roled_message_sender_recipient_none():
     """Sender and recipient with None values."""
     message = _MockMessage(

--- a/tests/service/test_token_budget.py
+++ b/tests/service/test_token_budget.py
@@ -97,10 +97,6 @@ class TestTokenBudgetBoundaries:
         budget = TokenBudget(used=70, limit=100)
         assert budget.is_warning is True
 
-    def test_is_warning_false_at_69_pct(self):
-        budget = TokenBudget(used=69, limit=100)
-        assert budget.is_warning is False
-
     def test_remaining_exactly_at_limit(self):
         budget = TokenBudget(used=100, limit=100)
         assert budget.remaining == 0

--- a/tests/session/test_branch_actionmanager_coverage.py
+++ b/tests/session/test_branch_actionmanager_coverage.py
@@ -98,12 +98,6 @@ class TestBranchMessageCount:
     def test_empty_branch_message_count(self, plain_branch):
         assert len(plain_branch.messages) == 0
 
-    def test_system_branch_message_count(self, system_branch):
-        assert len(system_branch.messages) == 1
-
-    def test_messages_pile_has_correct_length(self, system_branch):
-        assert len(system_branch.messages) == 1
-
 
 class TestBranchMessages:
     def test_messages_is_iterable(self, system_branch):


### PR DESCRIPTION
## Summary

- remove six exact duplicate test functions across five focused suites
- retain the clearer representative for each production behavior
- reduce the suite by 39 lines without changing production code or public behavior

This is the first deliberately small deletion batch from #3086. The parent issue remains open for the remaining independently reviewable groups.

## Regression evidence

- `scripts/ci.sh test-python -n 0 tests/session/test_branch_actionmanager_coverage.py tests/libs/test_to_list.py tests/protocols/messages/test_instruction.py tests/protocols/messages/test_message.py tests/service/test_token_budget.py` — 262 passed
- targeted Ruff format/check and `git diff --check` — passed
- mutation: changed the token warning boundary from `>= 0.7` to `> 0.7`; the retained exact-70% boundary test failed, then passed again after exact restoration
- commit hooks — passed

## Review note

Please keep this as a narrow test-deletion PR. Claude will perform additional review passes on the Draft; follow-up duplicate groups will be submitted separately rather than expanding this diff.