### PR TITLE
test: remove setup-only tool assertions

### DIFF
--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -14,21 +14,10 @@ from lionagi.protocols.action.tool import Tool
 from lionagi.tools.code.bash import BashRequest, BashResponse, BashTool
 
 
-def test_bash_request_required_command():
-    req = BashRequest(command="echo hi")
-    assert req.command == "echo hi"
-
-
 def test_bash_request_defaults():
     req = BashRequest(command="ls")
     assert req.timeout is None
     assert req.cwd is None
-
-
-def test_bash_request_custom_fields():
-    req = BashRequest(command="pwd", timeout=5000, cwd="/tmp")
-    assert req.timeout == 5000
-    assert req.cwd == "/tmp"
 
 
 def test_bash_request_allow_shell_kwarg_raises_validation_error():
@@ -46,14 +35,6 @@ def test_bash_response_defaults():
     assert resp.stdout == ""
     assert resp.stderr == ""
     assert resp.timed_out is False
-
-
-def test_bash_response_fields():
-    resp = BashResponse(stdout="out", stderr="err", return_code=1, timed_out=True)
-    assert resp.stdout == "out"
-    assert resp.stderr == "err"
-    assert resp.return_code == 1
-    assert resp.timed_out is True
 
 
 async def test_handle_request_echo_returns_stdout():

--- a/tests/tools/test_messenger.py
+++ b/tests/tools/test_messenger.py
@@ -60,6 +60,11 @@ class TestMessengerRequestModel:
         assert req.to is None
         assert req.content is None
 
+    def test_to_accepts_one_recipient_or_many(self):
+        """Both shapes are advertised in the tool schema, so both must load."""
+        assert MessengerRequest(action="send", to="alice").to == "alice"
+        assert MessengerRequest(action="send", to=["alice", "bob"]).to == ["alice", "bob"]
+
 
 class TestLionMessengerBasics:
     def test_is_system_tool(self):

--- a/tests/tools/test_messenger.py
+++ b/tests/tools/test_messenger.py
@@ -60,15 +60,6 @@ class TestMessengerRequestModel:
         assert req.to is None
         assert req.content is None
 
-    def test_send_request(self):
-        req = MessengerRequest(action="send", to="alice", content="hi")
-        assert req.to == "alice"
-        assert req.content == "hi"
-
-    def test_send_request_list_to(self):
-        req = MessengerRequest(action="send", to=["alice", "bob"], content="hi")
-        assert req.to == ["alice", "bob"]
-
 
 class TestLionMessengerBasics:
     def test_is_system_tool(self):

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -53,17 +53,6 @@ def test_sandbox_session_fields():
     assert s.is_active is True
 
 
-def test_sandbox_session_is_active_false():
-    s = SandboxSession(
-        worktree_path="/tmp/wt",
-        branch_name="b",
-        base_branch="main",
-        repo_root="/tmp/r",
-        is_active=False,
-    )
-    assert s.is_active is False
-
-
 def test_sandbox_session_base_sha_defaults_empty():
     """base_sha is additive — old call sites that don't pass it still work."""
     s = SandboxSession(

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -24,28 +24,11 @@ def test_search_action_find_value():
     assert SearchAction.find.value == "find"
 
 
-def test_search_request_required_fields():
-    req = SearchRequest(action=SearchAction.grep, pattern="foo")
-    assert req.action == SearchAction.grep
-    assert req.pattern == "foo"
-
-
 def test_search_request_defaults():
     req = SearchRequest(action=SearchAction.grep, pattern="x")
     assert req.path == "."
     assert req.max_results == 50
     assert req.include is None
-
-
-def test_search_request_custom_fields():
-    req = SearchRequest(
-        action=SearchAction.find,
-        pattern="*.py",
-        path="/tmp",
-        max_results=10,
-    )
-    assert req.path == "/tmp"
-    assert req.max_results == 10
 
 
 def test_search_request_accepts_explicit_null():


### PR DESCRIPTION
## Summary

- remove eight tests that only read back constructor inputs they just supplied
- retain default/coercion/error tests and end-to-end tool behavior tests
- reduce four tool suites by 56 lines with no production or public-surface change

This is the first narrow cleanup batch from #3087. The issue remains open for the endpoint patch-through tests, logging assertions, and the communicate test that should be strengthened rather than simply deleted.

## Regression evidence

- `scripts/ci.sh test-python -n 0 tests/tools/test_bash.py tests/tools/test_search.py tests/tools/test_sandbox.py tests/tools/test_messenger.py` — 146 passed
- targeted Ruff format/check and `git diff --check` — passed
- mutation: replaced Bash subprocess stdout projection with an empty string; the retained real echo behavior test failed, then passed after exact source restoration
- commit hooks — passed

## Review note

Please keep this PR deletion-only and narrow. Claude will perform additional review passes on the Draft; the remaining #3087 groups will be submitted separately.