### PR TITLE
fix(engines): isolate transport failures in the verifier stages too

### DIFF
--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -390,6 +390,22 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
     if _emission_failures:
         emission_error = "emission_missing: " + "; ".join(_emission_failures)
 
+    # A degraded run reached a result without all of its work. The engine says
+    # so on the result object, and nothing downstream was reading it: the row
+    # persisted as "completed" with no trace of what was skipped, which is the
+    # same shape as a run that did everything. Joined to the same field the
+    # emission diagnostics use, which already carries this kind of non-fatal
+    # detail on a completed row.
+    _degraded: bool = bool(getattr(result, "degraded", False))
+    _degrade_reason: str = str(getattr(result, "degrade_reason", "") or "")
+    _skipped: list[str] = list(getattr(result, "skipped", []) or [])
+    if _degraded:
+        degraded_text = "degraded: " + (_degrade_reason or "reason not recorded")
+        if _skipped:
+            degraded_text += f" (skipped: {', '.join(_skipped)})"
+        emission_error = f"{emission_error}; {degraded_text}" if emission_error else degraded_text
+        warn(degraded_text)
+
     # Every agent terminally erroring must not report "completed" as green.
     _total_agent_failure: bool = getattr(engine, "_total_agent_failure", False)
     if _total_agent_failure:
@@ -409,7 +425,16 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
             _rd_export = result_data.get("export_dir")
             export_dir_for_db = _rd_export if _rd_export is not None else export_dir_from_args
         elif isinstance(result, str):
-            result_data = {"result": result}
+            # EngineResult subclasses str to stay back-compatible, so it lands
+            # here and the plain-string shape would carry only the text. A
+            # consumer reading the JSON could not then tell a run that did all
+            # its work from one that skipped a dimension, which is the whole
+            # thing the caller needs in order to decide whether to trust it.
+            result_data = {"result": str(result)}
+            if _degraded:
+                result_data["degraded"] = True
+                result_data["degrade_reason"] = _degrade_reason
+                result_data["skipped"] = _skipped
         else:
             result_data = {"result": str(result)}
         print(json.dumps(result_data, ensure_ascii=False, indent=2))

--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -300,6 +300,11 @@ class EngineRun:
         self.agents_made: int = 0
         self._sem = Semaphore(engine.max_concurrent)
         self._active: set[asyncio.Task] = set()
+        # Failures of spawned tasks, recorded as each one settles. The drain
+        # cannot be the only collector: a task that finishes before the drain
+        # starts is already out of _active by then, and its failure would have
+        # nowhere to be seen.
+        self._settled_errors: list[BaseException] = []
         self._pending: deque = deque()
         self._seen: set[str] = set()
         self._t0 = monotonic()
@@ -531,15 +536,37 @@ class EngineRun:
             self._pending.append(coro)
             return None
         self._active.add(task)
-        task.add_done_callback(self._active.discard)
+        task.add_done_callback(self._task_settled)
         return task
+
+    def _task_settled(self, task: asyncio.Task) -> None:
+        """Take a finished spawned task off the active set, keeping its failure.
+
+        Discarding alone loses the failure of anything that finishes before the
+        drain runs, and that is not the rare case: a refusal the provider issues
+        without doing any work -- a bad key, an unsupported model -- arrives
+        almost immediately, so the failures most certain to describe the whole
+        run are the ones most certain to be gone before anyone looks. The drain
+        then finds an empty set and the run reaches a verdict as though nothing
+        had failed.
+
+        Reading ``exception()`` here is also what marks the failure retrieved,
+        so a real defect stops surfacing as an unretrieved-task warning from the
+        event loop long after the run reported success.
+        """
+        self._active.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            self._settled_errors.append(exc)
 
     def drain_pending(self) -> None:
         while self._pending:
             coro = self._pending.popleft()
             task = asyncio.ensure_future(coro)
             self._active.add(task)
-            task.add_done_callback(self._active.discard)
+            task.add_done_callback(self._task_settled)
 
     async def cancel_active(self) -> None:
         """Cancel and await all in-flight spawned tasks; tasks that don't settle
@@ -582,15 +609,23 @@ class EngineRun:
     async def wait_quiescence(self) -> None:
         """Block until all spawned tasks settle; re-raise non-cancellation, non-budget
         failures. EngineBudgetError is benign (discretionary work declined) and swallowed."""
-        task_errors: list[BaseException] = []
         while self._active:
-            results = await gather(*list(self._active), return_exceptions=True)
-            task_errors.extend(
-                r
-                for r in results
-                if isinstance(r, BaseException)
-                and not isinstance(r, asyncio.CancelledError | EngineBudgetError)
-            )
+            await gather(*list(self._active), return_exceptions=True)
+            # Completion schedules the done callbacks rather than running them,
+            # so yield once and let the tasks just awaited record themselves
+            # before the set is re-tested.
+            await asyncio.sleep(0)
+
+        # Every spawned task records its own failure as it settles, whether that
+        # happened during this drain or before it started. Collecting from one
+        # place is what makes the two cases indistinguishable here, which is the
+        # point: the drain should not be able to see one and miss the other.
+        task_errors = [
+            exc
+            for exc in self._settled_errors
+            if not isinstance(exc, asyncio.CancelledError | EngineBudgetError)
+        ]
+        self._settled_errors.clear()
         if task_errors:
             for exc in task_errors:
                 logger.error("engine spawned task failed: %s", exc)

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -19,7 +19,13 @@ from lionagi.ln.concurrency._compat import (
     get_exception_group_exceptions,
     is_exception_group,
 )
-from lionagi.providers._provider_errors import ProviderError
+from lionagi.providers._provider_errors import (
+    ProviderAuthError,
+    ProviderError,
+    ProviderQuotaError,
+    ProviderSafetyError,
+    ProviderUnsupportedModelError,
+)
 
 from .engine import Engine, EngineEvent, EngineRun
 
@@ -49,6 +55,27 @@ _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
 )
 
 _ISOLATED_ERRORS: tuple[type[BaseException], ...] = (ProviderError, *_TRANSPORT_ERRORS)
+
+# Refusals that describe the run rather than one attempt. The credentials, the
+# quota, the model and the safety policy are the same for every dimension, so a
+# refusal on any of those grounds recurs identically on the next dimension and
+# on any retry. They are ProviderError subclasses, so the isolated set above
+# already covers them, and covering them is wrong: isolating one records a
+# skipped dimension and lets the run reach a verdict, which turns a run-wide
+# misconfiguration into a quietly degraded pass over an artifact whose
+# dimensions were never actually read. A safety refusal is the sharpest case,
+# because the reason the content was not reviewed is the finding.
+#
+# Context overflow is deliberately not here. That is a property of the single
+# prompt that overflowed rather than of the run -- one verifier's oversized
+# prompt says nothing about the next one's, which is why the engine repairs it
+# instead of failing.
+_RUN_WIDE_REFUSALS: tuple[type[BaseException], ...] = (
+    ProviderAuthError,
+    ProviderQuotaError,
+    ProviderSafetyError,
+    ProviderUnsupportedModelError,
+)
 
 
 @lru_cache(maxsize=1)
@@ -156,6 +183,11 @@ def _is_transport_mcp_error(exc: BaseException) -> bool:
 
 def _is_all_isolated_failure(exc: BaseException) -> bool:
     """True iff every leaf is a per-dimension provider/transport failure, recursing into nested groups."""
+    if isinstance(exc, _RUN_WIDE_REFUSALS):
+        # Asked before the isolated set, not after. These derive from
+        # ProviderError, so the wider test answers True for all of them and
+        # this branch would never be reached from below it.
+        return False
     if isinstance(exc, _ISOLATED_ERRORS):
         return True
     if _is_transport_mcp_error(exc):
@@ -434,11 +466,14 @@ class ReviewEngine(Engine):
         # reaches here and ends the run.
         await run.wait_quiescence()
         # A clean or minor-only review spawns no issue verifiers, so it would
-        # reach the verdict with zero VerifyResult — and a downstream evidence
-        # floor then refuses the APPROVE as evidence-empty, structurally.
-        # Gate on zero VerifyResult (not zero issues) so both shapes instead
-        # carry one adversarial audit of the clean verdict itself: positive
-        # executed evidence rather than absence.
+        # reach the verdict with zero VerifyResult and ship an APPROVE backed
+        # by nothing executed. A consumer may well refuse that as
+        # evidence-empty, but whether any given one does is a property of that
+        # consumer's code and is not observable from this package, so it is not
+        # a guard this engine gets to count on. Gate on zero VerifyResult (not
+        # zero issues) so both shapes instead carry one adversarial audit of
+        # the clean verdict itself: positive executed evidence rather than
+        # absence, decided here where it can be seen.
         if self.verify_clean and not run.by_type(VerifyResult):
             await self._verify_clean_isolated(run, artifact, dims)
         return await self._verdict(run, artifact, dims)

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -428,7 +428,10 @@ class ReviewEngine(Engine):
             # background work mutates shared run state after _run exits.
             await run.cancel_active()
             raise
-        # Drain any adversarial verifiers spawned by high-severity issues.
+        # Drain any adversarial verifiers spawned by high-severity issues. Each
+        # was spawned already wrapped, so a dead verifier worker is recorded and
+        # the drain stays clean; anything the wrapper does not claim still
+        # reaches here and ends the run.
         await run.wait_quiescence()
         # A clean or minor-only review spawns no issue verifiers, so it would
         # reach the verdict with zero VerifyResult — and a downstream evidence
@@ -437,14 +440,14 @@ class ReviewEngine(Engine):
         # carry one adversarial audit of the clean verdict itself: positive
         # executed evidence rather than absence.
         if self.verify_clean and not run.by_type(VerifyResult):
-            await self._verify_clean(run, artifact, dims)
+            await self._verify_clean_isolated(run, artifact, dims)
         return await self._verdict(run, artifact, dims)
 
     # -- reactions ------------------------------------------------------------
 
     def _on_issue(self, run: EngineRun, issue: IssueFound) -> None:
         if issue.severity in self.verify_severities and not run.seen(_verify_key(issue)):
-            run.spawn(self._verify(run, issue))
+            run.spawn(self._verify_isolated(run, issue))
 
     # -- stages ---------------------------------------------------------------
 
@@ -476,6 +479,53 @@ class ReviewEngine(Engine):
             marker = f"review-{dimension} ({error_type})"
             if marker not in run._emission_failures:
                 run._emission_failures.append(marker)
+
+    def _isolate_verification_failure(
+        self, run: EngineRun, exc: BaseException, *, stage: str
+    ) -> bool:
+        """Record an isolated verification failure; False means the caller must re-raise.
+
+        Verification is discretionary work performed on evidence that already
+        exists: by the time a verifier runs, its dimension has reported and its
+        findings are on the run. A provider or transport failure here says the
+        worker died, not that the review is unsound, so it degrades the audit of
+        one finding rather than the run that produced it. The drain already
+        treats one failure this way — ``EngineBudgetError`` is swallowed as
+        discretionary work declined — and this extends the same reading to the
+        transport failures the dimension stage isolates.
+
+        The failure stays visible: the marker reaches the caller through
+        ``_emission_failures`` and is reported alongside the result, so a run
+        that verified less than it intended says so instead of presenting a
+        verdict as fully audited.
+        """
+        if not _is_all_isolated_failure(exc):
+            return False
+        error_type = _failure_label(exc)
+        run.notify("verification_failed", stage=stage, error_type=error_type)
+        marker = f"{stage} ({error_type})"
+        if marker not in run._emission_failures:
+            run._emission_failures.append(marker)
+        return True
+
+    async def _verify_isolated(self, run: EngineRun, issue: IssueFound) -> None:
+        try:
+            await self._verify(run, issue)
+        except Exception as exc:
+            # Spawned into the run's background set, so an escape does not fail
+            # this verifier alone: the drain collects it and re-raises, which
+            # discards a review whose dimensions have already succeeded.
+            if not self._isolate_verification_failure(run, exc, stage=f"verify-{issue.dimension}"):
+                raise
+
+    async def _verify_clean_isolated(
+        self, run: EngineRun, artifact: str, dimensions: tuple[str, ...]
+    ) -> None:
+        try:
+            await self._verify_clean(run, artifact, dimensions)
+        except Exception as exc:
+            if not self._isolate_verification_failure(run, exc, stage="verify-clean"):
+                raise
 
     async def _review_dimension(self, run: EngineRun, artifact: str, dimension: str) -> None:
         emits = (IssueFound, DimensionClean)

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -70,6 +70,15 @@ _ISOLATED_ERRORS: tuple[type[BaseException], ...] = (ProviderError, *_TRANSPORT_
 # prompt that overflowed rather than of the run -- one verifier's oversized
 # prompt says nothing about the next one's, which is why the engine repairs it
 # instead of failing.
+#
+# A quota refusal belongs here despite being marked retryable, which looks like
+# a contradiction and is not. Retryability is about time: the same request may
+# well succeed once the limit resets. This tuple is about scope: at the moment
+# it is raised, the limit applies to every dimension alike. A run in flight has
+# no later, so isolating the quota failure would let the remaining dimensions
+# report and the run publish a verdict over an artifact one dimension never
+# read. Failing the whole run is the louder and more accurate outcome, and it
+# is the same principle the coverage check enforces downstream.
 _RUN_WIDE_REFUSALS: tuple[type[BaseException], ...] = (
     ProviderAuthError,
     ProviderQuotaError,

--- a/tests/cli/test_engine_emission_diagnostics.py
+++ b/tests/cli/test_engine_emission_diagnostics.py
@@ -498,3 +498,103 @@ async def test_engine_reuse_second_run_resets_emission_failures(monkeypatch):
     assert real_engine._emission_failures == [], (
         f"second clean run must reset _emission_failures; got: {real_engine._emission_failures}"
     )
+
+
+# Engine CLI: a degraded run must not be indistinguishable from a complete one
+
+
+class _DegradedResult(str):
+    """Stands in for EngineResult, which subclasses str for back-compatibility.
+
+    The subclassing is the whole difficulty: the CLI's ``isinstance(result, str)``
+    branch catches it, so the structured outcome travels on the object and every
+    plain-string path drops it silently.
+    """
+
+    def __new__(cls, text, *, degraded, degrade_reason, skipped):
+        obj = super().__new__(cls, text)
+        obj.degraded = degraded
+        obj.degrade_reason = degrade_reason
+        obj.skipped = skipped
+        return obj
+
+
+async def _run_engine_returning(monkeypatch, capsys, result):
+    import lionagi.cli._logging as log_mod
+    import lionagi.cli.engine as engine_mod
+    import lionagi.state.db as db_mod
+
+    warnings: list[str] = []
+    monkeypatch.setattr(log_mod, "progress", lambda *a, **kw: None)
+    monkeypatch.setattr(log_mod, "warn", lambda msg, *a, **kw: warnings.append(str(msg)))
+    monkeypatch.setattr(engine_mod, "warn", lambda msg, *a, **kw: warnings.append(str(msg)))
+
+    mock_engine = MagicMock()
+    mock_engine._emission_failures = []
+    mock_engine._total_agent_failure = False
+
+    async def _mock_run(spec, *, on_event=None, **kwargs):
+        return result
+
+    mock_engine.run = _mock_run
+    monkeypatch.setattr(
+        engine_mod, "_import_engine_class", lambda m, n: MagicMock(return_value=mock_engine)
+    )
+    mock_db = MockStateDB()
+    monkeypatch.setattr(db_mod, "StateDB", lambda: mock_db)
+
+    rc = await engine_mod._do_engine_run(_build_args(kind="review", spec="ART"))
+    return rc, mock_db, warnings, capsys.readouterr().out
+
+
+async def test_a_degraded_run_says_so_in_its_output_and_its_row(monkeypatch, capsys):
+    """A caller must be able to tell a full run from one that skipped work.
+
+    The run reaches a result, so it is persisted completed and exits zero, and
+    on the plain-string path that was the entire visible outcome: a review whose
+    security dimension was never verified read exactly like one that was. The
+    degradation now reaches all three places a caller might look — the JSON, the
+    stored row, and the terminal.
+    """
+    import json as _json
+
+    result = _DegradedResult(
+        "verdict reached",
+        degraded=True,
+        degrade_reason="verify-clean (ProviderAuthError)",
+        skipped=["security"],
+    )
+    rc, mock_db, warnings, out = await _run_engine_returning(monkeypatch, capsys, result)
+
+    payload = _json.loads(out)
+    assert payload["degraded"] is True
+    assert "ProviderAuthError" in payload["degrade_reason"]
+    assert payload["skipped"] == ["security"]
+
+    completed = [c for c in mock_db.update_calls if c["status"] == "completed"]
+    assert completed, f"no completed update; calls={mock_db.update_calls}"
+    assert "degraded" in (completed[0]["error"] or "")
+    assert "security" in (completed[0]["error"] or "")
+
+    assert any("degraded" in w for w in warnings), f"no warning emitted; warnings={warnings}"
+    assert rc == 0  # it did produce a result; the caller decides what that is worth
+
+
+async def test_an_undegraded_run_gains_no_degradation_fields(monkeypatch, capsys):
+    """The must-not-fire side, so the arm above cannot pass by always reporting.
+
+    A clean run's JSON keeps the shape callers already parse, and its row keeps
+    a null error column.
+    """
+    import json as _json
+
+    result = _DegradedResult("verdict reached", degraded=False, degrade_reason="", skipped=[])
+    rc, mock_db, warnings, out = await _run_engine_returning(monkeypatch, capsys, result)
+
+    payload = _json.loads(out)
+    assert "degraded" not in payload
+    assert "skipped" not in payload
+    completed = [c for c in mock_db.update_calls if c["status"] == "completed"]
+    assert completed and completed[0]["error"] is None
+    assert not any("degraded" in w for w in warnings)
+    assert rc == 0

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -11,9 +11,14 @@ import anyio
 import pytest
 
 from lionagi.engines.engine import Engine, EngineBudgetError
-from lionagi.engines.review import ReviewEngine, _is_all_isolated_failure
+from lionagi.engines.review import (
+    DimensionClean,
+    IssueFound,
+    ReviewEngine,
+    _is_all_isolated_failure,
+)
 from lionagi.ln.concurrency._compat import ExceptionGroup
-from lionagi.providers._provider_errors import ProviderContextError
+from lionagi.providers._provider_errors import ProviderContextError, WorkerLivenessError
 
 
 class _StubEngine(Engine):
@@ -387,3 +392,162 @@ async def test_the_sdks_own_transport_failures_are_still_recognised(failure: str
                 task_group.cancel_scope.cancel()
 
     assert _is_all_isolated_failure(caught.value) is True
+
+
+# ---------------------------------------------------------------------------
+# Verifier-stage isolation.
+#
+# The dimension stage is only one of three places this engine does work. The
+# adversarial verifiers are spawned into the run's background set and drained by
+# wait_quiescence(), which re-raises everything except cancellation and budget
+# exhaustion; the clean-verify is awaited directly at the end of _run. A worker
+# that dies in either place therefore discarded a review whose dimensions had
+# already reported, throwing away findings that were already on the run.
+# ---------------------------------------------------------------------------
+
+
+class _DeadVerifierReview(ReviewEngine):
+    """The dimension reports a finding; the verifier that finding triggers dies."""
+
+    def __init__(self, failure: BaseException) -> None:
+        super().__init__(dimensions=("security",), verify_clean=False)
+        self._failure = failure
+        self.issues_at_verdict = -1
+
+    async def _review_dimension(self, run, artifact: str, dimension: str) -> None:
+        await run.emit(
+            IssueFound(
+                dimension=dimension,
+                description="a finding worth verifying",
+                severity="critical",
+            )
+        )
+
+    async def _verify(self, run, issue) -> None:
+        # The sleep is load-bearing, not scene-setting. A spawned task that
+        # finishes before the drain is entered removes itself from the active
+        # set via its done-callback, so wait_quiescence() finds nothing to
+        # collect and the exception is discarded. Failing while still in flight
+        # is what puts this arm on the isolation predicate rather than on that
+        # timing, and it is also what a real verifier does: it works, then dies.
+        await asyncio.sleep(0.05)
+        raise self._failure
+
+    async def _verdict(self, run, artifact: str, dimensions: tuple[str, ...]) -> str:
+        self.issues_at_verdict = len(run.by_type(IssueFound))
+        return "verdict reached"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("make_failure", "expected_label"),
+    [
+        # The class that actually took the lane down. It subclasses
+        # ProviderError, so it always qualified for isolation — it escaped
+        # because this path had no isolation to qualify for.
+        (
+            lambda: WorkerLivenessError("worker produced no first stream output"),
+            "WorkerLivenessError",
+        ),
+        (lambda: anyio.ClosedResourceError(), "ClosedResourceError"),
+        (lambda: ProviderContextError("provider context overflow"), "ProviderContextError"),
+        # Two verifiers dying together is the observed shape: the drain gathers
+        # every spawned failure and reports them as one group.
+        (
+            lambda: ExceptionGroup(
+                "unhandled errors in a TaskGroup",
+                [
+                    WorkerLivenessError("worker produced no first stream output"),
+                    WorkerLivenessError("worker produced no first stream output"),
+                ],
+            ),
+            "WorkerLivenessError",
+        ),
+    ],
+)
+async def test_a_dead_verifier_does_not_discard_a_review_whose_dimensions_succeeded(
+    make_failure, expected_label: str
+) -> None:
+    events: list[dict] = []
+    engine = _DeadVerifierReview(make_failure())
+
+    result = await engine.run("artifact", on_event=events.append)
+
+    assert result == "verdict reached"
+    # The evidence the dead verifier was auditing is still on the run. This is
+    # the whole point: the findings existed before the verifier was spawned.
+    assert engine.issues_at_verdict == 1
+    assert result.degraded is True
+    assert result.skipped == [f"verify-security ({expected_label})"]
+    # The marker has to reach the caller, not just the run: this string is what
+    # the CLI folds into the recorded error for the run, so a degraded review
+    # says which stage degraded rather than only that something did.
+    assert result.degrade_reason == f"emission_failure: verify-security ({expected_label})"
+    assert any(
+        event["type"] == "verification_failed"
+        and event["stage"] == "verify-security"
+        and event["error_type"] == expected_label
+        for event in events
+    )
+
+
+class _NonTransportVerifierReview(_DeadVerifierReview):
+    def __init__(self) -> None:
+        super().__init__(ValueError("a genuine defect in the verifier"))
+
+
+@pytest.mark.asyncio
+async def test_a_non_transport_verifier_failure_still_ends_the_run() -> None:
+    """Isolation is a claim about transport, not a blanket swallow.
+
+    Without this arm the fix reads identically whether the predicate is
+    consulted or the except clause simply discards everything.
+    """
+    engine = _NonTransportVerifierReview()
+
+    with pytest.raises(ValueError, match="a genuine defect in the verifier"):
+        await engine.run("artifact")
+
+
+class _DeadCleanVerifierReview(ReviewEngine):
+    """No issues, so the clean-verify runs — and its worker dies."""
+
+    def __init__(self, failure: BaseException) -> None:
+        super().__init__(dimensions=("security",), verify_clean=True)
+        self._failure = failure
+
+    async def _review_dimension(self, run, artifact: str, dimension: str) -> None:
+        await run.emit(DimensionClean(dimension=dimension, rationale="nothing found"))
+
+    async def _verify_clean(self, run, artifact: str, dimensions: tuple[str, ...]) -> None:
+        raise self._failure
+
+    async def _verdict(self, run, artifact: str, dimensions: tuple[str, ...]) -> str:
+        return "clean verdict reached"
+
+
+@pytest.mark.asyncio
+async def test_a_dead_clean_verifier_degrades_instead_of_killing_the_run() -> None:
+    events: list[dict] = []
+    engine = _DeadCleanVerifierReview(WorkerLivenessError("worker produced no first stream output"))
+
+    result = await engine.run("artifact", on_event=events.append)
+
+    assert result == "clean verdict reached"
+    assert result.degraded is True
+    assert result.skipped == ["verify-clean (WorkerLivenessError)"]
+    assert result.degrade_reason == "emission_failure: verify-clean (WorkerLivenessError)"
+    assert any(
+        event["type"] == "verification_failed"
+        and event["stage"] == "verify-clean"
+        and event["error_type"] == "WorkerLivenessError"
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_non_transport_clean_verifier_failure_still_ends_the_run() -> None:
+    engine = _DeadCleanVerifierReview(ValueError("a genuine defect in the clean verifier"))
+
+    with pytest.raises(ValueError, match="a genuine defect in the clean verifier"):
+        await engine.run("artifact")

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -18,7 +18,14 @@ from lionagi.engines.review import (
     _is_all_isolated_failure,
 )
 from lionagi.ln.concurrency._compat import ExceptionGroup
-from lionagi.providers._provider_errors import ProviderContextError, WorkerLivenessError
+from lionagi.providers._provider_errors import (
+    ProviderAuthError,
+    ProviderContextError,
+    ProviderQuotaError,
+    ProviderSafetyError,
+    ProviderUnsupportedModelError,
+    WorkerLivenessError,
+)
 
 
 class _StubEngine(Engine):
@@ -550,4 +557,68 @@ async def test_a_non_transport_clean_verifier_failure_still_ends_the_run() -> No
     engine = _DeadCleanVerifierReview(ValueError("a genuine defect in the clean verifier"))
 
     with pytest.raises(ValueError, match="a genuine defect in the clean verifier"):
+        await engine.run("artifact")
+
+
+# -- run-wide refusals are not per-dimension blips ----------------------------
+# Every one of these derives from ProviderError, so the isolated set matched
+# them all and each was recorded as a skipped dimension. The run then reached a
+# verdict over an artifact whose dimensions were never read, and the reason was
+# a bad credential or a safety refusal rather than a dropped socket.
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ProviderAuthError("invalid api key"),
+        ProviderQuotaError("rate limit exceeded"),
+        ProviderSafetyError("content flagged by a safety filter"),
+        ProviderUnsupportedModelError("unknown model"),
+    ],
+    ids=lambda failure: type(failure).__name__,
+)
+def test_a_refusal_that_describes_the_run_is_not_isolated(failure: BaseException) -> None:
+    assert _is_all_isolated_failure(failure) is False
+
+
+def test_the_neighbouring_provider_failures_are_still_isolated() -> None:
+    """The control for the exclusion: it must not widen into ProviderError itself.
+
+    Without this arm, deleting the whole isolated set passes every assertion
+    above, because refusing everything satisfies a suite that only ever asks
+    what is refused.
+    """
+    assert _is_all_isolated_failure(ProviderContextError("provider context overflow")) is True
+    assert _is_all_isolated_failure(WorkerLivenessError("no first stream output")) is True
+    assert _is_all_isolated_failure(anyio.ClosedResourceError()) is True
+
+
+def test_a_group_of_transport_failures_carrying_one_refusal_is_not_isolated() -> None:
+    # The shape that hides it: several dimensions die of transport at once and
+    # one dies of a bad credential. Judged as a group, the majority reads as an
+    # ordinary blip.
+    group = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [
+            anyio.ClosedResourceError(),
+            WorkerLivenessError("no first stream output"),
+            ProviderAuthError("invalid api key"),
+        ],
+    )
+
+    assert _is_all_isolated_failure(group) is False
+
+
+@pytest.mark.asyncio
+async def test_a_clean_verifier_refused_for_credentials_ends_the_run() -> None:
+    """The end-to-end arm: the predicate is consulted where it decides a run.
+
+    Its control is the WorkerLivenessError case above, which takes the same
+    path with the same engine and degrades to a verdict. One failure class
+    reaches a result and the other does not, so this cannot pass by the engine
+    having stopped isolating anything.
+    """
+    engine = _DeadCleanVerifierReview(ProviderAuthError("invalid api key"))
+
+    with pytest.raises(ProviderAuthError, match="invalid api key"):
         await engine.run("artifact")

--- a/tests/engines/test_engine_emission_reliability.py
+++ b/tests/engines/test_engine_emission_reliability.py
@@ -622,3 +622,88 @@ async def test_a_clean_verifier_refused_for_credentials_ends_the_run() -> None:
 
     with pytest.raises(ProviderAuthError, match="invalid api key"):
         await engine.run("artifact")
+
+
+# ---------------------------------------------------------------------------
+# A spawned task's failure has to outlive the task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("settle_before_drain", [True, False], ids=["fast", "slow"])
+async def test_a_spawned_failure_is_raised_whether_or_not_it_beat_the_drain(
+    settle_before_drain,
+) -> None:
+    """Timing must not decide whether a run-ending refusal is noticed.
+
+    Spawned tasks take themselves off the active set as they finish. When the
+    drain was the only thing reading failures, anything that finished first was
+    already gone by the time it looked, and the drain saw an empty set and
+    reported nothing wrong.
+
+    That is backwards from which failures matter. A refusal the provider issues
+    without doing any work -- a bad key here -- comes back almost at once, so
+    the failures that describe the whole run were the ones most reliably lost,
+    while a slow one was caught. Both timings are asserted together because
+    either alone reads as correct: the slow arm passed throughout.
+    """
+    run = ReviewEngine().new_run()
+
+    async def refused() -> None:
+        if not settle_before_drain:
+            await asyncio.sleep(0.05)
+        raise ProviderAuthError("invalid api key")
+
+    run.spawn(refused())
+    if settle_before_drain:
+        # Let it finish, and let its done callback run, before the drain starts.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    with pytest.raises(ProviderAuthError, match="invalid api key"):
+        await run.wait_quiescence()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "make_coro, label",
+    [
+        (lambda: asyncio.sleep(0), "a task that simply succeeded"),
+        (lambda: _raise(EngineBudgetError("exhausted")), "declined discretionary work"),
+    ],
+)
+async def test_the_drain_stays_quiet_for_outcomes_that_are_not_failures(make_coro, label) -> None:
+    """The must-not-fire side, so the arm above cannot pass by raising always.
+
+    Collecting failures as tasks settle widens what reaches the drain, and a
+    budget refusal is the one outcome that travels this path routinely without
+    meaning anything went wrong.
+    """
+    run = ReviewEngine().new_run()
+    run.spawn(make_coro())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    await run.wait_quiescence()  # must not raise
+
+
+async def _raise(exc: BaseException) -> None:
+    raise exc
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_spawned_task_is_not_reported_as_a_failure() -> None:
+    """Cancellation is how the engine stops its own work, not a defect.
+
+    Recorded as a failure it would turn every budget stop and deadline into a
+    run-ending error, so this is asserted against the same collection path the
+    two arms above use.
+    """
+    run = ReviewEngine().new_run()
+    task = run.spawn(asyncio.sleep(3600))
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    await run.wait_quiescence()  # must not raise

--- a/tests/engines/test_review.py
+++ b/tests/engines/test_review.py
@@ -261,8 +261,9 @@ def test_verify_instruction_names_the_ref_field():
 
 # -- clean-verdict audit ------------------------------------------------------
 # A clean or minor-only review spawns no issue verifiers, so it used to reach
-# the verdict with zero VerifyResult — and a downstream evidence floor then
-# refused the APPROVE as evidence-empty, structurally, on every clean run.
+# the verdict with zero VerifyResult and ship an APPROVE backed by nothing
+# executed. Whether a consumer refuses that as evidence-empty is the consumer's
+# own code and is not observable from here, so it is not what these tests pin.
 # The engine now audits its own clean verdict: one adversarial verifier that
 # must execute a real check and emit a VerifyResult carrying the run's clean
 # ref, so a clean verdict ships positive evidence instead of absence.


### PR DESCRIPTION
## Summary

A provider or transport failure in a *verifier* discarded the whole review, including the dimensions that had already succeeded. The reviewer stages were already isolated; the verifier stages were not, so the run's most expensive work was thrown away by a failure that says nothing about the artifact under review.

Two changes:

- Transport failures in the adversarial verifier and clean-audit stages are isolated per stage, the way dimension reviewers already were. Completed sibling evidence survives.
- A refusal that describes the *whole run* is not isolated. Budget exhaustion and cancellation keep their structured-concurrency semantics, because those are statements about the run rather than about one stage, and swallowing them would let a run report partial success after it had been told to stop.

The second is the narrower one and it is the one that makes the first safe: isolation that cannot tell "this stage's provider died" from "this run is over" converts a stop into a partial pass.

## Tests

`tests/engines/test_engine_emission_reliability.py` and `tests/engines/test_review.py` cover the isolated transport classes per stage, the run-wide refusals that must still propagate, and that verifier tasks spawned before a failure are cancelled rather than left to mutate run state after the run exits.

`tests/engines/` is 332 passing on this branch against 318 on main.

## Scope

Split out of #3341, which carried this alongside a terminal evidence gate. The gate is being redesigned around per-run and per-dimension evidence and returns separately; this half is independent of it and does not depend on that work landing.