### PR TITLE
test: remove duplicate graph guards

### DIFF
--- a/tests/protocols/graph/test_graph_basic.py
+++ b/tests/protocols/graph/test_graph_basic.py
@@ -55,11 +55,6 @@ def complex_graph():
 class TestGraphBasics:
     """Basic graph operations"""
 
-    def test_empty_graph_creation(self, empty_graph):
-        assert len(empty_graph.internal_nodes) == 0
-        assert len(empty_graph.internal_edges) == 0
-        assert isinstance(empty_graph.node_edge_mapping, dict)
-
     def test_add_node(self, empty_graph):
         node = create_test_node("TestNode")
         empty_graph.add_node(node)
@@ -68,10 +63,6 @@ class TestGraphBasics:
             "in": {},
             "out": {},
         }
-
-    def test_add_invalid_node(self, empty_graph):
-        with pytest.raises(RelationError):
-            empty_graph.add_node("not a node")
 
     def test_add_relational_non_node(self, empty_graph):
         with pytest.raises(RelationError):
@@ -88,10 +79,6 @@ class TestGraphBasics:
         assert edge.id in graph.internal_edges
         assert graph.node_edge_mapping[node1.id]["out"][edge.id] == node2.id
         assert graph.node_edge_mapping[node2.id]["in"][edge.id] == node1.id
-
-    def test_add_invalid_edge(self, empty_graph):
-        with pytest.raises(RelationError):
-            empty_graph.add_edge("not an edge")
 
     def test_add_edge_missing_nodes(self, empty_graph):
         node1 = create_test_node("Node1")


### PR DESCRIPTION
## Summary

- remove three graph tests duplicated in the canonical graph suite
- keep the stronger surviving add-node/add-edge guards and all non-overlapping basic coverage
- reduce the suite by 13 lines without changing production code or behavior

This is a separate high-confidence group from #3086; the parent issue remains open. Two independent inventory passes identified these same three pairs.

## Regression evidence

- `tests/protocols/graph/test_graph_basic.py tests/protocols/graph/test_graph.py` — 38 passed after deletion
- targeted Ruff format/check and `git diff --check` — passed
- mutation: changed invalid-node admission from raising `RelationError` to returning silently; the retained canonical guard failed, then passed after exact source restoration
- production `graph.py` SHA-256 matched before/after mutation
- commit hooks — passed

The normal project runner could not initialize this fresh worktree because PyPI DNS was unavailable, so the focused tests and Ruff checks ran with the already-built project virtualenv plus this worktree on `PYTHONPATH`. Claude will run additional review/CI passes on the Draft.