### PR TITLE
test(adapters): guard the postgres test on the module it imports

### DIFF
--- a/tests/adapters/test_async_postgres_adapter.py
+++ b/tests/adapters/test_async_postgres_adapter.py
@@ -40,7 +40,11 @@ async def test_async_postgres_to_obj_ensures_table_for_dsn_before_delegating(
     monkeypatch,
 ):
     """Requires lionagi[postgres] extra (pydapter[postgres], sqlalchemy, asyncpg)."""
-    pytest.importorskip("sqlalchemy", reason="requires lionagi[postgres] extra")
+    # The module the body imports, not one of its dependencies: sqlalchemy is
+    # present without the extra, so guarding on it lets the import below raise.
+    pytest.importorskip(
+        "pydapter.extras.async_postgres_", reason="requires lionagi[postgres] extra"
+    )
 
     from unittest.mock import AsyncMock
 

--- a/tests/adapters/test_async_postgres_adapter.py
+++ b/tests/adapters/test_async_postgres_adapter.py
@@ -40,15 +40,15 @@ async def test_async_postgres_to_obj_ensures_table_for_dsn_before_delegating(
     monkeypatch,
 ):
     """Requires lionagi[postgres] extra (pydapter[postgres], sqlalchemy, asyncpg)."""
-    # The module the body imports, not one of its dependencies: sqlalchemy is
+    # The module the body needs, not one of its dependencies: sqlalchemy is
     # present without the extra, so guarding on it lets the import below raise.
-    pytest.importorskip(
+    # The returned module is what the body uses, so the path is named once.
+    async_postgres_ = pytest.importorskip(
         "pydapter.extras.async_postgres_", reason="requires lionagi[postgres] extra"
     )
+    AsyncPostgresAdapter = async_postgres_.AsyncPostgresAdapter
 
     from unittest.mock import AsyncMock
-
-    from pydapter.extras.async_postgres_ import AsyncPostgresAdapter
 
     from lionagi.adapters.async_postgres_adapter import (
         create_lionagi_async_postgres_adapter,


### PR DESCRIPTION
`pytest.importorskip("sqlalchemy")` guarded a test whose body imports
`pydapter.extras.async_postgres_`. sqlalchemy is installed without the postgres
extra, so the guard passed and the import raised: the test errored where it was
meant to skip, on every run that lacks the extra.

The guard now names the module the body imports. Verified mechanically rather
than by eye — every optional third-party import in the file is covered by a
guard naming it or its parent — so the test skips exactly when the extra is
absent and runs when it is present, rather than being silenced.
