### PR TITLE
fix(cli): read a completed run's degradation from the outcome envelope

### DIFF
--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -444,12 +444,9 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
     if _emission_failures:
         emission_error = "emission_missing: " + "; ".join(_emission_failures)
 
-    # A degraded run reached a result without all of its work. The engine says
-    # so on the result object, and nothing downstream was reading it: the row
-    # persisted as "completed" with no trace of what was skipped, which is the
-    # same shape as a run that did everything. Joined to the same field the
-    # emission diagnostics use, which already carries this kind of non-fatal
-    # detail on a completed row.
+    # A degraded run reached a result without all of its work. The outcome
+    # envelope carries it on a completed row; this text is for the terminal and
+    # for the error column a total agent failure does write.
     _degraded: bool = bool(getattr(result, "degraded", False))
     _degrade_reason: str = str(getattr(result, "degrade_reason", "") or "")
     _skipped: list[str] = list(getattr(result, "skipped", []) or [])

--- a/tests/cli/test_engine_emission_diagnostics.py
+++ b/tests/cli/test_engine_emission_diagnostics.py
@@ -573,8 +573,14 @@ async def test_a_degraded_run_says_so_in_its_output_and_its_row(monkeypatch, cap
 
     completed = [c for c in mock_db.update_calls if c["status"] == "completed"]
     assert completed, f"no completed update; calls={mock_db.update_calls}"
-    assert "degraded" in (completed[0]["error"] or "")
-    assert "security" in (completed[0]["error"] or "")
+    # Degradation is not a terminal error, so it rides the outcome envelope and
+    # the completed row's error stays NULL.
+    assert completed[0]["error"] is None
+    assert len(mock_db.outcome_calls) == 1
+    outcome = mock_db.outcome_calls[0]["outcome"]
+    assert outcome["degraded"] is True
+    assert "ProviderAuthError" in outcome["degrade_reason"]
+    assert outcome["skipped"] == ["security"]
 
     assert any("degraded" in w for w in warnings), f"no warning emitted; warnings={warnings}"
     assert rc == 0  # it did produce a result; the caller decides what that is worth


### PR DESCRIPTION
main is red on `test_a_degraded_run_says_so_in_its_output_and_its_row`, on 3.10 through 3.14.

## What happened

Two changes landed that each read correctly on their own branch and contradict each other once merged.

One narrowed the completed row's `error` column so it is written only on a total agent failure, on the principle that a completed run should not carry an error string. The other added a test asserting that same column carries the degradation text. The two edits sit far apart in `lionagi/cli/engine.py`, so git merged them cleanly and the incoherence appeared only in CI.

The code even says both things. One comment reads "completed rows keep error NULL"; six lines later another claims the field "already carries this kind of non-fatal detail on a completed row". The second stopped being true when the first landed.

## Which one is right

The narrowing is the deliberate contract, and the sibling test directly above states it: emission loss is a completed degradation, not a terminal error. That test asserts `error is None` on the completed row and reads the degradation from the outcome envelope, which already carries `degraded`, `degrade_reason` and `skipped` as structured fields rather than as substrings of an error message.

So the new test now reads it there too. Its purpose is unchanged and still enforced: a caller can tell a run that did all of its work from one that skipped a dimension. The stored row does say so, in a field that is not named `error`.

The misleading comment is corrected in the same change.

## Evidence

`tests/cli/test_engine_emission_diagnostics.py` 12 passed. `tests/cli` 3250 passed with three failures, none of them this: two are pre-existing and fail identically on unmodified main, and the third is a timing test that passes in isolation twice and only fails under full-suite parallel load.

Mutation arm: forcing the outcome's `degraded` flag to false reddens three tests including this one, so the assertion cannot be satisfied by the envelope merely existing. Predicted two, observed three; the extra is in the same blast radius, since emission failures feed `skipped` which feeds `degraded`.