### PR TITLE
test: trim repeated same-path assertions

### DIFF
--- a/tests/casts/test_emission_security.py
+++ b/tests/casts/test_emission_security.py
@@ -54,12 +54,6 @@ class TestSpawnRequestOperationAllowlist:
         with pytest.raises(ValidationError):
             SpawnRequest.model_validate({"instruction": "x", "operation": "not_registered"})
 
-    def test_operation_none_falls_back_to_default(self):
-        """Explicit None uses the field default ('operate')."""
-        # None is not in the Literal, so it gets the default
-        req = SpawnRequest(instruction="x")
-        assert req.operation == "operate"
-
 
 class TestEmissionModelExtraForbid:
     """Emission models reject unknown keys via extra='forbid'."""

--- a/tests/cli/test_heartbeat.py
+++ b/tests/cli/test_heartbeat.py
@@ -93,20 +93,6 @@ async def test_heartbeat_skips_completed_ops():
     assert emitted == []
 
 
-def test_elapsed_threshold_requires_descendant_activity_signal():
-    now = time.time()
-    warning = flow_mod._heartbeat_warning(
-        _running_segment(now, 601),
-        now=now,
-        max_idle_seconds=600,
-        sample_interval_seconds=60,
-        previous=({41: 8.0}, True),
-        current=({41: 8.2}, True),
-    )
-
-    assert warning is None
-
-
 def _running_segment(now: float, age: float) -> dict:
     return {
         "branch_name": "worker",

--- a/tests/libs/fuzzy/test_fuzzy_json.py
+++ b/tests/libs/fuzzy/test_fuzzy_json.py
@@ -240,12 +240,6 @@ def test_fuzzy_json_max_size_enforcement():
         fuzzy_json('{"key": "value"}', max_size=5)
 
 
-def test_fuzzy_json_max_size_default_accepts_normal():
-    """Test fuzzy_json accepts normal-sized input with default max_size"""
-    result = fuzzy_json('{"key": "value"}')
-    assert result == {"key": "value"}
-
-
 def test_validate_return_type_dict():
     """Test _validate_return_type accepts dict"""
     result = _validate_return_type({"key": "value"})


### PR DESCRIPTION
## Summary

- remove three same-path duplicate tests: SpawnRequest default operation, busy-descendant heartbeat suppression, and normal fuzzy JSON parsing
- retain the clearer canonical test for each behavior
- reduce three suites by 26 lines without production or public-surface changes

This is another intentionally small group from #3086; the parent issue remains open.

## Regression evidence

- full touched suites — 97 passed (the heartbeat suite required loopback permission outside the restricted sandbox)
- retained representative nodeids — 3 passed after exact production-source restoration
- targeted Ruff format/check and `git diff --check` — passed
- mutation: replaced the direct fuzzy-JSON parse result with an empty mapping; the retained valid-JSON test failed, then passed after exact restoration
- production `_fuzzy_json.py` SHA-256 matched before/after mutation
- commit hooks — passed

The duplicate `flow_yaml` Studio launch test was deliberately left out because the current local environment did not have the Studio extra; it can land in a later independently validated batch. Claude will perform additional review passes on this Draft.