### PR TITLE
test: deduplicate artifact verifier cases

### DIFF
--- a/tests/state/test_artifact_verifier.py
+++ b/tests/state/test_artifact_verifier.py
@@ -30,17 +30,9 @@ class TestSafeJoin:
         result = _safe_join(str(tmp_path), "subdir/file.txt")
         assert result.startswith(os.path.realpath(str(tmp_path)))
 
-    def test_absolute_path_rejected(self, tmp_path):
-        with pytest.raises(ArtifactPathError, match="absolute path not allowed"):
-            _safe_join(str(tmp_path), "/etc/passwd")
-
     def test_dotdot_rejected(self, tmp_path):
         with pytest.raises(ArtifactPathError, match="segments not allowed"):
             _safe_join(str(tmp_path), "../escape.txt")
-
-    def test_glob_star_rejected(self, tmp_path):
-        with pytest.raises(ArtifactPathError, match="glob characters"):
-            _safe_join(str(tmp_path), "*.md")
 
     def test_glob_question_rejected(self, tmp_path):
         with pytest.raises(ArtifactPathError, match="glob characters"):
@@ -61,9 +53,6 @@ class TestSafeJoin:
 class TestValidateArtifactContract:
     def test_none_is_valid(self):
         validate_artifact_contract(None)
-
-    def test_valid_contract(self):
-        validate_artifact_contract({"expected": [{"id": "report", "path": "report.md"}]})
 
     def test_missing_expected_list(self):
         with pytest.raises(ArtifactPathError, match="expected: list"):
@@ -88,10 +77,6 @@ class TestValidateArtifactContract:
         with pytest.raises(ArtifactPathError, match="alphanumeric"):
             validate_artifact_contract({"expected": [{"id": "bad id", "path": "x.md"}]})
 
-    def test_absolute_path_rejected_via_validate(self):
-        with pytest.raises(ArtifactPathError, match="absolute path not allowed"):
-            validate_artifact_contract({"expected": [{"id": "x", "path": "/etc/passwd"}]})
-
     def test_required_must_be_bool(self):
         with pytest.raises(ArtifactPathError, match="required must be a bool"):
             validate_artifact_contract(
@@ -106,9 +91,6 @@ class TestValidateArtifactContract:
 
 
 class TestResolveArtifactContract:
-    def test_both_none_returns_none(self):
-        assert resolve_artifact_contract(playbook_artifacts=None, agent_defaults=None) is None
-
     def test_agent_defaults_only(self):
         result = resolve_artifact_contract(
             playbook_artifacts=None,
@@ -149,9 +131,6 @@ class TestResolveArtifactContract:
 
 
 class TestVerifyArtifactContract:
-    def test_none_contract_returns_none(self):
-        assert verify_artifact_contract(None, artifacts_root="/tmp") is None
-
     def test_missing_root_dir_fails(self):
         contract = {"expected": [{"id": "report", "path": "report.md"}]}
         result = verify_artifact_contract(contract, artifacts_root="/nonexistent_root_abc")


### PR DESCRIPTION
## Summary

- remove six class-method tests duplicated by the ADR-0064 canonical-name block in the same file
- retain the canonical module-level names and all non-overlapping artifact-verifier coverage
- reduce the suite by 21 lines without production or public-behavior changes

This is the independently audited artifact-verifier group from #3086; the parent issue remains open. Each deleted/surviving pair has the same fixture/decorator/call path and identical normalized AST body.

## Regression evidence

- `tests/state/test_artifact_verifier.py` — 65 passed after deletion
- six exact canonical survivors — passed
- targeted Ruff format/check and `git diff --check` — passed
- mutation: removed the absolute-path discriminator from `_safe_join`; the two canonical absolute-path guards failed with the changed diagnostic while the other four survivors passed, then all passed after exact restoration
- production `artifact_verifier.py` SHA-256 matched before/after mutation
- commit hooks — passed

Claude will perform additional review passes on this Draft.