### PR TITLE
docs: drop internal tracking references from source comments

### DIFF
--- a/apps/studio/frontend/src/components/canvas/SidePanel.tsx
+++ b/apps/studio/frontend/src/components/canvas/SidePanel.tsx
@@ -1,6 +1,5 @@
-// TODO(#1020 follow-up): SidePanel form labels need htmlFor/id wiring.
-// Tracked as a Track 1 a11y follow-up — substantial refactor of label+input
-// pairs across this file.
+// TODO: SidePanel form labels need htmlFor/id wiring. Deferred because it is a
+// substantial refactor of label+input pairs across this file.
 
 "use client";
 

--- a/apps/studio/frontend/src/components/fleet/FleetView.test.ts
+++ b/apps/studio/frontend/src/components/fleet/FleetView.test.ts
@@ -302,7 +302,7 @@ describe("selectedRunId deep link", () => {
 import { formatElapsed, formatCompactCount, patchSearch, isPlayRoot } from "./FleetView";
 import { resetDetailScrollPosition } from "./SessionDetail";
 
-// ─── isPlayRoot — the play-vs-single-agent discriminator (issue #2842) ───────
+// ─── isPlayRoot — the play-vs-single-agent discriminator ───────────────────
 
 describe("isPlayRoot", () => {
   it("is true for every multi-agent invocation_kind", () => {

--- a/apps/studio/frontend/src/components/fleet/FleetView.tsx
+++ b/apps/studio/frontend/src/components/fleet/FleetView.tsx
@@ -34,7 +34,7 @@ export function formatCompactCount(n: number): string {
 // ─── Agent row ────────────────────────────────────────────────────────────────
 
 // invocation_kind values that mean "this row is the root of a multi-agent
-// execution, not a single agent" (issue #2842) — the closed vocabulary lives
+// execution, not a single agent" — the closed vocabulary lives
 // in lionagi/state/db.py's sessions.invocation_kind CHECK constraint.
 const PLAY_ROOT_KINDS = new Set(["play", "flow", "fanout", "show-play"]);
 

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.ts
@@ -43,7 +43,7 @@ export interface AgentRow {
   message_count: number;
   kind: "run" | "invocation";
   invocation_id: string | null;
-  // agent | play | flow | fanout | show-play (issue #2842) — the discriminator
+  // agent | play | flow | fanout | show-play — the discriminator
   // that says whether this row is a single agent or the root of a multi-agent
   // execution. `agentName`/label text alone never establishes that.
   invocationKind: string | null;

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -1316,7 +1316,7 @@ describe("history/RunDetail.tsx — operation lane escalation presentation", () 
   });
 });
 
-// ─── visibleEventPayloadEntries / summarizeHookEvent — #2862 ─────────────────
+// ─── visibleEventPayloadEntries / summarizeHookEvent ───────────────────────
 // Element/Signal attach created_at/metadata/schema_version to every signal
 // row; the events panel must not dump them into the one-line summary, and a
 // HookSignal row must read as a human summary, not a struct.
@@ -1439,7 +1439,7 @@ describe("history/RunDetail.tsx — summarizeHookEvent", () => {
   });
 });
 
-// ─── deriveGateOutcome — #2863 ────────────────────────────────────────────────
+// ─── deriveGateOutcome ───────────────────────────────────────────────────────
 // A gate/review step's structured verdict is a different population from
 // runtime tool errors; deriveGateOutcome scans the signal stream for it so
 // the page can surface "Gate: approve-with-fixes · 1 major, 5 minor" beside

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -130,7 +130,7 @@ describe("history/ — no Drawer overlay import (master-detail doctrine §4)", (
   }
 });
 
-// ─── SSE done-refetch stale-write race guard (MAJ-3) ─────────────────────────
+// ─── SSE done-refetch stale-write race guard ────────────────────────────────
 // The 'done' handler refetches status/reason fields after streamSession
 // reports completion. Without a same-session guard, navigating A→B before
 // A's refetch resolves lets A's data clobber B's freshly-fetched state.

--- a/apps/studio/frontend/src/components/mission/LiveBoard.test.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.test.tsx
@@ -161,7 +161,7 @@ describe("isUnknownHealth", () => {
   });
 });
 
-describe("LiveBoard — InvocationCard health rendering (issue #2851)", () => {
+describe("LiveBoard — InvocationCard health rendering", () => {
   let container: HTMLDivElement;
   let root: Root;
 

--- a/apps/studio/frontend/src/components/mission/LiveBoard.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.tsx
@@ -121,7 +121,7 @@ function InvocationCard({ inv, nowSec }: { inv: InvocationSummary; nowSec: numbe
   const t = useTranslations("mission");
   const elapsed = elapsedSec(inv.started_at, nowSec);
   // Health axis, same as RunCard: never an unconditional "running" dot
-  // regardless of whether there's evidence behind it (issue #2851).
+  // regardless of whether there's evidence behind it.
   const dead = isDeadHealth(inv.health);
   const unknown = isUnknownHealth(inv.health);
   // last_activity_at is the real worst-of child-session heartbeat now that

--- a/apps/studio/frontend/src/components/ui/Markdown.test.ts
+++ b/apps/studio/frontend/src/components/ui/Markdown.test.ts
@@ -77,7 +77,7 @@ describe("Markdown.tsx — file-link resolution wiring", () => {
     expect(SRC).toMatch(/knownFiles: fileContext\.knownFiles/);
   });
 
-  it("renders a distinct no-artifact-root state, not the generic missing-file message (issue #2848)", () => {
+  it("renders a distinct no-artifact-root state, not the generic missing-file message", () => {
     expect(SRC).toMatch(/status === "no_artifact_root"/);
     expect(SRC).toMatch(/isNoArtifactRootDetail\(result\.detail\)/);
   });

--- a/apps/studio/frontend/src/components/ui/Markdown.tsx
+++ b/apps/studio/frontend/src/components/ui/Markdown.tsx
@@ -135,7 +135,7 @@ function FileRef({
   return <>{fallback}</>;
 }
 
-// issue #2848: get_run_file 404s for two different reasons -- the run never
+// get_run_file 404s for two different reasons -- the run never
 // recorded an artifact root, or a file inside a recorded root is genuinely
 // gone -- and the detail string is the only thing that tells them apart.
 // Matches both `get_run_file` 404 details ("has no artifact root" and

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1423,7 +1423,7 @@ export interface InvocationSummary {
   project_source?: string | null;
   // ADR-0057 health verdict (worst-of across child sessions) + the real
   // last-activity timestamp behind it, "unknown" when the invocation has
-  // no child sessions yet (issue #2851) — same vocabulary runs use, plus
+  // no child sessions yet — same vocabulary runs use, plus
   // "unknown" for a case runs never hit (a run always has itself).
   health?: "healthy" | "idle" | "unresponsive" | "stale" | "orphaned" | "zombie" | "unknown" | null;
   last_activity_at?: number | null;

--- a/benchmarks/orchestration/suites/lionbench/harvest.py
+++ b/benchmarks/orchestration/suites/lionbench/harvest.py
@@ -134,7 +134,7 @@ _FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
 # Stateful raw-diff stripper (see _strip_raw_diff_blocks below). A bare "line
 # starts with + or -" pattern is a false-positive magnet on its own — it nukes
 # ordinary markdown bullet lists ("- **file.py** — did X") in PR bodies, which
-# is exactly the prose we want to KEEP (confirmed live against PR #1665's
+# is exactly the prose we want to KEEP (confirmed against a real harvested PR
 # body). But dropping that alternative entirely leaves *unfenced* raw diffs
 # untouched: a PR/issue body is not guaranteed to fence a pasted patch, and a
 # flat regex with no notion of "am I inside a diff block" can't tell a diff's
@@ -246,8 +246,8 @@ def default_oracle_command(held_out_paths: list[str]) -> str:
     # project deps, so any held-out test that imports an extra-gated module
     # fails at COLLECTION (ModuleNotFoundError), which is indistinguishable
     # from a real regression unless you inspect the traceback. Confirmed live
-    # against PR #1643 (tests/cli/test_argv_injection.py imports
-    # lionagi.studio.services.schedules -> fastapi).
+    # against a harvested instance whose held-out test imports
+    # lionagi.studio.services.schedules -> fastapi.
     return f"uv run --all-extras pytest {' '.join(held_out_paths)} -q"
 
 
@@ -280,8 +280,8 @@ def harvest(
     # moved past the PR's actual base — using it as base_commit silently pulls
     # in unrelated later history. baseRefOid is "world before the fix" for a
     # squash merge (verified against LIONAGI_NOMINATIONS.md's methodology, and
-    # confirmed live: PR #1665's merge-commit parent b01d8190.. != its
-    # baseRefOid b1fd2ad2..).
+    # confirmed live on a harvested instance whose merge-commit parent differs
+    # from its baseRefOid).
     base_commit = view.get("baseRefOid")
     if not base_commit:
         save_rejection(instance_id, "no baseRefOid recorded", out_dir, subject=subject)

--- a/benchmarks/orchestration/suites/lionbench/image.py
+++ b/benchmarks/orchestration/suites/lionbench/image.py
@@ -24,7 +24,7 @@ def lionbench_image(
     ``uv`` is in ``extra_pip`` (not just ``pytest``) because harvested oracle
     commands are ``uv run --all-extras pytest ...`` (see harvest.py's
     ``default_oracle_command`` — extras like studio's fastapi aren't in the
-    base dependency tree, confirmed live against PR #1643); the swebench
+    base dependency tree, confirmed live on a harvested instance); the swebench
     suite's own snapshot never needed `uv` since its runner drives tests via
     bare `pip install -e .`, but lionbench's harvested oracle commands do."""
     from lionagi.tools.daytona import _require_daytona

--- a/benchmarks/orchestration/suites/lionbench/test_data_hygiene.py
+++ b/benchmarks/orchestration/suites/lionbench/test_data_hygiene.py
@@ -1,14 +1,14 @@
 """Publication-hygiene gate over every committed instance/rejection JSON.
 
-A round-1 review of the first three harvested instances found local worktree
-paths, an internal actor identifier, an internal issue-tracker comment, and a
-test-generated session UUID leaking into fields outside ``task_text`` —
-``provenance.nominated_by``, ``validation.gold_output``/``null_output``, and
-``oracle.test_patch``. ``save_instance`` now redacts the first two at write
-time (see ``schema._redact_for_publication``), but this repo is public and a
-future harvest run (or a hand-edited fixture) could reintroduce any of these —
-so every scalar field of every committed JSON under ``data/`` is walked here
-and checked against the concrete leak patterns from that review.
+Early harvested instances leaked local worktree paths, an actor identifier, a
+tracker comment, and a test-generated session UUID into fields outside
+``task_text`` — ``provenance.nominated_by``,
+``validation.gold_output``/``null_output``, and ``oracle.test_patch``.
+``save_instance`` now redacts the first two at write time (see
+``schema._redact_for_publication``), but this repo is public and a future
+harvest run (or a hand-edited fixture) could reintroduce any of these — so
+every scalar field of every committed JSON under ``data/`` is walked here and
+checked against those leak patterns.
 """
 
 from __future__ import annotations

--- a/benchmarks/orchestration/suites/lionbench/test_harvest.py
+++ b/benchmarks/orchestration/suites/lionbench/test_harvest.py
@@ -92,7 +92,7 @@ def test_infer_held_out_paths_dedupes_in_order():
 
 def test_default_oracle_command_joins_paths():
     # --all-extras: held-out tests can import extra-gated modules (e.g. studio's
-    # fastapi) that a plain `uv run pytest` won't have installed (PR #1643).
+    # fastapi) that a plain `uv run pytest` won't have installed.
     assert default_oracle_command(["a.py", "b.py"]) == "uv run --all-extras pytest a.py b.py -q"
 
 
@@ -158,7 +158,7 @@ Something broke. Two coupled fixes:
 def test_scrub_task_text_preserves_markdown_bullet_lists():
     """A bare '- ' prefix is an ordinary markdown bullet, not a diff line — the
     scrub must not treat every dash-prefixed line as diff noise (real
-    regression: this nuked PR #1665's bulleted fix summary before the fix)."""
+    regression: this nuked a real PR body's bulleted fix summary before the fix)."""
     scrubbed = scrub_task_text(_PR_BODY_WITH_MARKDOWN_BULLETS)
     assert "did the first thing" in scrubbed
     assert "did the second thing" in scrubbed

--- a/lionagi/providers/ag2/agent.py
+++ b/lionagi/providers/ag2/agent.py
@@ -127,7 +127,7 @@ def _build_policies(names: list[str]) -> list:
     return policies
 
 
-# TODO(#1043 Phase 2): migrate create_task + Queue + wait_for to anyio primitives
+# TODO: migrate create_task + Queue + wait_for to anyio primitives
 async def run_beta_agent(
     config: AgentConfig | None,
     message: str,

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -554,7 +554,7 @@ ClaudeSession = CLISession
 # --------------------------------------------------------------------------- NDJSON stream
 
 
-# TODO(#1043 Phase 2): migrate create_subprocess_exec + wait_for to anyio
+# TODO: migrate create_subprocess_exec + wait_for to anyio
 async def _ndjson_from_cli(request: ClaudeCodeRequest):
     workspace = request.cwd()
     workspace.mkdir(parents=True, exist_ok=True)

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -608,7 +608,7 @@ CodexSession = CLISession
 # --------------------------------------------------------------------------- NDJSON stream
 
 
-# TODO(#1043 Phase 2): migrate create_subprocess_exec + wait_for to anyio
+# TODO: migrate create_subprocess_exec + wait_for to anyio
 async def _ndjson_from_cli(request: CodexCodeRequest):
     if CODEX_CLI is None:
         raise RuntimeError("Codex CLI not found. Install with: npm i -g @openai/codex")

--- a/lionagi/providers/pi/cli.py
+++ b/lionagi/providers/pi/cli.py
@@ -290,7 +290,7 @@ PiSession = CLISession
 # --------------------------------------------------------------------------- NDJSON stream
 
 
-# TODO(#1043 Phase 2): migrate create_subprocess_exec + wait_for to anyio
+# TODO: migrate create_subprocess_exec + wait_for to anyio
 async def _ndjson_from_cli(request: PiCodeRequest):
     if PI_CLI is None:
         raise RuntimeError("Pi CLI not found. Install with: npm i -g @mariozechner/pi-coding-agent")

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -373,7 +373,7 @@ async def resolve_invocation_terminal(
         # ANY terminal status (e.g. still "running") even though the
         # invocation's own leader process has already exited. The leader's
         # exit is not evidence that a child's own work finished -- it is
-        # only evidence that the leader's stderr pipe closed (see #2535).
+        # only evidence that the leader's stderr pipe closed.
         # Never silently trust fallback_status="completed" here; route to
         # the same no-evidence bucket a known-empty child already uses.
         if fallback_status == "completed":

--- a/lionrs/crates/lion-core/src/extract_anchor.rs
+++ b/lionrs/crates/lion-core/src/extract_anchor.rs
@@ -51,7 +51,7 @@ use crate::{
     },
     // Actor and message types
     state::{ActorError, ActorRuntime, Message},
-    // Thread and scheduler types (Issue #111)
+    // Thread and scheduler types
     state::{
         DomainScheduleEntry,
         FaultType,
@@ -68,7 +68,7 @@ use crate::{
         // due to Vec<ThreadTableEntry> where ThreadTableEntry contains deeply nested TCB
         TCB,
     },
-    // Workflow types (Issue #110: WorkflowDef and WorkflowInstance now extractable)
+    // Workflow types (WorkflowDef and WorkflowInstance now extractable)
     state::{
         Edge, NodeState, NodeStateEntry, RetryEntry, WorkflowDef, WorkflowError, WorkflowInstance,
         WorkflowStatus,
@@ -160,7 +160,7 @@ pub fn export_types(
     _host_function: HostFunction,
     _host_call: HostCall,
     _host_result: HostResult,
-    // Workflow types (WorkflowDef + WorkflowInstance newly extractable - Issue #110)
+    // Workflow types (WorkflowDef + WorkflowInstance newly extractable)
     _workflow_status: WorkflowStatus,
     _node_state: NodeState,
     _edge: Edge,
@@ -170,13 +170,13 @@ pub fn export_types(
     _workflow_instance: WorkflowInstance,
     // Policy error (NEW)
     _policy_error: PolicyError,
-    // Kernel operations (NEW - Issue #108)
+    // Kernel operations (NEW)
     _kernel_op: KernelOp,
-    // Authorization errors (NEW - Issue #109)
+    // Authorization errors (NEW)
     _auth_error: AuthorizationError,
-    // Actor runtime (NEW - Issue #112)
+    // Actor runtime (NEW)
     _actor_runtime: ActorRuntime,
-    // Thread/scheduler types (NEW - Issue #111)
+    // Thread/scheduler types (NEW)
     _thread_state: ThreadState,
     _ipc_block_reason: IPCBlockReason,
     _fault_type: FaultType,

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -884,10 +884,7 @@ def test_schedule_run_retention_is_chunked_and_archived(tmp_path, monkeypatch):
 
 
 def test_session_prune_archives_preimages_of_nullified_soft_fk_rows(tmp_path, monkeypatch):
-    """artifacts/dispatch_outbox rows whose session_id gets NULLIFIED by a
-    session prune must have their pre-nullify state captured as a
-    ``preimages/<table>.jsonl`` member -- otherwise a restore permanently
-    orphans them."""
+    """Rows whose session_id a prune nullifies get their pre-nullify state captured, or a restore orphans them permanently."""
     from lionagi.dispatch import enqueue_dispatch
     from lionagi.studio.services import db_maintenance as maint
     from lionagi.studio.services.retention_archive import read_archive_chunk

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -887,7 +887,7 @@ def test_session_prune_archives_preimages_of_nullified_soft_fk_rows(tmp_path, mo
     """artifacts/dispatch_outbox rows whose session_id gets NULLIFIED by a
     session prune must have their pre-nullify state captured as a
     ``preimages/<table>.jsonl`` member -- otherwise a restore permanently
-    orphans them (round-1 critic MAJ finding)."""
+    orphans them."""
     from lionagi.dispatch import enqueue_dispatch
     from lionagi.studio.services import db_maintenance as maint
     from lionagi.studio.services.retention_archive import read_archive_chunk

--- a/tests/apps_studio_server/test_schedule_health.py
+++ b/tests/apps_studio_server/test_schedule_health.py
@@ -275,7 +275,7 @@ def test_failing_threshold_contract_is_exactly_one():
 
 
 async def test_overdue_when_no_execution_within_expected_cadence(temp_db_path):
-    """The #2845 shape: enabled interval schedule, cadence known, but no
+    """Enabled interval schedule, cadence known, but no
     execution evidence in a long time -- overdue regardless of a rosy
     next_fire_at."""
     sid = await _make_schedule(interval_sec=300)

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -3184,10 +3184,9 @@ async def test_live_cli_mirror_run_once_relative_root_produces_resolvable_pointe
 
 
 def test_grep_evidence_live_mirror_paths_call_bound_mirror_content() -> None:
-    """Regression guard for the round-1 gate finding ("zero callers"): the two
-    writers must call the bounding codec directly, and the CLI tailer that
-    feeds them must thread the source-pointer data (byte offsets + the
-    preview-chars budget) into every live write."""
+    """The bounding codec must not end up with zero callers: both writers call
+    it directly, and the CLI tailer feeding them threads the source-pointer data
+    (byte offsets and the preview-chars budget) into every live write."""
     root = Path(__file__).resolve().parents[2] / "lionagi"
     codec_callers = {
         root / "state" / "claude_mirror.py": "claude_mirror.py",

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -3184,9 +3184,7 @@ async def test_live_cli_mirror_run_once_relative_root_produces_resolvable_pointe
 
 
 def test_grep_evidence_live_mirror_paths_call_bound_mirror_content() -> None:
-    """The bounding codec must not end up with zero callers: both writers call
-    it directly, and the CLI tailer feeding them threads the source-pointer data
-    (byte offsets and the preview-chars budget) into every live write."""
+    """The bounding codec must not end up with zero callers: both writers call it directly and the CLI tailer threads the source-pointer data into every live write."""
     root = Path(__file__).resolve().parents[2] / "lionagi"
     codec_callers = {
         root / "state" / "claude_mirror.py": "claude_mirror.py",

--- a/tests/cli/test_scheduler_flow_yaml.py
+++ b/tests/cli/test_scheduler_flow_yaml.py
@@ -378,7 +378,7 @@ def test_flow_yaml_db_roundtrip():
                     f"action_flow_yaml lost on INSERT: got {row['action_flow_yaml']!r}"
                 )
 
-                # UPDATE path (CRIT-2)
+                # UPDATE path
                 updated_spec = "prompt: updated spec\nworkers: 2\n"
                 await db.update_schedule(schedule_id, action_flow_yaml=updated_spec)
                 row2 = await db.get_schedule(schedule_id)

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -17,9 +17,9 @@ from unittest.mock import patch
 
 import pytest
 
-# Real Vite fixture used by the binding/host-selection tests below — these
-# prove claims about actual Vite startup output rather than a hand-built
-# fixture, which round-1 review found could hide a real parsing defect.
+# Real Vite fixture for the binding/host-selection tests below: they prove
+# claims about actual Vite startup output rather than a hand-built fixture,
+# which could hide a real parsing defect.
 _FRONTEND_DIR = Path(__file__).resolve().parents[2] / "apps" / "studio" / "frontend"
 _VITE_BIN = _FRONTEND_DIR / "node_modules" / ".bin" / "vite"
 requires_real_vite = pytest.mark.skipif(

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -17,9 +17,8 @@ from unittest.mock import patch
 
 import pytest
 
-# Real Vite fixture for the binding/host-selection tests below: they prove
-# claims about actual Vite startup output rather than a hand-built fixture,
-# which could hide a real parsing defect.
+# Real Vite fixture, so the binding tests read actual startup output rather
+# than a hand-built one that could hide a parsing defect.
 _FRONTEND_DIR = Path(__file__).resolve().parents[2] / "apps" / "studio" / "frontend"
 _VITE_BIN = _FRONTEND_DIR / "node_modules" / ".bin" / "vite"
 requires_real_vite = pytest.mark.skipif(

--- a/tests/session/test_run_event_contract.py
+++ b/tests/session/test_run_event_contract.py
@@ -29,7 +29,7 @@ from lionagi.session.signal import (
     build_run_end,
 )
 
-# #1539 — schema_version on every signal
+# schema_version on every signal
 
 
 def test_schema_version_constant():
@@ -56,7 +56,7 @@ def test_schema_version_on_run_failed():
     assert RunFailed().schema_version == SIGNAL_SCHEMA_VERSION
 
 
-# #1538 — RunEnd carries usage fields
+# RunEnd carries usage fields
 
 
 def test_run_end_default_usage_fields():
@@ -140,7 +140,7 @@ def test_collect_branch_usage_anthropic_convention():
     assert usage["output_tokens"] == 30
 
 
-# #2889 — cache-token dimensions (Anthropic cache_read/cache_creation,
+# cache-token dimensions (Anthropic cache_read/cache_creation,
 # OpenAI prompt_tokens_details.cached_tokens)
 
 
@@ -239,7 +239,7 @@ def test_collect_multi_branch_usage_sums_cache_dimensions():
     assert usage["cache_write_tokens"] == 10
 
 
-# #2379 — claude_code whole-agent-tree usage: a per-model modelUsage
+# claude_code whole-agent-tree usage: a per-model modelUsage
 # breakdown (subagent spend included) must be preferred over the flat,
 # top-level-loop-only usage dict when both are present on the same message.
 
@@ -629,7 +629,7 @@ def test_collect_multi_branch_usage_skips_branches_that_raise():
     assert usage["output_tokens"] == 5
 
 
-# #1537 — NodeSpawned exists and carries expected fields
+# NodeSpawned exists and carries expected fields
 
 
 def test_node_spawned_defaults():
@@ -676,7 +676,7 @@ def test_node_lifecycle_signals_parent_defaults_none():
         assert sig.depends_on == []
 
 
-# #1540 — HookSignal suppressed for MESSAGE_ADD; other points still recorded
+# HookSignal suppressed for MESSAGE_ADD; other points still recorded
 
 
 @pytest.mark.asyncio

--- a/tests/state/test_dual_backend.py
+++ b/tests/state/test_dual_backend.py
@@ -1723,7 +1723,7 @@ async def test_postgres_attach_session_invocation_decrements_off_the_value_a_con
     read old immediately (the holder hasn't committed yet), block later on
     the UPDATE's implicit row lock instead, and decrement old after its own
     WHERE clause re-evaluates against the post-commit row — leaving mid's
-    count stale at 1, exactly the round-2 finding.
+    count stale at 1.
     """
     import asyncio
 

--- a/tests/state/test_dual_backend.py
+++ b/tests/state/test_dual_backend.py
@@ -1709,22 +1709,7 @@ async def test_postgres_teardown_gives_up_rather_than_deadlocking_after_it_holds
 async def test_postgres_attach_session_invocation_decrements_off_the_value_a_concurrent_repoint_left(
     pg_url,
 ):
-    """A concurrent attach must decrement the invocation another attach's
-    still-open transaction actually left the session on, not the value it
-    read before that transaction committed.
-
-    A holder connection takes the session row's lock and repoints it
-    old -> mid — the same statements ``attach_session_invocation`` runs —
-    without committing, standing in for a first attach still in flight. A
-    concurrent ``attach_session_invocation(sid, new)`` call must block on
-    that lock (proving the fix takes it at all) rather than reading old's
-    invocation_id straight through; once the holder commits, it must resolve
-    against mid. Without the ``FOR UPDATE`` fix, the unlocked SELECT would
-    read old immediately (the holder hasn't committed yet), block later on
-    the UPDATE's implicit row lock instead, and decrement old after its own
-    WHERE clause re-evaluates against the post-commit row — leaving mid's
-    count stale at 1.
-    """
+    """A concurrent attach decrements the invocation another attach left the session on, not the value it read before that transaction committed."""
     import asyncio
 
     from sqlalchemy import text as _text


### PR DESCRIPTION
Source comments should say why the code is the way it is, not point at a
tracker. This removes the references that were doing the latter.

Two shapes were in the tree:

- Process vocabulary in docstrings and comments, which said which pass of
  review produced a guard rather than what the guard protects. Those
  docstrings are also cut to one line each.
- Bare issue and PR numbers, in the frontend, the providers, the lionbench
  harvest and the Rust core. Each is reworded to state the reason inline.

Issue-shaped strings that are test data stay. The harvest tests feed them to
the scrubber and assert on the result, and the benchmark instance fixtures key
on their source PR, so those are values rather than references.
