### PR TITLE
docs(studio): drop the duplicated max-runs budget entry

### DIFF
--- a/docs/internals/studio.md
+++ b/docs/internals/studio.md
@@ -169,50 +169,6 @@ Only top-level fires (`chain_depth == 0`) of a threshold-configured schedule
 stamp the cooldown; `on_success`/`on_fail` chain children are follow-on
 actions of the same alert cycle, not a new one.
 
-**`_reserve_max_runs_budget`** — reserves one top-level fire against a
-schedule's `max_runs` cap. A fire consumes budget the instant it fires, not
-when it resolves, so the count it checks is `fired + inflight`: `fired` is
-the persisted count of `running`-or-terminal `schedule_run` rows, and
-`inflight` is an in-process counter of fires that have claimed budget but
-whose occurrence row has not yet committed. The two are disjoint views of
-the same fire — a claim is released the moment the occurrence row lands —
-so summing them counts each fire exactly once, except for a brief instant
-during the handoff where a fire can appear in both; that only ever
-over-counts, which just causes a spurious refusal that self-corrects on the
-next tick. Only one scheduler process runs today, so this reservation is
-in-memory (an `asyncio.Lock`-guarded dict), not a database compare-and-set.
-
-The order of the two reads inside that lock is the load-bearing part.
-`inflight` is read *before* the `await` on `count_schedule_runs()`, not
-after. `release()` (called from `_fire()`'s `finally` block on every exit
-path, so a claim always gets freed even from a cancelled or failing fire)
-does not take the lock — it must work even while a fire is mid-cancellation,
-where acquiring a lock from a `finally` block risks a deadlock. That makes
-it possible for a concurrent fire to release its claim *while this call is
-suspended awaiting the database*. If `inflight` were read after that await,
-a fire that both writes its occurrence row and releases its claim entirely
-inside the suspended window would vanish from both counts at once: too late
-for the in-flight snapshot (already released) and too early for the
-persisted count (the read started before the write landed) — letting a
-bounded schedule fire one more time than `max_runs` allows. Reading
-`inflight` first means it still captures that other fire's claim before it
-can disappear, so the sum can only ever over-count, never under-count.
-
-`_tick()`'s ad-hoc task-worker pass runs single-flight: a second `_tick()`
-firing while the first pass is still in progress must not start a second
-pass, and must not await the first pass either — a slow or hung worker pass
-would otherwise stall every schedule's due-time evaluation for the whole
-tick. `_tick()` starts the pass as a background task and returns promptly
-regardless of whether it is still running.
-
-`resolve_terminal` (child-session outcome inference) does not trust a
-leader process's exit code as evidence that a still-running child session's
-own work has finished — the terminal stamp comes from the leader's stderr
-pipe closing, not from the child's work actually ending. A child session
-that has not reached any terminal status of its own is reported as
-`completed_empty` (no positive evidence) rather than being inferred as
-`completed`.
-
 ## lionagi/studio/scheduler/subprocess.py
 
 **`spawn_and_wait`** — Both stdout/stderr streams are captured and drained


### PR DESCRIPTION
`docs/internals/studio.md` described `_reserve_max_runs_budget` twice: once
under the engine section and again, byte identical, under the
admission-and-dispatch section it had been moved to. A merge kept both copies.

This removes the stale copy under the older section and leaves the one where
the entry now lives. Documentation only.