### PR TITLE
test(studio): scope the operator echo assertions to the transcript

### DIFF
--- a/apps/studio/frontend/e2e/operator.spec.ts
+++ b/apps/studio/frontend/e2e/operator.spec.ts
@@ -41,6 +41,11 @@ test.beforeEach(async ({ page }) => {
   );
 });
 
+/** What the operator typed, as the transcript shows it back rather than as the composer still holds it. */
+function userSaid(page: Page, text: string) {
+  return page.getByLabel("You").getByText(text, { exact: true });
+}
+
 test("Operator streams, persists, stops, records a run, and resumes it", async ({ page }) => {
   test.setTimeout(45_000);
   const discovery = page.waitForResponse(
@@ -60,7 +65,10 @@ test("Operator streams, persists, stops, records a run, and resumes it", async (
   await instruction.fill("Show me the fleet readiness.");
   await page.getByRole("button", { name: "Send", exact: true }).click();
 
-  await expect(page.getByText("Show me the fleet readiness.", { exact: true })).toBeVisible();
+  // The composer keeps what was typed until the submit resolves, so an
+  // unscoped match on the echoed text sees the textarea as well as the bubble
+  // and fails on strict mode whenever the assertion wins that race.
+  await expect(userSaid(page, "Show me the fleet readiness.")).toBeVisible();
   await expect(page.getByText("Fleet ready.", { exact: true })).toBeVisible({
     timeout: 20_000,
   });
@@ -72,7 +80,7 @@ test("Operator streams, persists, stops, records a run, and resumes it", async (
   expect(runHref).toMatch(/^\/fleet\?s=.+/);
 
   await page.reload();
-  await expect(page.getByText("Show me the fleet readiness.", { exact: true })).toBeVisible();
+  await expect(userSaid(page, "Show me the fleet readiness.")).toBeVisible();
   await expect(page.getByText("Fleet ready.", { exact: true })).toBeVisible();
 
   await instruction.fill("wait until I stop you");


### PR DESCRIPTION
## Summary

The `studio-e2e` job fails on `operator.spec.ts:63` with a strict-mode violation. The composer keeps what was typed until the submit resolves and only then clears it, so between the click and the response the same text is in the textarea and in the transcript bubble. Playwright's own message enumerated the two elements: the message `<p>` and the disabled instruction `<textarea>`.

Both assertions on echoed user text now read the transcript bubble instead of the whole page.

## Scope

Test only. No production behavior changes.

The other place a filled value is asserted, the follow-up on the run pane, is already scoped to main content and runs after navigating away, so it is left alone.

## Validation

- `npm run e2e -- e2e/operator.spec.ts` locally: 4 passed.
- Prettier, eslint and typecheck clean.
- The race does not reproduce locally with the unscoped form, since the submit resolves before the assertion runs here. The evidence for the defect is the CI job's own output naming both matching elements, not a local reproduction.