### PR TITLE
ci: check Python formatting in the lint step

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -31,6 +31,15 @@ lint-python() {
   else
     uv run ruff check "$@"
   fi
+  # --check, never the writing form: fmt-python is where formatting is applied.
+  # Without this a file can sit unformatted on main indefinitely, since the
+  # pre-commit hook only ever sees files someone is committing.
+  echo "==> ruff format --check"
+  if [ $# -eq 0 ]; then
+    uv run ruff format --check lionagi/ apps/ tests/ marketplace/ scripts/
+  else
+    uv run ruff format --check "$@"
+  fi
 }
 
 lint-quarantine() {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -25,21 +25,19 @@ _require() {
 # ---------------------------------------------------------------------------
 
 lint-python() {
-  echo "==> ruff check"
+  # One list for both steps, or a directory added later reaches one of them and
+  # is silently left out of the other.
+  local paths=("$@")
   if [ $# -eq 0 ]; then
-    uv run ruff check lionagi/ apps/ tests/ marketplace/ scripts/
-  else
-    uv run ruff check "$@"
+    paths=(lionagi/ apps/ tests/ marketplace/ scripts/)
   fi
+  echo "==> ruff check"
+  uv run ruff check "${paths[@]}"
   # --check, never the writing form: fmt-python is where formatting is applied.
   # Without this a file can sit unformatted on main indefinitely, since the
   # pre-commit hook only ever sees files someone is committing.
   echo "==> ruff format --check"
-  if [ $# -eq 0 ]; then
-    uv run ruff format --check lionagi/ apps/ tests/ marketplace/ scripts/
-  else
-    uv run ruff format --check "$@"
-  fi
+  uv run ruff format --check "${paths[@]}"
 }
 
 lint-quarantine() {

--- a/tests/cli/test_schedule_cli_route_drift.py
+++ b/tests/cli/test_schedule_cli_route_drift.py
@@ -60,9 +60,7 @@ class _FakeResponse:
         return self._body
 
 
-def _run_and_capture(
-    monkeypatch, args: argparse.Namespace
-) -> tuple[str, str, str | None]:
+def _run_and_capture(monkeypatch, args: argparse.Namespace) -> tuple[str, str, str | None]:
     """Run a real `li schedule` dispatch, capturing the request the
     CLI's _api() helper would have sent — without any real network I/O."""
     from lionagi.studio.cli import run_schedule
@@ -119,6 +117,5 @@ def test_schedule_cli_paths_are_served(monkeypatch, argv):
     )
     if method not in {"GET", "HEAD", "OPTIONS"}:
         assert content_type == "application/json", (
-            f"li schedule {argv[1]} sends unsafe {method} without declaring "
-            "application/json"
+            f"li schedule {argv[1]} sends unsafe {method} without declaring application/json"
         )


### PR DESCRIPTION
The `lint` job ran `ruff check` but never `ruff format --check`, so nothing in
CI could see a formatting drift. The pre-commit hook formats, but it only ever
sees files someone is committing, so a file that drifted stays drifted.

One file had: `tests/cli/test_schedule_cli_route_drift.py`. The other 1490 over
the lint step's own path list are already formatted, so the new check goes green
on everything else.

Both halves are in this change because either alone leaves the tree red: the
check without the reformat fails immediately, and the reformat without the check
would drift again. Verified in both directions — with the reformat the step exits
0, and restoring the file's previous contents makes it exit 1.

`--check`, never the writing form; applying formatting stays in `fmt-python`.
