### PR TITLE
fix(studio): make the due cursor a claim so two schedulers cannot dispatch one occurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   selected on: the advance runs first with a compare-and-swap on `next_fire_at`, the occurrence is
   written only if the claim holds, and the scheduler that loses it writes nothing and cancels its
   own invocation with a reason naming what happened. The same claim refuses a fire whose cursor an
-  operator moved between selection and dispatch.
+  operator moved between selection and dispatch. Fires that do not stand for a due instant, such as
+  chain children and manual triggers, say so explicitly and keep the guarantees they already had.
 - `Params` subclasses now receive their declared dataclass defaults, including a fresh value
   from each `default_factory`, instead of replacing every omitted field with `Unset`. `Params`
   and `DataClass` now discover inherited instance fields through one ordered dataclass path,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Two studio schedulers running against one database could each dispatch the same occurrence.
+  The tick selects due schedules and fires them in separate statements, and every admission gate
+  between the two lives in the firing process's own memory, so both processes committed, each with
+  its own run id and each launching a child. The occurrence write now claims the cursor it was
+  selected on: the advance runs first with a compare-and-swap on `next_fire_at`, the occurrence is
+  written only if the claim holds, and the scheduler that loses it writes nothing and cancels its
+  own invocation with a reason naming what happened. The same claim refuses a fire whose cursor an
+  operator moved between selection and dispatch.
 - `Params` subclasses now receive their declared dataclass defaults, including a fresh value
   from each `default_factory`, instead of replacing every omitted field with `Unset`. `Params`
   and `DataClass` now discover inherited instance fields through one ordered dataclass path,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   own invocation with a reason naming what happened. The same claim refuses a fire whose cursor an
   operator moved between selection and dispatch. Fires that do not stand for a due instant, such as
   chain children and manual triggers, say so explicitly and keep the guarantees they already had.
+  A GitHub poll batch claims `github_cursor` per event rather than `next_fire_at`, because every
+  event of one batch resolves to the same `next_fire_at` and a claim on an unchanging value matches
+  twice; `github_cursor` advances per event and is what separates them, so a second scheduler that
+  polls after this one commits an earlier event can no longer dispatch a later one twice.
 - `Params` subclasses now receive their declared dataclass defaults, including a fresh value
   from each `default_factory`, instead of replacing every omitted field with `Unset`. `Params`
   and `DataClass` now discover inherited instance fields through one ordered dataclass path,

--- a/docs/internals/state-db.md
+++ b/docs/internals/state-db.md
@@ -430,9 +430,18 @@ finished, a manual trigger runs because a person asked, and a startup re-fire
 replaces an occurrence whose cursor already moved; those pass `NO_CURSOR_CLAIM`
 and are guarded by their own mechanisms, the CAS-tombstone of the orphan row in
 the re-fire's case. A `github_poll` batch is one due instant however many events
-it carries: the first dispatched event claims it, and the rest are separated by
-`github_cursor`, which is monotonic and advances in the same transaction as each
-event's occurrence. Missed-fire recovery reserves the cursor itself before
+it carries: the first dispatched event claims it, and the rest are separated by a
+claim on `github_cursor` instead. That second claim is not a convenience. Every
+event of one batch resolves to the same `next_fire_at`, so claiming that value
+would either refuse every event after the first or, since the value does not
+change between them, match twice and separate nothing. `github_cursor` advances
+per event, in the same transaction as that event's occurrence, and is the only
+value in the row that tells one event of a batch from the next. Without the claim
+the column is written but never read, which leaves a window: a second scheduler
+polling after this one commits event 1 reads the advanced cursor, starts its poll
+at event 2, and dispatches it while this one has not reached it yet. The claim
+follows what was written, not how far the poll has read, because a filtered-out
+event moves the read position without writing anything. Missed-fire recovery reserves the cursor itself before
 dispatching, so its reserve is where it claims the instant, and the fire that
 follows claims the value the reserve wrote rather than the pre-reserve value its
 local snapshot still holds.

--- a/docs/internals/state-db.md
+++ b/docs/internals/state-db.md
@@ -418,6 +418,25 @@ of silently claiming nothing. It bounds the race it names and no more: if the
 update carries no new `next_fire_at`, the cursor does not move and the next
 caller holds the same claim.
 
+The predicate is spelled as a branch on the Python value, `IS NULL` for a claim
+of nothing and `= :param` otherwise, rather than as a single NULL-safe operator.
+`IS` accepts a bound parameter in sqlite and is a syntax error in postgres, and
+their common spelling, `IS NOT DISTINCT FROM`, is newer than the sqlite versions
+this project still runs against. The dual-backend tests skip without `asyncpg`
+installed, so the shape of the generated statement is asserted directly.
+
+Not every fire claims a due instant. A chain child runs because its parent
+finished, a manual trigger runs because a person asked, and a startup re-fire
+replaces an occurrence whose cursor already moved; those pass `NO_CURSOR_CLAIM`
+and are guarded by their own mechanisms, the CAS-tombstone of the orphan row in
+the re-fire's case. A `github_poll` batch is one due instant however many events
+it carries: the first dispatched event claims it, and the rest are separated by
+`github_cursor`, which is monotonic and advances in the same transaction as each
+event's occurrence. Missed-fire recovery reserves the cursor itself before
+dispatching, so its reserve is where it claims the instant, and the fire that
+follows claims the value the reserve wrote rather than the pre-reserve value its
+local snapshot still holds.
+
 `_build_update_schedule_stmt` is the single choke point for both the field
 allowlist and the SQL shape, shared by `update_schedule` and by the folded-in
 update inside `create_schedule_run_and_advance`, so the two write paths cannot

--- a/docs/internals/state-db.md
+++ b/docs/internals/state-db.md
@@ -405,6 +405,19 @@ owning schedule's cursor together, so a crash can only discard an occurrence
 that was never durably recorded. It can never leave the cursor pointing before
 one that was, which would make a restart re-fire it.
 
+The cursor advance also carries `expect_next_fire_at`, and it runs first: the
+occurrence is written only if the schedule still holds the cursor the caller
+selected on, and a caller that lost it gets `False` having written nothing.
+Selecting a due schedule and firing it are separate statements, and every
+admission gate above this one lives in the firing process's own memory, so
+without this predicate two schedulers reading one due row both commit, each
+with its own run id and each launching a child. The predicate is NULL-safe
+because a schedule with no cursor is a real state, and it is required rather
+than defaulted so that a new caller has to decide what it is claiming instead
+of silently claiming nothing. It bounds the race it names and no more: if the
+update carries no new `next_fire_at`, the cursor does not move and the next
+caller holds the same claim.
+
 `_build_update_schedule_stmt` is the single choke point for both the field
 allowlist and the SQL shape, shared by `update_schedule` and by the folded-in
 update inside `create_schedule_run_and_advance`, so the two write paths cannot

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -3727,18 +3727,25 @@ class StateDB:
         *,
         guard_cursor_forward: bool = False,
         expect_next_fire_at: Any = NO_CURSOR_CLAIM,
+        expect_github_cursor: Any = NO_CURSOR_CLAIM,
         **fields: Any,
     ) -> bool:
         """Update one schedule; returns whether a row matched.
 
         With *expect_next_fire_at* the update also claims that cursor value, so a caller that
         reserves a due instant ahead of dispatching it learns whether it won the reservation.
+
+        *expect_github_cursor* claims the poll cursor the same way, which is what serializes the
+        events inside one poll batch. A batch's events all resolve to the same next_fire_at, so a
+        claim on that value matches twice and separates nothing; github_cursor advances per event
+        and is the only value in the row that distinguishes one event of a batch from the next.
         """
         stmt, params = self._build_update_schedule_stmt(
             schedule_id,
             fields,
             guard_cursor_forward=guard_cursor_forward,
             expect_next_fire_at=expect_next_fire_at,
+            expect_github_cursor=expect_github_cursor,
         )
         async with self._tx() as conn:
             result = await conn.execute(stmt, params)
@@ -3752,6 +3759,7 @@ class StateDB:
         *,
         guard_cursor_forward: bool = False,
         expect_next_fire_at: Any = NO_CURSOR_CLAIM,
+        expect_github_cursor: Any = NO_CURSOR_CLAIM,
     ):
         """Validate and build the ``UPDATE schedules`` statement and params, no transaction."""
         bad = set(fields) - cls._SCHEDULE_UPDATE_ALLOWED_FIELDS
@@ -3794,16 +3802,22 @@ class StateDB:
         params = dict(fields)
         params["_id"] = schedule_id
         where = "id = :_id"
-        if expect_next_fire_at is not NO_CURSOR_CLAIM:
-            # Branching on the Python value rather than emitting a NULL-safe operator: sqlite
-            # spells one `IS`, postgres rejects `IS` with a bound parameter outright, and their
-            # shared spelling (`IS NOT DISTINCT FROM`) is too new to rely on. A schedule with no
-            # cursor is still guarded on the same terms as one that has it.
-            if expect_next_fire_at is None:
-                where += " AND next_fire_at IS NULL"
+        # One loop rather than a block per column, so a second claim cannot be given subtly
+        # different NULL handling from the first. Branching on the Python value rather than
+        # emitting a NULL-safe operator: sqlite spells one `IS`, postgres rejects `IS` with a
+        # bound parameter outright, and their shared spelling (`IS NOT DISTINCT FROM`) is too
+        # new to rely on. A schedule with no cursor is guarded on the same terms as one with it.
+        for column, expected, bind in (
+            ("next_fire_at", expect_next_fire_at, "_expect_nfa"),
+            ("github_cursor", expect_github_cursor, "_expect_ghc"),
+        ):
+            if expected is NO_CURSOR_CLAIM:
+                continue
+            if expected is None:
+                where += f" AND {column} IS NULL"
             else:
-                where += " AND next_fire_at = :_expect_nfa"
-                params["_expect_nfa"] = expect_next_fire_at
+                where += f" AND {column} = :{bind}"
+                params[bind] = expected
         stmt = text(f"UPDATE schedules SET {', '.join(sets_parts)} WHERE {where}")  # noqa: S608
         if bind_params:
             stmt = stmt.bindparams(*bind_params)
@@ -3874,12 +3888,14 @@ class StateDB:
         schedule_id: str,
         schedule_fields: dict[str, Any],
         expect_next_fire_at: Any,
+        expect_github_cursor: Any = NO_CURSOR_CLAIM,
     ) -> bool:
         """Insert one occurrence row and advance the schedule's cursor in a single transaction.
 
-        Returns False when *expect_next_fire_at* no longer matches, having written nothing.
-        Pass ``NO_CURSOR_CLAIM`` for a fire that does not stand for a due instant, such as a
-        chain child or a replacement for an occurrence already recorded.
+        Returns False when a claim no longer matches, having written nothing. Pass
+        ``NO_CURSOR_CLAIM`` for a fire that does not stand for a due instant, such as a chain
+        child or a replacement for an occurrence already recorded. *expect_github_cursor* is the
+        per-event claim a poll batch needs, since every event in one batch shares a due instant.
         """
         run_stmt, run_params = self._build_schedule_run_insert_stmt(run)
         # Engine-only path, so the monotonic cursor guard always applies: this value came from a
@@ -3889,6 +3905,7 @@ class StateDB:
             schedule_fields,
             guard_cursor_forward=True,
             expect_next_fire_at=expect_next_fire_at,
+            expect_github_cursor=expect_github_cursor,
         )
         async with self._tx() as conn:
             # The cursor claim goes FIRST so a lost race writes no occurrence at all. Selecting a

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -127,8 +127,9 @@ def _default_reason_code_for_entity_status(entity_type: str, status: str) -> str
 _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
 
-# Distinguishes "no cursor predicate" from a predicate whose expected value is NULL.
-_NO_CURSOR_PREDICATE = object()
+# Distinguishes "this write claims no due instant" from "it claims one whose value is NULL".
+# Public because callers several layers up have to state which of the two they mean.
+NO_CURSOR_CLAIM = object()
 
 # Shape of the schema this code applies; ``_apply_schema`` stamps it into ``schema_meta.version`` on
 # every open, so the recorded version describes the database after migrations. Bump it whenever a
@@ -3721,13 +3722,27 @@ class StateDB:
     )
 
     async def update_schedule(
-        self, schedule_id: str, *, guard_cursor_forward: bool = False, **fields: Any
-    ) -> None:
+        self,
+        schedule_id: str,
+        *,
+        guard_cursor_forward: bool = False,
+        expect_next_fire_at: Any = NO_CURSOR_CLAIM,
+        **fields: Any,
+    ) -> bool:
+        """Update one schedule; returns whether a row matched.
+
+        With *expect_next_fire_at* the update also claims that cursor value, so a caller that
+        reserves a due instant ahead of dispatching it learns whether it won the reservation.
+        """
         stmt, params = self._build_update_schedule_stmt(
-            schedule_id, fields, guard_cursor_forward=guard_cursor_forward
+            schedule_id,
+            fields,
+            guard_cursor_forward=guard_cursor_forward,
+            expect_next_fire_at=expect_next_fire_at,
         )
         async with self._tx() as conn:
-            await conn.execute(stmt, params)
+            result = await conn.execute(stmt, params)
+        return result.rowcount > 0
 
     @classmethod
     def _build_update_schedule_stmt(
@@ -3736,7 +3751,7 @@ class StateDB:
         fields: dict[str, Any],
         *,
         guard_cursor_forward: bool = False,
-        expect_next_fire_at: Any = _NO_CURSOR_PREDICATE,
+        expect_next_fire_at: Any = NO_CURSOR_CLAIM,
     ):
         """Validate and build the ``UPDATE schedules`` statement and params, no transaction."""
         bad = set(fields) - cls._SCHEDULE_UPDATE_ALLOWED_FIELDS
@@ -3779,11 +3794,16 @@ class StateDB:
         params = dict(fields)
         params["_id"] = schedule_id
         where = "id = :_id"
-        if expect_next_fire_at is not _NO_CURSOR_PREDICATE:
-            # NULL-safe on purpose: IS compares NULL to NULL, so a schedule with no cursor is
-            # guarded on the same terms as one that has it.
-            where += " AND next_fire_at IS :_expect_nfa"
-            params["_expect_nfa"] = expect_next_fire_at
+        if expect_next_fire_at is not NO_CURSOR_CLAIM:
+            # Branching on the Python value rather than emitting a NULL-safe operator: sqlite
+            # spells one `IS`, postgres rejects `IS` with a bound parameter outright, and their
+            # shared spelling (`IS NOT DISTINCT FROM`) is too new to rely on. A schedule with no
+            # cursor is still guarded on the same terms as one that has it.
+            if expect_next_fire_at is None:
+                where += " AND next_fire_at IS NULL"
+            else:
+                where += " AND next_fire_at = :_expect_nfa"
+                params["_expect_nfa"] = expect_next_fire_at
         stmt = text(f"UPDATE schedules SET {', '.join(sets_parts)} WHERE {where}")  # noqa: S608
         if bind_params:
             stmt = stmt.bindparams(*bind_params)
@@ -3853,11 +3873,13 @@ class StateDB:
         *,
         schedule_id: str,
         schedule_fields: dict[str, Any],
-        expect_next_fire_at: float | None,
+        expect_next_fire_at: Any,
     ) -> bool:
         """Insert one occurrence row and advance the schedule's cursor in a single transaction.
 
         Returns False when *expect_next_fire_at* no longer matches, having written nothing.
+        Pass ``NO_CURSOR_CLAIM`` for a fire that does not stand for a due instant, such as a
+        chain child or a replacement for an occurrence already recorded.
         """
         run_stmt, run_params = self._build_schedule_run_insert_stmt(run)
         # Engine-only path, so the monotonic cursor guard always applies: this value came from a

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -127,9 +127,24 @@ def _default_reason_code_for_entity_status(entity_type: str, status: str) -> str
 _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
 
+
+class NoCursorClaim:
+    """The type of :data:`NO_CURSOR_CLAIM`, so a claim is not typed as ``Any`` end to end."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "NO_CURSOR_CLAIM"
+
+
 # Distinguishes "this write claims no due instant" from "it claims one whose value is NULL".
 # Public because callers several layers up have to state which of the two they mean.
-NO_CURSOR_CLAIM = object()
+NO_CURSOR_CLAIM = NoCursorClaim()
+
+# What a caller may claim a cursor column still holds: the value it read, including NULL, or
+# the sentinel for a write that claims nothing. Spelled out so a reader of any of the three
+# layers that forward it can tell a cursor value from a missing claim.
+CursorClaim = float | str | None | NoCursorClaim
 
 # Shape of the schema this code applies; ``_apply_schema`` stamps it into ``schema_meta.version`` on
 # every open, so the recorded version describes the database after migrations. Bump it whenever a
@@ -3726,8 +3741,8 @@ class StateDB:
         schedule_id: str,
         *,
         guard_cursor_forward: bool = False,
-        expect_next_fire_at: Any = NO_CURSOR_CLAIM,
-        expect_github_cursor: Any = NO_CURSOR_CLAIM,
+        expect_next_fire_at: CursorClaim = NO_CURSOR_CLAIM,
+        expect_github_cursor: CursorClaim = NO_CURSOR_CLAIM,
         **fields: Any,
     ) -> bool:
         """Update one schedule; returns whether a row matched.
@@ -3758,8 +3773,8 @@ class StateDB:
         fields: dict[str, Any],
         *,
         guard_cursor_forward: bool = False,
-        expect_next_fire_at: Any = NO_CURSOR_CLAIM,
-        expect_github_cursor: Any = NO_CURSOR_CLAIM,
+        expect_next_fire_at: CursorClaim = NO_CURSOR_CLAIM,
+        expect_github_cursor: CursorClaim = NO_CURSOR_CLAIM,
     ):
         """Validate and build the ``UPDATE schedules`` statement and params, no transaction."""
         bad = set(fields) - cls._SCHEDULE_UPDATE_ALLOWED_FIELDS
@@ -3887,8 +3902,8 @@ class StateDB:
         *,
         schedule_id: str,
         schedule_fields: dict[str, Any],
-        expect_next_fire_at: Any,
-        expect_github_cursor: Any = NO_CURSOR_CLAIM,
+        expect_next_fire_at: CursorClaim,
+        expect_github_cursor: CursorClaim = NO_CURSOR_CLAIM,
     ) -> bool:
         """Insert one occurrence row and advance the schedule's cursor in a single transaction.
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -127,6 +127,9 @@ def _default_reason_code_for_entity_status(entity_type: str, status: str) -> str
 _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
 
+# Distinguishes "no cursor predicate" from a predicate whose expected value is NULL.
+_NO_CURSOR_PREDICATE = object()
+
 # Shape of the schema this code applies; ``_apply_schema`` stamps it into ``schema_meta.version`` on
 # every open, so the recorded version describes the database after migrations. Bump it whenever a
 # migration changes the shape a reader would see.
@@ -3733,6 +3736,7 @@ class StateDB:
         fields: dict[str, Any],
         *,
         guard_cursor_forward: bool = False,
+        expect_next_fire_at: Any = _NO_CURSOR_PREDICATE,
     ):
         """Validate and build the ``UPDATE schedules`` statement and params, no transaction."""
         bad = set(fields) - cls._SCHEDULE_UPDATE_ALLOWED_FIELDS
@@ -3774,7 +3778,13 @@ class StateDB:
                 bind_params.append(bindparam(k, type_=JSON))
         params = dict(fields)
         params["_id"] = schedule_id
-        stmt = text(f"UPDATE schedules SET {', '.join(sets_parts)} WHERE id = :_id")  # noqa: S608
+        where = "id = :_id"
+        if expect_next_fire_at is not _NO_CURSOR_PREDICATE:
+            # NULL-safe on purpose: IS compares NULL to NULL, so a schedule with no cursor is
+            # guarded on the same terms as one that has it.
+            where += " AND next_fire_at IS :_expect_nfa"
+            params["_expect_nfa"] = expect_next_fire_at
+        stmt = text(f"UPDATE schedules SET {', '.join(sets_parts)} WHERE {where}")  # noqa: S608
         if bind_params:
             stmt = stmt.bindparams(*bind_params)
         return stmt, params
@@ -3843,15 +3853,28 @@ class StateDB:
         *,
         schedule_id: str,
         schedule_fields: dict[str, Any],
-    ) -> None:
-        """Insert one occurrence row and advance the schedule's cursor in a single transaction."""
+        expect_next_fire_at: float | None,
+    ) -> bool:
+        """Insert one occurrence row and advance the schedule's cursor in a single transaction.
+
+        Returns False when *expect_next_fire_at* no longer matches, having written nothing.
+        """
         run_stmt, run_params = self._build_schedule_run_insert_stmt(run)
         # Engine-only path, so the monotonic cursor guard always applies: this value came from a
         # poll snapshot and must never walk an operator's move backwards.
         sched_stmt, sched_params = self._build_update_schedule_stmt(
-            schedule_id, schedule_fields, guard_cursor_forward=True
+            schedule_id,
+            schedule_fields,
+            guard_cursor_forward=True,
+            expect_next_fire_at=expect_next_fire_at,
         )
         async with self._tx() as conn:
+            # The cursor claim goes FIRST so a lost race writes no occurrence at all. Selecting a
+            # due schedule and firing it are separate statements, so without this predicate two
+            # schedulers reading one due row both commit, each with its own run id.
+            result = await conn.execute(sched_stmt, sched_params)
+            if result.rowcount == 0:
+                return False
             await conn.execute(run_stmt, run_params)
             await self._initialize_managed_entity_in_tx(
                 conn,
@@ -3860,7 +3883,7 @@ class StateDB:
                 status=run_params["status"],
                 actor_id="create_schedule_run_and_advance",
             )
-            await conn.execute(sched_stmt, sched_params)
+        return True
 
     async def tombstone_and_replace_schedule_run(
         self,

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1242,11 +1242,15 @@ class SchedulerEngine:
             dropped_prs: list[Any] = []
             # One poll cycle is one due instant, however many events it carries. The first event
             # to dispatch claims that instant on behalf of the whole batch; the rest are already
-            # inside a cycle this scheduler won, and each dispatched event advances next_fire_at,
-            # so re-claiming the pre-poll value would refuse every event after the first. What
-            # keeps the later events from double-firing is github_cursor, which is monotonic and
-            # advances in the same transaction as each event's occurrence.
+            # inside a cycle this scheduler won, and every event of a batch resolves to the same
+            # next_fire_at, so re-claiming it would either refuse every event after the first or,
+            # since the value does not change between them, match twice and separate nothing.
+            # github_cursor is what distinguishes one event of a batch from the next: it advances
+            # per event, in the same transaction as that event's occurrence. Claiming it per event
+            # is what stops a second scheduler that polled after this one committed an earlier
+            # event from dispatching a later one this scheduler has not reached yet.
             unclaimed_poll_cycle = True
+            claimed_cursor = schedule.get("github_cursor")
 
             for idx, item in enumerate(polled):
                 if not item.dispatchable:
@@ -1313,9 +1317,14 @@ class SchedulerEngine:
                             if unclaimed_poll_cycle
                             else NO_CURSOR_CLAIM
                         ),
+                        expect_github_cursor=claimed_cursor,
                     )
                     if fired:
                         unclaimed_poll_cycle = False
+                        # Only a written advance moves the claim. Skipped events move the local
+                        # read position below without writing, so following that instead would
+                        # claim a value no transaction ever put in the row.
+                        claimed_cursor = item.updated_at
                     if not fired:
                         # A refusal before a process started means nothing ran, so re-offering the
                         # event is not a re-execution. Bounded, because a refusal can be a property
@@ -1865,6 +1874,7 @@ class SchedulerEngine:
         extra_schedule_fields: dict[str, Any] | None = None,
         supersedes_run_id: str | None = None,
         expect_next_fire_at: Any,
+        expect_github_cursor: Any = NO_CURSOR_CLAIM,
     ) -> bool:
         """Thin wrapper that releases every admission claim on all exit paths.
 
@@ -1885,6 +1895,7 @@ class SchedulerEngine:
                 extra_schedule_fields=extra_schedule_fields,
                 supersedes_run_id=supersedes_run_id,
                 expect_next_fire_at=expect_next_fire_at,
+                expect_github_cursor=expect_github_cursor,
             )
         finally:
             if rate_limit_claim is not None:
@@ -1912,6 +1923,7 @@ class SchedulerEngine:
         schedule_fields: dict[str, Any],
         supersedes_run_id: str | None,
         expect_next_fire_at: Any,
+        expect_github_cursor: Any = NO_CURSOR_CLAIM,
     ) -> bool:
         """Durably record one occurrence row: the choke point both write sites take."""
         if supersedes_run_id is not None:
@@ -1943,6 +1955,7 @@ class SchedulerEngine:
             schedule_id=schedule_id,
             schedule_fields=schedule_fields,
             expect_next_fire_at=expect_next_fire_at,
+            expect_github_cursor=expect_github_cursor,
         )
 
     async def _abandon_refused_fire(
@@ -2015,6 +2028,7 @@ class SchedulerEngine:
         extra_schedule_fields: dict[str, Any] | None = None,
         supersedes_run_id: str | None = None,
         expect_next_fire_at: Any,
+        expect_github_cursor: Any = NO_CURSOR_CLAIM,
     ) -> bool:
         """Fire one occurrence of *schedule*; False only if it refused before anything committed."""
         sid = schedule["id"]
@@ -2125,6 +2139,7 @@ class SchedulerEngine:
                     schedule_fields=failed_schedule_fields,
                     supersedes_run_id=supersedes_run_id,
                     expect_next_fire_at=expect_next_fire_at,
+                    expect_github_cursor=expect_github_cursor,
                 )
                 if not written_occurrence:
                     # Abandon writes the invocation's cancelled terminal status, and the finally
@@ -2236,6 +2251,7 @@ class SchedulerEngine:
                 schedule_fields=update_fields,
                 supersedes_run_id=supersedes_run_id,
                 expect_next_fire_at=expect_next_fire_at,
+                expect_github_cursor=expect_github_cursor,
             )
             if not written_occurrence:
                 await self._abandon_refused_fire(inv_id, sid, orphan_id=supersedes_run_id)

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -21,6 +21,7 @@ from lionagi.state.db import (
     NO_CURSOR_CLAIM,
     SESSION_TERMINAL_STATUSES,
     TERMINAL_RUN_STATUSES,
+    CursorClaim,
 )
 from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS, RunTerminalEnvelope
 from lionagi.state.lifecycle.notify_settings import build_handler, resolve_notify_config
@@ -1873,8 +1874,8 @@ class SchedulerEngine:
         threshold_cooldown_claim: _ThresholdCooldownClaim | None = None,
         extra_schedule_fields: dict[str, Any] | None = None,
         supersedes_run_id: str | None = None,
-        expect_next_fire_at: Any,
-        expect_github_cursor: Any = NO_CURSOR_CLAIM,
+        expect_next_fire_at: CursorClaim,
+        expect_github_cursor: CursorClaim = NO_CURSOR_CLAIM,
     ) -> bool:
         """Thin wrapper that releases every admission claim on all exit paths.
 
@@ -1922,8 +1923,8 @@ class SchedulerEngine:
         schedule_id: str,
         schedule_fields: dict[str, Any],
         supersedes_run_id: str | None,
-        expect_next_fire_at: Any,
-        expect_github_cursor: Any = NO_CURSOR_CLAIM,
+        expect_next_fire_at: CursorClaim,
+        expect_github_cursor: CursorClaim = NO_CURSOR_CLAIM,
     ) -> bool:
         """Durably record one occurrence row: the choke point both write sites take."""
         if supersedes_run_id is not None:
@@ -2027,8 +2028,8 @@ class SchedulerEngine:
         max_runs_claim: _MaxRunsClaim | None = None,
         extra_schedule_fields: dict[str, Any] | None = None,
         supersedes_run_id: str | None = None,
-        expect_next_fire_at: Any,
-        expect_github_cursor: Any = NO_CURSOR_CLAIM,
+        expect_next_fire_at: CursorClaim,
+        expect_github_cursor: CursorClaim = NO_CURSOR_CLAIM,
     ) -> bool:
         """Fire one occurrence of *schedule*; False only if it refused before anything committed."""
         sid = schedule["id"]

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1861,6 +1861,7 @@ class SchedulerEngine:
         schedule_id: str,
         schedule_fields: dict[str, Any],
         supersedes_run_id: str | None,
+        expect_next_fire_at: float | None,
     ) -> bool:
         """Durably record one occurrence row: the choke point both write sites take."""
         if supersedes_run_id is not None:
@@ -1885,10 +1886,47 @@ class SchedulerEngine:
                     actor="scheduler_startup_recovery",
                 )
             return applied
-        await self._svc.create_schedule_run_and_advance(
-            run, schedule_id=schedule_id, schedule_fields=schedule_fields
+        # The cursor this fire was selected on is the claim: if another scheduler already advanced
+        # it, that scheduler owns this occurrence and nothing is written here.
+        return await self._svc.create_schedule_run_and_advance(
+            run,
+            schedule_id=schedule_id,
+            schedule_fields=schedule_fields,
+            expect_next_fire_at=expect_next_fire_at,
         )
-        return True
+
+    async def _abandon_refused_fire(
+        self, inv_id: str, schedule_id: str, *, orphan_id: str | None
+    ) -> None:
+        """Route a refused occurrence write to the reason that actually refused it."""
+        if orphan_id is not None:
+            await self._abandon_superseded_recovery_fire(inv_id, orphan_id=orphan_id)
+        else:
+            await self._abandon_lost_cursor_claim(inv_id, schedule_id=schedule_id)
+
+    async def _abandon_lost_cursor_claim(self, inv_id: str, *, schedule_id: str) -> None:
+        """Clean up a fire whose occurrence write lost the cursor claim to another scheduler."""
+        _log.info(
+            "Abandoning fire for invocation %s: schedule %s was already advanced past "
+            "this occurrence by another scheduler",
+            inv_id,
+            schedule_id,
+        )
+        await self._guarded_terminal_status(
+            "invocation",
+            inv_id,
+            new_status="cancelled",
+            reason_code=RunReasons.CANCELLED_STALE_AUTO,
+            reason_summary=(
+                f"Fire abandoned: another scheduler advanced schedule {schedule_id} "
+                "past this occurrence before this fire's own write landed, so that "
+                "scheduler owns it."
+            ),
+            evidence_refs=[{"kind": "schedule", "id": schedule_id}],
+            source="system",
+            actor="scheduler_cursor_claim",
+            extra_fields={"ended_at": time.time()},
+        )
 
     async def _abandon_superseded_recovery_fire(self, inv_id: str, *, orphan_id: str) -> None:
         """Clean up a recovery re-fire whose occurrence write was refused."""
@@ -2035,13 +2073,12 @@ class SchedulerEngine:
                     schedule_id=sid,
                     schedule_fields=failed_schedule_fields,
                     supersedes_run_id=supersedes_run_id,
+                    expect_next_fire_at=schedule.get("next_fire_at"),
                 )
                 if not written_occurrence:
                     # Abandon writes the invocation's cancelled terminal status, and the finally
                     # unregisters only after it, so a declared notify still fires.
-                    await self._abandon_superseded_recovery_fire(
-                        inv_id, orphan_id=supersedes_run_id
-                    )
+                    await self._abandon_refused_fire(inv_id, sid, orphan_id=supersedes_run_id)
                     return False
                 if rate_limit_claim is not None:
                     # The durable row now accounts for this fire across process
@@ -2147,9 +2184,10 @@ class SchedulerEngine:
                 schedule_id=sid,
                 schedule_fields=update_fields,
                 supersedes_run_id=supersedes_run_id,
+                expect_next_fire_at=schedule.get("next_fire_at"),
             )
             if not written_occurrence:
-                await self._abandon_superseded_recovery_fire(inv_id, orphan_id=supersedes_run_id)
+                await self._abandon_refused_fire(inv_id, sid, orphan_id=supersedes_run_id)
                 return False
             occurrence_committed = True
             if rate_limit_claim is not None:

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -17,7 +17,11 @@ from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from lionagi.ln.concurrency import ExceptionGroup
-from lionagi.state.db import SESSION_TERMINAL_STATUSES, TERMINAL_RUN_STATUSES
+from lionagi.state.db import (
+    NO_CURSOR_CLAIM,
+    SESSION_TERMINAL_STATUSES,
+    TERMINAL_RUN_STATUSES,
+)
 from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS, RunTerminalEnvelope
 from lionagi.state.lifecycle.notify_settings import build_handler, resolve_notify_config
 from lionagi.state.reasons import RunReasons, ScheduleReasons
@@ -621,6 +625,9 @@ class SchedulerEngine:
                 rate_limit_claim=rate_claim,
                 max_runs_claim=claim,
                 global_slot_claim=slot_claim,
+                # A manual trigger is not competing for a due instant. Claiming the cursor here
+                # would refuse the trigger whenever a scheduled fire landed alongside it.
+                expect_next_fire_at=NO_CURSOR_CLAIM,
             )
             handed_off = True
             return run_id
@@ -742,6 +749,9 @@ class SchedulerEngine:
                 new_run_id,
                 trigger_context=row.get("trigger_context") or {},
                 supersedes_run_id=run_id,
+                # The occurrence this replaces already advanced the cursor. Its own claim is the
+                # CAS-tombstone of the orphan row, which is what stops two recoveries of one.
+                expect_next_fire_at=NO_CURSOR_CLAIM,
             )
 
     async def _tombstone_orphan_only(self, run_id: str, *, sid: str | None, log_note: str) -> None:
@@ -913,6 +923,7 @@ class SchedulerEngine:
                         trigger_context=chain_ctx,
                         chain_parent_id=run_id,
                         chain_depth=chain_depth + 1,
+                        expect_next_fire_at=NO_CURSOR_CLAIM,
                     )
 
     async def _check_missed_fires(self) -> None:
@@ -977,9 +988,16 @@ class SchedulerEngine:
             # _next_fire_field, not a bare not-None check: an 'at' trigger's terminal None must be
             # reserved too, or the next tick still sees the past-due instant and queues a duplicate.
             fields = self._next_fire_field(schedule, next_at)
+            # This path reserves the cursor before dispatching, so the reserve is where it claims
+            # the missed instant. The fire that follows claims the value the reserve WROTE: the
+            # local snapshot still holds the pre-reserve value, and claiming that would refuse the
+            # recovery against its own reservation.
+            claimed = schedule.get("next_fire_at")
             if fields:
                 try:
-                    await self._svc.update_schedule(schedule["id"], **fields)
+                    reserved = await self._svc.update_schedule(
+                        schedule["id"], expect_next_fire_at=claimed, **fields
+                    )
                 except Exception:
                     # Reserve didn't land: skip recovery and let the normal
                     # tick own this cycle's fire instead of double-running it.
@@ -989,6 +1007,14 @@ class SchedulerEngine:
                         schedule.get("id"),
                     )
                     return
+                if not reserved:
+                    _log.info(
+                        "Missed-fire recovery for schedule %s stood down: another scheduler "
+                        "reserved the same missed instant",
+                        schedule.get("id"),
+                    )
+                    return
+                claimed = fields.get("next_fire_at", claimed)
             run_id = uuid.uuid4().hex[:12]
             _log.info(
                 "Missed fire recovery for schedule %s (%s)",
@@ -1002,6 +1028,7 @@ class SchedulerEngine:
                 rate_limit_claim=rate_claim,
                 max_runs_claim=claim,
                 global_slot_claim=slot_claim,
+                expect_next_fire_at=claimed,
             )
             handed_off = True
         finally:
@@ -1213,6 +1240,13 @@ class SchedulerEngine:
             cursor = schedule.get("github_cursor")
             drop_reason: str | None = None
             dropped_prs: list[Any] = []
+            # One poll cycle is one due instant, however many events it carries. The first event
+            # to dispatch claims that instant on behalf of the whole batch; the rest are already
+            # inside a cycle this scheduler won, and each dispatched event advances next_fire_at,
+            # so re-claiming the pre-poll value would refuse every event after the first. What
+            # keeps the later events from double-firing is github_cursor, which is monotonic and
+            # advances in the same transaction as each event's occurrence.
+            unclaimed_poll_cycle = True
 
             for idx, item in enumerate(polled):
                 if not item.dispatchable:
@@ -1274,7 +1308,14 @@ class SchedulerEngine:
                         # occurrence insert, durably before the action runs, closing the double-fire
                         # hazard of batching the cursor write until after the loop.
                         extra_schedule_fields={"github_cursor": item.updated_at},
+                        expect_next_fire_at=(
+                            schedule.get("next_fire_at")
+                            if unclaimed_poll_cycle
+                            else NO_CURSOR_CLAIM
+                        ),
                     )
+                    if fired:
+                        unclaimed_poll_cycle = False
                     if not fired:
                         # A refusal before a process started means nothing ran, so re-offering the
                         # event is not a re-execution. Bounded, because a refusal can be a property
@@ -1723,6 +1764,7 @@ class SchedulerEngine:
                 max_runs_claim=claim,
                 global_slot_claim=slot_claim,
                 threshold_cooldown_claim=threshold_claim,
+                expect_next_fire_at=schedule.get("next_fire_at"),
             )
             # Flipped only after _tracked_fire() returns, so even a synchronous task-launch failure
             # releases the claims below. Release is idempotent, so there is no double-free against
@@ -1822,8 +1864,15 @@ class SchedulerEngine:
         threshold_cooldown_claim: _ThresholdCooldownClaim | None = None,
         extra_schedule_fields: dict[str, Any] | None = None,
         supersedes_run_id: str | None = None,
+        expect_next_fire_at: Any,
     ) -> bool:
-        """Thin wrapper that releases every admission claim on all exit paths."""
+        """Thin wrapper that releases every admission claim on all exit paths.
+
+        *expect_next_fire_at* is the due instant this fire claims, and it has no default: only
+        the caller knows whether its schedule dict still holds the cursor it decided on, and a
+        caller that already reserved the instant itself claims the value it reserved. Fires that
+        do not stand for a due instant, such as chain children, pass ``NO_CURSOR_CLAIM``.
+        """
         try:
             return await self._fire_inner(
                 schedule,
@@ -1835,6 +1884,7 @@ class SchedulerEngine:
                 max_runs_claim=max_runs_claim,
                 extra_schedule_fields=extra_schedule_fields,
                 supersedes_run_id=supersedes_run_id,
+                expect_next_fire_at=expect_next_fire_at,
             )
         finally:
             if rate_limit_claim is not None:
@@ -1861,7 +1911,7 @@ class SchedulerEngine:
         schedule_id: str,
         schedule_fields: dict[str, Any],
         supersedes_run_id: str | None,
-        expect_next_fire_at: float | None,
+        expect_next_fire_at: Any,
     ) -> bool:
         """Durably record one occurrence row: the choke point both write sites take."""
         if supersedes_run_id is not None:
@@ -1964,6 +2014,7 @@ class SchedulerEngine:
         max_runs_claim: _MaxRunsClaim | None = None,
         extra_schedule_fields: dict[str, Any] | None = None,
         supersedes_run_id: str | None = None,
+        expect_next_fire_at: Any,
     ) -> bool:
         """Fire one occurrence of *schedule*; False only if it refused before anything committed."""
         sid = schedule["id"]
@@ -2073,7 +2124,7 @@ class SchedulerEngine:
                     schedule_id=sid,
                     schedule_fields=failed_schedule_fields,
                     supersedes_run_id=supersedes_run_id,
-                    expect_next_fire_at=schedule.get("next_fire_at"),
+                    expect_next_fire_at=expect_next_fire_at,
                 )
                 if not written_occurrence:
                     # Abandon writes the invocation's cancelled terminal status, and the finally
@@ -2184,7 +2235,7 @@ class SchedulerEngine:
                 schedule_id=sid,
                 schedule_fields=update_fields,
                 supersedes_run_id=supersedes_run_id,
-                expect_next_fire_at=schedule.get("next_fire_at"),
+                expect_next_fire_at=expect_next_fire_at,
             )
             if not written_occurrence:
                 await self._abandon_refused_fire(inv_id, sid, orphan_id=supersedes_run_id)
@@ -2342,6 +2393,7 @@ class SchedulerEngine:
                         trigger_context=chain_ctx,
                         chain_parent_id=run_id,
                         chain_depth=chain_depth + 1,
+                        expect_next_fire_at=NO_CURSOR_CLAIM,
                     )
             return dispatched
 

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -16,7 +16,12 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Protocol
 
-from lionagi.state.db import NO_CURSOR_CLAIM, TERMINAL_RUN_STATUSES, StateDB
+from lionagi.state.db import (
+    NO_CURSOR_CLAIM,
+    TERMINAL_RUN_STATUSES,
+    CursorClaim,
+    StateDB,
+)
 from lionagi.state.reasons import RunReasons
 from lionagi.studio.scheduler import coordination as _coordination
 
@@ -35,8 +40,8 @@ class SchedulerStateService(Protocol):
         schedule_id: str,
         *,
         guard_cursor_forward: bool = False,
-        expect_next_fire_at: Any = NO_CURSOR_CLAIM,
-        expect_github_cursor: Any = NO_CURSOR_CLAIM,
+        expect_next_fire_at: CursorClaim = NO_CURSOR_CLAIM,
+        expect_github_cursor: CursorClaim = NO_CURSOR_CLAIM,
         **fields: Any,
     ) -> bool: ...
 
@@ -63,8 +68,8 @@ class SchedulerStateService(Protocol):
         *,
         schedule_id: str,
         schedule_fields: dict[str, Any],
-        expect_next_fire_at: Any,
-        expect_github_cursor: Any = NO_CURSOR_CLAIM,
+        expect_next_fire_at: CursorClaim,
+        expect_github_cursor: CursorClaim = NO_CURSOR_CLAIM,
     ) -> bool: ...
 
     async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool: ...
@@ -178,8 +183,8 @@ class _DBSchedulerStateService:
         schedule_id: str,
         *,
         guard_cursor_forward: bool = False,
-        expect_next_fire_at: Any = NO_CURSOR_CLAIM,
-        expect_github_cursor: Any = NO_CURSOR_CLAIM,
+        expect_next_fire_at: CursorClaim = NO_CURSOR_CLAIM,
+        expect_github_cursor: CursorClaim = NO_CURSOR_CLAIM,
         **fields: Any,
     ) -> bool:
         async with self._db_context() as db:
@@ -229,8 +234,8 @@ class _DBSchedulerStateService:
         *,
         schedule_id: str,
         schedule_fields: dict[str, Any],
-        expect_next_fire_at: Any,
-        expect_github_cursor: Any = NO_CURSOR_CLAIM,
+        expect_next_fire_at: CursorClaim,
+        expect_github_cursor: CursorClaim = NO_CURSOR_CLAIM,
     ) -> bool:
         async with self._db_context() as db:
             return await db.create_schedule_run_and_advance(

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -57,7 +57,8 @@ class SchedulerStateService(Protocol):
         *,
         schedule_id: str,
         schedule_fields: dict[str, Any],
-    ) -> None: ...
+        expect_next_fire_at: float | None,
+    ) -> bool: ...
 
     async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool: ...
 
@@ -211,10 +212,14 @@ class _DBSchedulerStateService:
         *,
         schedule_id: str,
         schedule_fields: dict[str, Any],
-    ) -> None:
+        expect_next_fire_at: float | None,
+    ) -> bool:
         async with self._db_context() as db:
-            await db.create_schedule_run_and_advance(
-                run, schedule_id=schedule_id, schedule_fields=schedule_fields
+            return await db.create_schedule_run_and_advance(
+                run,
+                schedule_id=schedule_id,
+                schedule_fields=schedule_fields,
+                expect_next_fire_at=expect_next_fire_at,
             )
 
     async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool:

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -36,6 +36,7 @@ class SchedulerStateService(Protocol):
         *,
         guard_cursor_forward: bool = False,
         expect_next_fire_at: Any = NO_CURSOR_CLAIM,
+        expect_github_cursor: Any = NO_CURSOR_CLAIM,
         **fields: Any,
     ) -> bool: ...
 
@@ -62,7 +63,8 @@ class SchedulerStateService(Protocol):
         *,
         schedule_id: str,
         schedule_fields: dict[str, Any],
-        expect_next_fire_at: float | None,
+        expect_next_fire_at: Any,
+        expect_github_cursor: Any = NO_CURSOR_CLAIM,
     ) -> bool: ...
 
     async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool: ...
@@ -177,6 +179,7 @@ class _DBSchedulerStateService:
         *,
         guard_cursor_forward: bool = False,
         expect_next_fire_at: Any = NO_CURSOR_CLAIM,
+        expect_github_cursor: Any = NO_CURSOR_CLAIM,
         **fields: Any,
     ) -> bool:
         async with self._db_context() as db:
@@ -184,6 +187,7 @@ class _DBSchedulerStateService:
                 schedule_id,
                 guard_cursor_forward=guard_cursor_forward,
                 expect_next_fire_at=expect_next_fire_at,
+                expect_github_cursor=expect_github_cursor,
                 **fields,
             )
 
@@ -225,7 +229,8 @@ class _DBSchedulerStateService:
         *,
         schedule_id: str,
         schedule_fields: dict[str, Any],
-        expect_next_fire_at: float | None,
+        expect_next_fire_at: Any,
+        expect_github_cursor: Any = NO_CURSOR_CLAIM,
     ) -> bool:
         async with self._db_context() as db:
             return await db.create_schedule_run_and_advance(
@@ -233,6 +238,7 @@ class _DBSchedulerStateService:
                 schedule_id=schedule_id,
                 schedule_fields=schedule_fields,
                 expect_next_fire_at=expect_next_fire_at,
+                expect_github_cursor=expect_github_cursor,
             )
 
     async def schedule_run_exists_since(self, schedule_id: str, since: float) -> bool:

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -16,7 +16,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Protocol
 
-from lionagi.state.db import TERMINAL_RUN_STATUSES, StateDB
+from lionagi.state.db import NO_CURSOR_CLAIM, TERMINAL_RUN_STATUSES, StateDB
 from lionagi.state.reasons import RunReasons
 from lionagi.studio.scheduler import coordination as _coordination
 
@@ -31,8 +31,13 @@ class SchedulerStateService(Protocol):
     async def list_schedules(self, *, enabled: bool | None = None) -> list[dict[str, Any]]: ...
 
     async def update_schedule(
-        self, schedule_id: str, *, guard_cursor_forward: bool = False, **fields: Any
-    ) -> None: ...
+        self,
+        schedule_id: str,
+        *,
+        guard_cursor_forward: bool = False,
+        expect_next_fire_at: Any = NO_CURSOR_CLAIM,
+        **fields: Any,
+    ) -> bool: ...
 
     async def count_schedule_runs(
         self,
@@ -167,11 +172,19 @@ class _DBSchedulerStateService:
             return await db.list_schedules(enabled=enabled, limit=None)
 
     async def update_schedule(
-        self, schedule_id: str, *, guard_cursor_forward: bool = False, **fields: Any
-    ) -> None:
+        self,
+        schedule_id: str,
+        *,
+        guard_cursor_forward: bool = False,
+        expect_next_fire_at: Any = NO_CURSOR_CLAIM,
+        **fields: Any,
+    ) -> bool:
         async with self._db_context() as db:
-            await db.update_schedule(
-                schedule_id, guard_cursor_forward=guard_cursor_forward, **fields
+            return await db.update_schedule(
+                schedule_id,
+                guard_cursor_forward=guard_cursor_forward,
+                expect_next_fire_at=expect_next_fire_at,
+                **fields,
             )
 
     async def count_schedule_runs(

--- a/tests/_scheduler_claims.py
+++ b/tests/_scheduler_claims.py
@@ -11,6 +11,7 @@ from lionagi.state.db import NO_CURSOR_CLAIM
 
 __all__ = (
     "claim_and_advance",
+    "claiming_advance",
     "claim_holds",
     "fire_inner_with_claim",
     "fire_with_claim",
@@ -77,3 +78,34 @@ def persisting_update_schedule(schedule: dict):
         return True
 
     return _update
+
+
+def claiming_advance(stored: dict, *, on_write=None):
+    """A ``create_schedule_run_and_advance`` double that honors both claims.
+
+    Mirrors the real signature instead of absorbing the claims into ``**fields``. A double
+    that always returns True cannot tell a winning claim from a losing one, so every test
+    using it would pass whether or not the engine claims anything.
+
+    *stored* stands for the schedule row and is updated on a winning write, which is what
+    makes a second caller's stale claim fail the way the database would fail it.
+    """
+
+    async def _advance(
+        payload,
+        *,
+        schedule_id,
+        schedule_fields,
+        expect_next_fire_at,
+        expect_github_cursor=NO_CURSOR_CLAIM,
+    ):
+        if not claim_holds(stored.get("next_fire_at"), expect_next_fire_at):
+            return False
+        if not claim_holds(stored.get("github_cursor"), expect_github_cursor):
+            return False
+        stored.update(schedule_fields)
+        if on_write is not None:
+            on_write(payload)
+        return True
+
+    return _advance

--- a/tests/_scheduler_claims.py
+++ b/tests/_scheduler_claims.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 - 2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for tests that exercise the scheduler's due-instant claim."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lionagi.state.db import NO_CURSOR_CLAIM
+
+__all__ = (
+    "claim_and_advance",
+    "claim_holds",
+    "fire_inner_with_claim",
+    "fire_with_claim",
+    "persisting_update_schedule",
+)
+
+
+async def claim_and_advance(db, run, *, schedule_id, schedule_fields):
+    """Write an occurrence holding whatever cursor the schedule currently has.
+
+    For tests that predate the claim and are about something else; the claim itself is
+    covered in tests/state/test_schedule_due_cursor_claim.py.
+    """
+    current = (await db.get_schedule(schedule_id))["next_fire_at"]
+    return await db.create_schedule_run_and_advance(
+        run,
+        schedule_id=schedule_id,
+        schedule_fields=schedule_fields,
+        expect_next_fire_at=current,
+    )
+
+
+async def fire_with_claim(engine, schedule, run_id, **kwargs):
+    """Call ``_fire`` the way the ordinary due tick does, claiming the schedule's cursor."""
+    kwargs.setdefault("expect_next_fire_at", schedule.get("next_fire_at"))
+    return await engine._fire(schedule, run_id, **kwargs)
+
+
+async def fire_inner_with_claim(engine, schedule, run_id, **kwargs):
+    """``fire_with_claim`` for tests that drive ``_fire_inner`` directly."""
+    kwargs.setdefault("expect_next_fire_at", schedule.get("next_fire_at"))
+    return await engine._fire_inner(schedule, run_id, **kwargs)
+
+
+def claim_holds(stored_next_fire_at: Any, expect: Any) -> bool:
+    """Whether a claim of *expect* still holds against *stored_next_fire_at*.
+
+    Test doubles route their claim through this so a mismatched claim is refused there too;
+    a double that always returned True could not tell a correct cursor from a stale one.
+    """
+    return expect is NO_CURSOR_CLAIM or stored_next_fire_at == expect
+
+
+def persisting_update_schedule(schedule: dict):
+    """An ``update_schedule`` double that persists into *schedule* and honors the claim.
+
+    Mirrors the real signature rather than swallowing it into ``**fields``: a double that
+    accepted the claim as an ordinary field would write it onto the row and report success
+    whatever the caller claimed.
+    """
+
+    async def _update(
+        schedule_id: str,
+        *,
+        guard_cursor_forward: bool = False,
+        expect_next_fire_at: Any = NO_CURSOR_CLAIM,
+        **fields: Any,
+    ) -> bool:
+        if schedule_id != schedule["id"]:
+            return False
+        if not claim_holds(schedule.get("next_fire_at"), expect_next_fire_at):
+            return False
+        schedule.update(fields)
+        return True
+
+    return _update

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -14,6 +14,8 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
 import lionagi.state.db as state_db_mod
+from lionagi.state.db import NO_CURSOR_CLAIM
+from tests._scheduler_claims import fire_with_claim
 
 # Helpers
 
@@ -136,7 +138,9 @@ class TestSchedulerFireTaskLifecycle:
 
         # Inject a tracked task directly via _tracked_fire
         with patch.object(engine, "_fire", side_effect=fake_fire):
-            task = engine._tracked_fire({}, "run_id", trigger_context={})
+            task = engine._tracked_fire(
+                {}, "run_id", trigger_context={}, expect_next_fire_at=NO_CURSOR_CLAIM
+            )
 
         # Task is still running — should be in the set
         await fired.wait()
@@ -283,7 +287,7 @@ class TestFireBuildFailureRecorded:
         schedule = _interval_schedule(action_kind="totally-bogus")  # same id
 
         # Must NOT raise (no LookupError leaking out) and must return cleanly.
-        await engine._fire(schedule, run_id, trigger_context={})
+        await fire_with_claim(engine, schedule, run_id, trigger_context={})
 
         async with StateDB() as db:
             run = await db.get_schedule_run(run_id)
@@ -436,7 +440,9 @@ class TestFireCancellationRecorded:
 
         engine = SchedulerEngine()
         run_id = "run-cancel"
-        engine._tracked_fire(_interval_schedule(), run_id, trigger_context={})
+        engine._tracked_fire(
+            _interval_schedule(), run_id, trigger_context={}, expect_next_fire_at=NO_CURSOR_CLAIM
+        )
 
         await started.wait()  # row created, now inside spawn
         await engine.stop()  # cancels + awaits the fire task

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -19,22 +19,7 @@ import pytest
 from sqlalchemy import text
 
 from lionagi.state.db import SCHEMA_VERSION, StateDB
-
-
-async def _claim_and_advance(db, run, *, schedule_id, schedule_fields):
-    """Write an occurrence holding whatever cursor the schedule currently has.
-
-    These tests predate the cursor claim and are about atomicity, so they always hold it;
-    the claim itself is covered in tests/state/test_schedule_due_cursor_claim.py.
-    """
-    current = (await db.get_schedule(schedule_id))["next_fire_at"]
-    return await db.create_schedule_run_and_advance(
-        run,
-        schedule_id=schedule_id,
-        schedule_fields=schedule_fields,
-        expect_next_fire_at=current,
-    )
-
+from tests._scheduler_claims import claim_and_advance
 
 # Fixtures
 
@@ -208,7 +193,7 @@ async def test_managed_entity_creations_write_initial_lifecycle_history(db: Stat
         "status": "running",
         "fired_at": time.time(),
     }
-    await _claim_and_advance(
+    await claim_and_advance(
         db,
         advanced_run,
         schedule_id=schedule_id,

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -20,6 +20,22 @@ from sqlalchemy import text
 
 from lionagi.state.db import SCHEMA_VERSION, StateDB
 
+
+async def _claim_and_advance(db, run, *, schedule_id, schedule_fields):
+    """Write an occurrence holding whatever cursor the schedule currently has.
+
+    These tests predate the cursor claim and are about atomicity, so they always hold it;
+    the claim itself is covered in tests/state/test_schedule_due_cursor_claim.py.
+    """
+    current = (await db.get_schedule(schedule_id))["next_fire_at"]
+    return await db.create_schedule_run_and_advance(
+        run,
+        schedule_id=schedule_id,
+        schedule_fields=schedule_fields,
+        expect_next_fire_at=current,
+    )
+
+
 # Fixtures
 
 
@@ -192,7 +208,8 @@ async def test_managed_entity_creations_write_initial_lifecycle_history(db: Stat
         "status": "running",
         "fired_at": time.time(),
     }
-    await db.create_schedule_run_and_advance(
+    await _claim_and_advance(
+        db,
         advanced_run,
         schedule_id=schedule_id,
         schedule_fields={"last_fired_at": time.time()},

--- a/tests/state/test_schedule_due_cursor_claim.py
+++ b/tests/state/test_schedule_due_cursor_claim.py
@@ -208,3 +208,46 @@ async def test_a_claim_of_none_matches_only_a_null_cursor(db: StateDB):
     assert (await db.get_schedule(sid))["next_fire_at"] is None
     assert await db.update_schedule(sid, expect_next_fire_at=None, next_fire_at=900.0)
     assert (await db.get_schedule(sid))["next_fire_at"] == 900.0
+
+
+def test_the_poll_cursor_claim_uses_the_same_predicate_shape():
+    """A second claim column has to get the same NULL handling as the first.
+
+    Every event of one poll batch resolves to the same next_fire_at, so a claim on that
+    value matches twice and separates nothing. github_cursor advances per event, and a
+    schedule polling for the first time has none, so the NULL arm is the common case here
+    rather than an edge.
+    """
+    with_value, params = StateDB._build_update_schedule_stmt(
+        "sched-1", {"github_cursor": "b"}, expect_github_cursor="a"
+    )
+    with_null, null_params = StateDB._build_update_schedule_stmt(
+        "sched-1", {"github_cursor": "b"}, expect_github_cursor=None
+    )
+    both, both_params = StateDB._build_update_schedule_stmt(
+        "sched-1",
+        {"github_cursor": "b"},
+        expect_next_fire_at=100.0,
+        expect_github_cursor="a",
+    )
+    unclaimed, unclaimed_params = StateDB._build_update_schedule_stmt(
+        "sched-1", {"github_cursor": "b"}
+    )
+
+    for stmt in (with_value, with_null, both):
+        assert " IS :" not in str(stmt), f"postgres rejects a bound parameter after IS: {stmt}"
+
+    assert "github_cursor = :_expect_ghc" in str(with_value)
+    assert params["_expect_ghc"] == "a"
+    assert "github_cursor IS NULL" in str(with_null)
+    assert "_expect_ghc" not in null_params
+    # Both claims are independent conditions on one statement, not one overwriting the other.
+    assert "next_fire_at = :_expect_nfa" in str(both)
+    assert "github_cursor = :_expect_ghc" in str(both)
+    assert both_params["_expect_nfa"] == 100.0
+    assert both_params["_expect_ghc"] == "a"
+    # Control: unasked, neither predicate appears, so the arms above measure something the
+    # builder emits only on request rather than a condition it always writes.
+    assert "_expect_ghc" not in str(unclaimed)
+    assert "_expect_ghc" not in unclaimed_params
+    assert "_expect_nfa" not in str(unclaimed)

--- a/tests/state/test_schedule_due_cursor_claim.py
+++ b/tests/state/test_schedule_due_cursor_claim.py
@@ -169,3 +169,42 @@ async def test_update_schedule_still_writes_without_a_cursor_predicate(db: State
 
     await db.update_schedule(sid, next_fire_at=due + 5)
     assert await _cursor(db, sid) == due + 5
+
+
+def test_the_claim_predicate_is_valid_on_every_supported_dialect():
+    """`IS` with a bound parameter parses on sqlite and is a syntax error on postgres.
+
+    The dual-backend suite skips without asyncpg, so a postgres-invalid predicate reaches
+    CI unnoticed. Reading the generated text is what closes that.
+    """
+    with_value, params = StateDB._build_update_schedule_stmt(
+        "sched-1", {"next_fire_at": 200.0}, expect_next_fire_at=100.0
+    )
+    with_null, null_params = StateDB._build_update_schedule_stmt(
+        "sched-1", {"next_fire_at": 200.0}, expect_next_fire_at=None
+    )
+    unclaimed, _ = StateDB._build_update_schedule_stmt("sched-1", {"next_fire_at": 200.0})
+
+    for stmt in (with_value, with_null):
+        assert " IS :" not in str(stmt), f"postgres rejects a bound parameter after IS: {stmt}"
+
+    assert "next_fire_at = :_expect_nfa" in str(with_value)
+    assert params["_expect_nfa"] == 100.0
+    assert "next_fire_at IS NULL" in str(with_null)
+    assert "_expect_nfa" not in null_params
+    # Control: without a claim there is no predicate at all, so the two arms above are
+    # measuring a predicate that this builder only emits when asked for one.
+    assert "next_fire_at IS NULL" not in str(unclaimed)
+    assert "_expect_nfa" not in str(unclaimed)
+
+
+@pytest.mark.asyncio
+async def test_a_claim_of_none_matches_only_a_null_cursor(db: StateDB):
+    """The NULL arm has to behave like a claim, not like an unclaimed write."""
+    sid = await _schedule(db, due=500.0)
+    assert not await db.update_schedule(sid, expect_next_fire_at=None, next_fire_at=900.0)
+    assert (await db.get_schedule(sid))["next_fire_at"] == 500.0
+    assert await db.update_schedule(sid, expect_next_fire_at=500.0, next_fire_at=None)
+    assert (await db.get_schedule(sid))["next_fire_at"] is None
+    assert await db.update_schedule(sid, expect_next_fire_at=None, next_fire_at=900.0)
+    assert (await db.get_schedule(sid))["next_fire_at"] == 900.0

--- a/tests/state/test_schedule_due_cursor_claim.py
+++ b/tests/state/test_schedule_due_cursor_claim.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The due cursor is the claim two schedulers race for."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+async def db():
+    state = StateDB(":memory:")
+    await state.open()
+    yield state
+    await state.close()
+
+
+async def _schedule(db: StateDB, *, due: float | None) -> str:
+    sid = "sched-" + uuid.uuid4().hex[:8]
+    await db.create_schedule(
+        {
+            "id": sid,
+            "name": sid,
+            "description": "",
+            "enabled": 1,
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+            "action_prompt": "noop",
+            "next_fire_at": due,
+            "last_fired_at": None,
+        }
+    )
+    return sid
+
+
+def _occurrence(sid: str, fired_at: float) -> dict:
+    return {
+        "id": "run-" + uuid.uuid4().hex[:8],
+        "schedule_id": sid,
+        "invocation_id": None,
+        "trigger_context": {"fired_at": fired_at},
+        "action_kind": "agent",
+        "action_args": {},
+        "status": "running",
+        "exit_code": None,
+        "chain_parent_id": None,
+        "chain_depth": 0,
+        "fired_at": fired_at,
+        "ended_at": None,
+        "error_detail": None,
+        "created_at": time.time(),
+    }
+
+
+async def _occurrence_count(db: StateDB, sid: str) -> int:
+    async with db._tx() as conn:
+        return (
+            await conn.execute(
+                text("SELECT COUNT(*) FROM schedule_runs WHERE schedule_id = :s"), {"s": sid}
+            )
+        ).scalar()
+
+
+async def _cursor(db: StateDB, sid: str) -> float | None:
+    async with db._tx() as conn:
+        return (
+            await conn.execute(text("SELECT next_fire_at FROM schedules WHERE id = :s"), {"s": sid})
+        ).scalar()
+
+
+async def test_two_schedulers_racing_one_due_instant_write_one_occurrence(db: StateDB):
+    """Selecting a due row and firing it are separate statements, so the cursor is the claim."""
+    due = time.time() - 1
+    sid = await _schedule(db, due=due)
+    advanced = {"last_fired_at": due, "next_fire_at": due + 60}
+
+    async def fire():
+        return await db.create_schedule_run_and_advance(
+            _occurrence(sid, due),
+            schedule_id=sid,
+            schedule_fields=dict(advanced),
+            expect_next_fire_at=due,
+        )
+
+    assert sorted(await asyncio.gather(fire(), fire())) == [False, True]
+    assert await _occurrence_count(db, sid) == 1
+
+
+async def test_the_scheduler_that_holds_the_cursor_still_fires(db: StateDB):
+    """The control: a claim that refuses everything would bound duplicates by firing nothing."""
+    due = time.time() - 1
+    sid = await _schedule(db, due=due)
+
+    assert await db.create_schedule_run_and_advance(
+        _occurrence(sid, due),
+        schedule_id=sid,
+        schedule_fields={"last_fired_at": due, "next_fire_at": due + 60},
+        expect_next_fire_at=due,
+    )
+    assert await _occurrence_count(db, sid) == 1
+    assert await _cursor(db, sid) == due + 60
+
+
+async def test_a_refused_fire_leaves_no_occurrence_and_no_cursor_move(db: StateDB):
+    """A partial write is worse than a lost race: the loser must write nothing at all."""
+    due = time.time() - 1
+    sid = await _schedule(db, due=due)
+    await db.update_schedule(sid, next_fire_at=due + 60)
+
+    assert not await db.create_schedule_run_and_advance(
+        _occurrence(sid, due),
+        schedule_id=sid,
+        schedule_fields={"last_fired_at": due, "next_fire_at": due + 120},
+        expect_next_fire_at=due,
+    )
+    assert await _occurrence_count(db, sid) == 0
+    assert await _cursor(db, sid) == due + 60
+
+
+async def test_a_schedule_with_no_cursor_is_claimed_on_the_same_terms(db: StateDB):
+    """NULL is a cursor value here, so the predicate has to compare NULL to NULL."""
+    sid = await _schedule(db, due=None)
+    now = time.time()
+
+    assert await db.create_schedule_run_and_advance(
+        _occurrence(sid, now),
+        schedule_id=sid,
+        schedule_fields={"last_fired_at": now, "next_fire_at": now + 60},
+        expect_next_fire_at=None,
+    )
+    assert not await db.create_schedule_run_and_advance(
+        _occurrence(sid, now),
+        schedule_id=sid,
+        schedule_fields={"last_fired_at": now, "next_fire_at": now + 120},
+        expect_next_fire_at=None,
+    )
+    assert await _occurrence_count(db, sid) == 1
+
+
+async def test_an_operator_edit_between_selection_and_fire_refuses_the_fire(db: StateDB):
+    """The claim is not only about a second scheduler: any writer moving the cursor wins it."""
+    due = time.time() - 1
+    sid = await _schedule(db, due=due)
+    await db.update_schedule(sid, next_fire_at=due + 3600)
+
+    assert not await db.create_schedule_run_and_advance(
+        _occurrence(sid, due),
+        schedule_id=sid,
+        schedule_fields={"last_fired_at": due, "next_fire_at": due + 60},
+        expect_next_fire_at=due,
+    )
+    assert await _occurrence_count(db, sid) == 0
+    assert await _cursor(db, sid) == due + 3600
+
+
+async def test_update_schedule_still_writes_without_a_cursor_predicate(db: StateDB):
+    """The predicate is opt-in on one shared statement builder, so the other path must not gain it."""
+    due = time.time() - 1
+    sid = await _schedule(db, due=due)
+
+    await db.update_schedule(sid, next_fire_at=due + 5)
+    assert await _cursor(db, sid) == due + 5

--- a/tests/studio/test_schedule_effective_timezone.py
+++ b/tests/studio/test_schedule_effective_timezone.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._scheduler_claims import fire_with_claim
+
 pytest.importorskip("fastapi", reason="studio extra not installed")
 pytest.importorskip("croniter", reason="studio extra not installed")
 
@@ -214,7 +216,7 @@ async def test_an_actual_fire_stamps_the_row_too(temp_db_path, monkeypatch):
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-tz-001", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-tz-001", trigger_context={"scheduled": True})
 
     async with StateDB() as db:
         row = await db.get_schedule(sid)
@@ -251,7 +253,7 @@ async def test_a_fire_that_could_not_spawn_stamps_the_row_too(temp_db_path, monk
         "lionagi.studio.scheduler.subprocess.build_argv",
         side_effect=ValueError("action is not buildable"),
     ):
-        await engine._fire(schedule, "run-tz-002", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-tz-002", trigger_context={"scheduled": True})
 
     async with StateDB() as db:
         row = await db.get_schedule(sid)

--- a/tests/studio/test_schedule_github_cursor_patch.py
+++ b/tests/studio/test_schedule_github_cursor_patch.py
@@ -205,6 +205,21 @@ def test_update_rejects_an_impossible_cursor_before_any_write():
 from lionagi.state.db import StateDB  # noqa: E402
 
 
+async def _claim_and_advance(db, run, *, schedule_id, schedule_fields):
+    """Write an occurrence holding whatever cursor the schedule currently has.
+
+    These tests predate the cursor claim and are about atomicity, so they always hold it;
+    the claim itself is covered in tests/state/test_schedule_due_cursor_claim.py.
+    """
+    current = (await db.get_schedule(schedule_id))["next_fire_at"]
+    return await db.create_schedule_run_and_advance(
+        run,
+        schedule_id=schedule_id,
+        schedule_fields=schedule_fields,
+        expect_next_fire_at=current,
+    )
+
+
 def _gh_schedule(sid: str, cursor: str | None) -> dict:
     return {
         "id": sid,
@@ -255,7 +270,8 @@ async def test_operator_patch_survives_an_in_flight_polls_cursor_write(tmp_path)
     # The in-flight tick now lands, carrying the value it computed from the
     # cursor it read before the PATCH.
     async with StateDB(db_path) as db:
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-race", sid),
             schedule_id=sid,
             schedule_fields={"github_cursor": "2026-07-21T00:00:00Z", "last_fired_at": 1000.0},
@@ -282,7 +298,8 @@ async def test_normal_forward_advance_is_unaffected_by_the_guard(tmp_path):
     sid = "sched-fwd"
     async with StateDB(db_path) as db:
         await db.create_schedule(_gh_schedule(sid, "2026-07-20T00:00:00Z"))
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-fwd", sid),
             schedule_id=sid,
             schedule_fields={"github_cursor": "2026-07-22T00:00:00Z"},
@@ -299,7 +316,8 @@ async def test_guard_advances_from_a_null_cursor(tmp_path):
     sid = "sched-null"
     async with StateDB(db_path) as db:
         await db.create_schedule(_gh_schedule(sid, None))
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-null", sid),
             schedule_id=sid,
             schedule_fields={"github_cursor": "2026-07-22T00:00:00Z"},
@@ -344,7 +362,8 @@ async def test_guard_is_inert_for_schedules_with_no_cursor_field(tmp_path):
                 "next_fire_at": 1000.0,
             }
         )
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-cron", sid),
             schedule_id=sid,
             schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},

--- a/tests/studio/test_schedule_github_cursor_patch.py
+++ b/tests/studio/test_schedule_github_cursor_patch.py
@@ -203,21 +203,7 @@ def test_update_rejects_an_impossible_cursor_before_any_write():
 # The interleaving: an operator PATCH vs an in-flight poll, against a real store
 
 from lionagi.state.db import StateDB  # noqa: E402
-
-
-async def _claim_and_advance(db, run, *, schedule_id, schedule_fields):
-    """Write an occurrence holding whatever cursor the schedule currently has.
-
-    These tests predate the cursor claim and are about atomicity, so they always hold it;
-    the claim itself is covered in tests/state/test_schedule_due_cursor_claim.py.
-    """
-    current = (await db.get_schedule(schedule_id))["next_fire_at"]
-    return await db.create_schedule_run_and_advance(
-        run,
-        schedule_id=schedule_id,
-        schedule_fields=schedule_fields,
-        expect_next_fire_at=current,
-    )
+from tests._scheduler_claims import claim_and_advance
 
 
 def _gh_schedule(sid: str, cursor: str | None) -> dict:
@@ -270,7 +256,7 @@ async def test_operator_patch_survives_an_in_flight_polls_cursor_write(tmp_path)
     # The in-flight tick now lands, carrying the value it computed from the
     # cursor it read before the PATCH.
     async with StateDB(db_path) as db:
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-race", sid),
             schedule_id=sid,
@@ -298,7 +284,7 @@ async def test_normal_forward_advance_is_unaffected_by_the_guard(tmp_path):
     sid = "sched-fwd"
     async with StateDB(db_path) as db:
         await db.create_schedule(_gh_schedule(sid, "2026-07-20T00:00:00Z"))
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-fwd", sid),
             schedule_id=sid,
@@ -316,7 +302,7 @@ async def test_guard_advances_from_a_null_cursor(tmp_path):
     sid = "sched-null"
     async with StateDB(db_path) as db:
         await db.create_schedule(_gh_schedule(sid, None))
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-null", sid),
             schedule_id=sid,
@@ -362,7 +348,7 @@ async def test_guard_is_inert_for_schedules_with_no_cursor_field(tmp_path):
                 "next_fire_at": 1000.0,
             }
         )
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-cron", sid),
             schedule_id=sid,

--- a/tests/studio/test_scheduler_cwd.py
+++ b/tests/studio/test_scheduler_cwd.py
@@ -19,6 +19,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests._scheduler_claims import fire_with_claim
+
 # _resolve_action_cwd's action_project branch imports lionagi.studio.services.projects,
 # which requires fastapi (the `studio` extra); skip gracefully in a bare-core install.
 pytest.importorskip("fastapi", reason="studio extra not installed")
@@ -670,7 +672,7 @@ async def test_fire_threads_resolved_cwd_into_spawn_and_wait(tmp_path, monkeypat
         ),
         patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=spawn_mock),
     ):
-        await engine._fire(schedule, "run-cwd-001", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-cwd-001", trigger_context={"scheduled": True})
 
     spawn_mock.assert_awaited_once()
     _args, kwargs = spawn_mock.await_args
@@ -710,7 +712,7 @@ async def test_fire_refuses_owner_carrying_cwd_inherit(monkeypatch):
         ),
         patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=spawn_mock),
     ):
-        await engine._fire(schedule, "run-cwd-002", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-cwd-002", trigger_context={"scheduled": True})
 
     spawn_mock.assert_not_awaited()
 
@@ -747,7 +749,7 @@ async def test_fire_plain_nonzero_exit_keeps_generic_reason(monkeypatch):
             new=AsyncMock(return_value=(1, "boom")),
         ),
     ):
-        await engine._fire(schedule, "run-cwd-003", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-cwd-003", trigger_context={"scheduled": True})
 
     terminal_calls = [
         c

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -14,6 +14,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from lionagi.state.db import NO_CURSOR_CLAIM
 from tests._scheduler_claims import fire_with_claim, persisting_update_schedule
 
 NY = ZoneInfo("America/New_York")
@@ -2670,8 +2671,20 @@ class _StatefulSvc:
     async def list_schedules(self, *, enabled=None):
         return []
 
-    async def update_schedule(self, schedule_id, **fields):
+    async def update_schedule(
+        self,
+        schedule_id,
+        *,
+        guard_cursor_forward=False,
+        expect_next_fire_at=NO_CURSOR_CLAIM,
+        expect_github_cursor=NO_CURSOR_CLAIM,
+        **fields,
+    ):
+        # Mirrors the real signature and return type. Absorbing the claims into **fields
+        # would record them as schedule columns and return None, which the recovery path
+        # reads as a refusal, so a test reusing this fake would model a different interface.
         self.schedule_updates.append((schedule_id, fields))
+        return True
 
     async def count_schedule_runs(
         self,
@@ -2694,7 +2707,13 @@ class _StatefulSvc:
         self.runs[run["id"]] = dict(run)
 
     async def create_schedule_run_and_advance(
-        self, run, *, schedule_id, schedule_fields, expect_next_fire_at
+        self,
+        run,
+        *,
+        schedule_id,
+        schedule_fields,
+        expect_next_fire_at,
+        expect_github_cursor=NO_CURSOR_CLAIM,
     ):
         self.runs[run["id"]] = dict(run)
         self.schedule_updates.append((schedule_id, dict(schedule_fields)))

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -15,7 +15,7 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from lionagi.state.db import NO_CURSOR_CLAIM
-from tests._scheduler_claims import fire_with_claim, persisting_update_schedule
+from tests._scheduler_claims import claim_holds, fire_with_claim, persisting_update_schedule
 
 NY = ZoneInfo("America/New_York")
 
@@ -2659,7 +2659,13 @@ class _StatefulSvc:
         self,
         existing_runs: dict[str, dict] | None = None,
         fail_create_invocation_times: int = 0,
+        schedule_row: dict | None = None,
     ):
+        # Stands for the schedule row the claims are decided against. Empty by default, which
+        # reads as a row whose cursors are NULL; a test modelling a refusal seeds it. Held by
+        # reference rather than copied, so a caller passing the schedule dict it also hands the
+        # engine sees its own writes, the way a caller re-reading the row would.
+        self.schedule_row: dict = schedule_row if schedule_row is not None else {}
         self.runs: dict[str, dict] = dict(existing_runs or {})
         self.schedule_updates: list[tuple[str, dict]] = []
         self._fail_create_invocation_times = fail_create_invocation_times
@@ -2670,6 +2676,16 @@ class _StatefulSvc:
 
     async def list_schedules(self, *, enabled=None):
         return []
+
+    def _claims_hold(self, expect_next_fire_at, expect_github_cursor) -> bool:
+        """Decide both claims against the modelled row rather than accepting either.
+
+        Returning True regardless would let a claim-dependent test pass without the claim
+        being checked at all, which is the same as not having written the claim.
+        """
+        return claim_holds(self.schedule_row.get("next_fire_at"), expect_next_fire_at) and (
+            claim_holds(self.schedule_row.get("github_cursor"), expect_github_cursor)
+        )
 
     async def update_schedule(
         self,
@@ -2683,7 +2699,10 @@ class _StatefulSvc:
         # Mirrors the real signature and return type. Absorbing the claims into **fields
         # would record them as schedule columns and return None, which the recovery path
         # reads as a refusal, so a test reusing this fake would model a different interface.
+        if not self._claims_hold(expect_next_fire_at, expect_github_cursor):
+            return False
         self.schedule_updates.append((schedule_id, fields))
+        self.schedule_row.update(fields)
         return True
 
     async def count_schedule_runs(
@@ -2715,8 +2734,11 @@ class _StatefulSvc:
         expect_next_fire_at,
         expect_github_cursor=NO_CURSOR_CLAIM,
     ):
+        if not self._claims_hold(expect_next_fire_at, expect_github_cursor):
+            return False
         self.runs[run["id"]] = dict(run)
         self.schedule_updates.append((schedule_id, dict(schedule_fields)))
+        self.schedule_row.update(schedule_fields)
         return True
 
     async def schedule_run_exists_since(self, schedule_id, since):
@@ -2814,9 +2836,11 @@ async def test_max_runs_reservation_released_lets_next_schedule_check_run():
     count (not an over-counted stale claim)."""
     from lionagi.studio.scheduler.engine import SchedulerEngine
 
-    svc = _StatefulSvc()
-    engine = SchedulerEngine(svc)
     schedule = _minimal_schedule(id="sched-multi", max_runs=2)
+    # The fake decides the due-instant claim against this row, so it is the same object the
+    # engine is handed: a fire advances it, and the next fire claims the advanced value.
+    svc = _StatefulSvc(schedule_row=schedule)
+    engine = SchedulerEngine(svc)
 
     with (
         patch(

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -8,10 +8,13 @@ import asyncio
 import logging
 import time
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
+
+from tests._scheduler_claims import fire_with_claim, persisting_update_schedule
 
 NY = ZoneInfo("America/New_York")
 
@@ -249,7 +252,7 @@ async def test_fire_happy_path_records_invocation_and_run():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-001", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-001", trigger_context={"scheduled": True})
 
     svc.create_invocation.assert_awaited_once()
     # Occurrence-insert + cursor-advance land together, atomically, through
@@ -312,7 +315,7 @@ async def test_fire_records_substituted_prompt_not_raw_template():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-002", trigger_context={"pr_number": "42"})
+        await fire_with_claim(engine, schedule, "run-002", trigger_context={"pr_number": "42"})
 
     svc.create_invocation.assert_awaited_once()
     (invocation_payload,), _kwargs = svc.create_invocation.await_args
@@ -341,7 +344,7 @@ async def test_fire_records_empty_rendered_prompt_as_is_not_playbook_fallback():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-002b", trigger_context={"payload": ""})
+        await fire_with_claim(engine, schedule, "run-002b", trigger_context={"payload": ""})
 
     svc.create_invocation.assert_awaited_once()
     (invocation_payload,), _kwargs = svc.create_invocation.await_args
@@ -366,7 +369,7 @@ async def test_fire_executable_resolution_failure_records_failed_run_with_action
         ),
         patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=AsyncMock()) as spawn_mock,
     ):
-        await engine._fire(schedule, "run-003", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-003", trigger_context={"scheduled": True})
 
     spawn_mock.assert_not_awaited()
     svc.create_schedule_run.assert_not_awaited()
@@ -396,7 +399,7 @@ async def test_fire_nonzero_exit_records_failed_status():
             new=AsyncMock(return_value=(1, "error text")),
         ),
     ):
-        await engine._fire(schedule, "run-002", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-002", trigger_context={"scheduled": True})
 
     # Find the update_status call for "schedule_run" with new_status="failed"
     failed_calls = [
@@ -426,7 +429,7 @@ async def test_fire_build_argv_exception_records_failed_run():
             new=AsyncMock(),
         ) as mock_spawn,
     ):
-        await engine._fire(schedule, "run-003", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-003", trigger_context={"scheduled": True})
 
     mock_spawn.assert_not_awaited()
     svc.create_schedule_run.assert_not_awaited()
@@ -457,7 +460,7 @@ async def test_fire_cancellation_records_cancelled_run():
         ),
     ):
         with pytest.raises(asyncio.CancelledError):
-            await engine._fire(schedule, "run-004", trigger_context={"scheduled": True})
+            await fire_with_claim(engine, schedule, "run-004", trigger_context={"scheduled": True})
 
     # "Scheduler shutdown" is a placeholder, not a measured cause, and it used
     # to be written unguarded ahead of the guarded transition. A run already
@@ -509,7 +512,7 @@ async def test_fire_inner_exception_records_failed_and_does_not_reraise():
         ),
     ):
         # Should not raise
-        await engine._fire(schedule, "run-005", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-005", trigger_context={"scheduled": True})
 
     failed_calls = [
         c for c in svc.update_status.await_args_list if c.kwargs.get("new_status") == "failed"
@@ -537,7 +540,7 @@ async def test_fire_chain_depth_0_tracks_running():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-006", trigger_context={}, chain_depth=0)
+        await fire_with_claim(engine, schedule, "run-006", trigger_context={}, chain_depth=0)
 
     assert sid not in engine._running
 
@@ -561,8 +564,13 @@ async def test_fire_chain_depth_nonzero_does_not_track_running():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(
-            schedule, "run-007", trigger_context={}, chain_depth=1, chain_parent_id="run-006"
+        await fire_with_claim(
+            engine,
+            schedule,
+            "run-007",
+            trigger_context={},
+            chain_depth=1,
+            chain_parent_id="run-006",
         )
 
     assert schedule["id"] not in engine._running
@@ -582,7 +590,9 @@ async def test_fire_on_success_chain_fires():
     fire_calls: list[tuple] = []
     original_fire = engine._fire
 
-    async def _patched_fire(sched, run_id, *, trigger_context, chain_parent_id=None, chain_depth=0):
+    async def _patched_fire(
+        sched, run_id, *, trigger_context, chain_parent_id=None, chain_depth=0, **kw
+    ):
         fire_calls.append((sched["id"], chain_depth))
         if chain_depth > 0:
             return
@@ -592,6 +602,7 @@ async def test_fire_on_success_chain_fires():
             trigger_context=trigger_context,
             chain_parent_id=chain_parent_id,
             chain_depth=chain_depth,
+            **kw,
         )
 
     engine._fire = _patched_fire  # type: ignore[method-assign]
@@ -606,7 +617,13 @@ async def test_fire_on_success_chain_fires():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await original_fire(schedule, "run-chain", trigger_context={}, chain_depth=0)
+        await original_fire(
+            schedule,
+            "run-chain",
+            trigger_context={},
+            chain_depth=0,
+            expect_next_fire_at=schedule.get("next_fire_at"),
+        )
 
     # The chain should have been triggered
     chained = [c for c in fire_calls if c[1] == 1]
@@ -637,7 +654,9 @@ async def test_fire_running_child_with_on_success_does_not_run_success_chain():
     fire_calls: list[tuple] = []
     original_fire = engine._fire
 
-    async def _patched_fire(sched, run_id, *, trigger_context, chain_parent_id=None, chain_depth=0):
+    async def _patched_fire(
+        sched, run_id, *, trigger_context, chain_parent_id=None, chain_depth=0, **kw
+    ):
         fire_calls.append((sched["id"], chain_depth))
         if chain_depth > 0:
             return
@@ -647,6 +666,7 @@ async def test_fire_running_child_with_on_success_does_not_run_success_chain():
             trigger_context=trigger_context,
             chain_parent_id=chain_parent_id,
             chain_depth=chain_depth,
+            **kw,
         )
 
     engine._fire = _patched_fire  # type: ignore[method-assign]
@@ -661,7 +681,13 @@ async def test_fire_running_child_with_on_success_does_not_run_success_chain():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await original_fire(schedule, "run-empty-success", trigger_context={}, chain_depth=0)
+        await original_fire(
+            schedule,
+            "run-empty-success",
+            trigger_context={},
+            chain_depth=0,
+            expect_next_fire_at=schedule.get("next_fire_at"),
+        )
 
     # Assertion 1: status. completed_empty must not be recorded as "completed".
     terminal_calls = [
@@ -731,7 +757,7 @@ async def test_fire_invocation_finalization_cas_miss_is_checked_and_does_not_rai
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-cas", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-cas", trigger_context={"scheduled": True})
 
     svc.count_schedule_runs.assert_awaited()
 
@@ -788,7 +814,7 @@ async def test_fire_exception_during_invocation_resolution_marks_run_failed_once
             new=AsyncMock(side_effect=_resolve_invocation_terminal),
         ),
     ):
-        await engine._fire(schedule, "run-late-exc", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-late-exc", trigger_context={"scheduled": True})
 
     assert resolve_calls["n"] == 2, "the broad-except handler must retry invocation resolution"
     assert len(schedule_run_terminal_calls) == 1, (
@@ -826,7 +852,9 @@ async def test_fire_chain_runs_when_terminal_write_loses_cas():
     fire_calls: list[tuple] = []
     original_fire = engine._fire
 
-    async def _patched_fire(sched, run_id, *, trigger_context, chain_parent_id=None, chain_depth=0):
+    async def _patched_fire(
+        sched, run_id, *, trigger_context, chain_parent_id=None, chain_depth=0, **kw
+    ):
         fire_calls.append((sched["id"], chain_depth))
         if chain_depth > 0:
             return
@@ -836,6 +864,7 @@ async def test_fire_chain_runs_when_terminal_write_loses_cas():
             trigger_context=trigger_context,
             chain_parent_id=chain_parent_id,
             chain_depth=chain_depth,
+            **kw,
         )
 
     engine._fire = _patched_fire  # type: ignore[method-assign]
@@ -850,7 +879,13 @@ async def test_fire_chain_runs_when_terminal_write_loses_cas():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await original_fire(schedule, "run-chain-cas", trigger_context={}, chain_depth=0)
+        await original_fire(
+            schedule,
+            "run-chain-cas",
+            trigger_context={},
+            chain_depth=0,
+            expect_next_fire_at=schedule.get("next_fire_at"),
+        )
 
     chained = [c for c in fire_calls if c[1] == 1]
     assert chained, "on_success chain must still fire when the invocation write lost its CAS"
@@ -889,7 +924,9 @@ async def test_fire_invalid_action_invocation_cas_miss_is_checked_and_does_not_r
         "lionagi.studio.scheduler.subprocess.build_argv",
         side_effect=RuntimeError("bad template"),
     ):
-        await engine._fire(schedule, "run-invalid-action", trigger_context={"scheduled": True})
+        await fire_with_claim(
+            engine, schedule, "run-invalid-action", trigger_context={"scheduled": True}
+        )
 
     svc.count_schedule_runs.assert_awaited()
 
@@ -928,7 +965,9 @@ async def test_fire_cancellation_schedule_run_cas_miss_does_not_skip_side_effect
         ),
     ):
         with pytest.raises(asyncio.CancelledError):
-            await engine._fire(schedule, "run-cancel-cas", trigger_context={"scheduled": True})
+            await fire_with_claim(
+                engine, schedule, "run-cancel-cas", trigger_context={"scheduled": True}
+            )
 
     # Invocation finalization must still be attempted despite the lost CAS
     # race on the schedule_run status write above.
@@ -977,7 +1016,9 @@ async def test_fire_normal_path_discards_counters_when_invocation_write_loses_ra
             new=AsyncMock(),
         ) as flush_mock,
     ):
-        await engine._fire(schedule, "run-race-normal", trigger_context={"scheduled": True})
+        await fire_with_claim(
+            engine, schedule, "run-race-normal", trigger_context={"scheduled": True}
+        )
 
     flush_mock.assert_not_awaited()
     assert engine._signal_bus.pop_run_counters("run-race-normal") is None
@@ -1004,7 +1045,9 @@ async def test_fire_invalid_action_discards_counters_when_invocation_write_loses
             new=AsyncMock(),
         ) as flush_mock,
     ):
-        await engine._fire(schedule, "run-race-invalid", trigger_context={"scheduled": True})
+        await fire_with_claim(
+            engine, schedule, "run-race-invalid", trigger_context={"scheduled": True}
+        )
 
     flush_mock.assert_not_awaited()
     assert engine._signal_bus.pop_run_counters("run-race-invalid") is None
@@ -1035,7 +1078,9 @@ async def test_fire_cancellation_discards_counters_when_invocation_write_loses_r
         ) as flush_mock,
     ):
         with pytest.raises(asyncio.CancelledError):
-            await engine._fire(schedule, "run-race-cancel", trigger_context={"scheduled": True})
+            await fire_with_claim(
+                engine, schedule, "run-race-cancel", trigger_context={"scheduled": True}
+            )
 
     flush_mock.assert_not_awaited()
     assert engine._signal_bus.pop_run_counters("run-race-cancel") is None
@@ -1065,7 +1110,7 @@ async def test_fire_exception_path_discards_counters_when_invocation_write_loses
             new=AsyncMock(),
         ) as flush_mock,
     ):
-        await engine._fire(schedule, "run-race-exc", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-race-exc", trigger_context={"scheduled": True})
 
     flush_mock.assert_not_awaited()
     assert engine._signal_bus.pop_run_counters("run-race-exc") is None
@@ -1095,7 +1140,9 @@ async def test_fire_telemetry_flush_failure_does_not_alter_run_outcome():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-flush-fails", trigger_context={"scheduled": True})
+        await fire_with_claim(
+            engine, schedule, "run-flush-fails", trigger_context={"scheduled": True}
+        )
 
     # Exactly the one terminal write from the normal completion path -- no
     # second rewrite from a broad-except handler catching a telemetry failure
@@ -1144,7 +1191,7 @@ async def test_fire_normal_completion_dispatches_signal_before_flush_pops_counte
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-order", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-order", trigger_context={"scheduled": True})
 
     node_metadata_calls = [
         call.kwargs["node_metadata"]
@@ -1445,7 +1492,7 @@ async def test_fire_at_trigger_persists_explicit_none_next_fire_at():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-001", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-001", trigger_context={"scheduled": True})
 
     (_run_payload,), kwargs = svc.create_schedule_run_and_advance.await_args
     schedule_fields = kwargs["schedule_fields"]
@@ -1470,13 +1517,77 @@ async def test_recover_missed_fire_run_once_reserves_cleared_next_fire_for_at_tr
         next_fire_at=time.time() - 60,
     )
 
-    fired: list[str] = []
+    due_instant = schedule["next_fire_at"]
+    fired: list[tuple[str, Any]] = []
+    engine._tracked_fire = lambda sched, run_id, **kw: fired.append(
+        (run_id, kw.get("expect_next_fire_at"))
+    )
+
+    await engine._recover_missed_fire_run_once(schedule, time.time())
+
+    # The reserve claims the instant it is recovering, and the fire that follows claims the
+    # value the reserve wrote, not the pre-reserve value still sitting in the local dict.
+    svc.update_schedule.assert_awaited_once_with(
+        "sched-001", expect_next_fire_at=due_instant, next_fire_at=None
+    )
+    assert len(fired) == 1
+    assert fired[0][1] is None
+
+
+@pytest.mark.asyncio
+async def test_missed_fire_recovery_claims_the_instant_it_reserved_not_the_one_it_read():
+    """The recovery moves the cursor itself, so it must claim the value it wrote.
+
+    Claiming the pre-reserve value the local dict still holds refuses the recovery against
+    its own reservation: no occurrence, and the invocation cancelled.
+    """
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    due = time.time() - 60
+    schedule = _minimal_schedule(next_fire_at=due, missed_fire_policy="run_once")
+    # The row, kept apart from the dict the recovery holds: a real reserve does not write back
+    # into the caller's snapshot, so the snapshot stays stale exactly as it does in production.
+    stored: dict[str, Any] = {"next_fire_at": due}
+
+    async def _reserve(sid, *, expect_next_fire_at=None, **fields):
+        if stored["next_fire_at"] != expect_next_fire_at:
+            return False
+        stored.update(fields)
+        return True
+
+    svc.update_schedule = AsyncMock(side_effect=_reserve)
+
+    fired: list[Any] = []
+    engine._tracked_fire = lambda sched, run_id, **kw: fired.append(kw["expect_next_fire_at"])
+
+    await engine._recover_missed_fire_run_once(schedule, time.time())
+
+    assert len(fired) == 1
+    reserved = stored["next_fire_at"]
+    assert reserved != due, "the reserve did not move the cursor, so this proves nothing"
+    assert schedule["next_fire_at"] == due, "the snapshot must stay stale for this to mean anything"
+    assert fired[0] == reserved
+
+
+@pytest.mark.asyncio
+async def test_missed_fire_recovery_stands_down_when_another_scheduler_reserved_first():
+    """Two daemons recovering one missed instant: the reserve is the claim, so one wins."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(next_fire_at=time.time() - 60, missed_fire_policy="run_once")
+    # Already reserved by someone else: the row no longer holds the value this caller read.
+    svc.update_schedule = AsyncMock(return_value=False)
+
+    fired: list[Any] = []
     engine._tracked_fire = lambda sched, run_id, **kw: fired.append(run_id)
 
     await engine._recover_missed_fire_run_once(schedule, time.time())
 
-    svc.update_schedule.assert_awaited_once_with("sched-001", next_fire_at=None)
-    assert len(fired) == 1
+    assert fired == []
 
 
 @pytest.mark.asyncio
@@ -1726,13 +1837,8 @@ async def test_startup_missed_fire_run_once_recovers_and_advances(monkeypatch):
     svc = _make_svc()
     svc.list_schedules = AsyncMock(return_value=[schedule])
 
-    async def _persist_update_schedule(sid, **fields):
-        # Mutate the same dict list_schedules() keeps returning, mirroring
-        # a real DB: a persisted update must be visible to the next fetch.
-        if sid == schedule["id"]:
-            schedule.update(fields)
-
-    svc.update_schedule = AsyncMock(side_effect=_persist_update_schedule)
+    # Persists into the same dict list_schedules() keeps returning, mirroring a real DB.
+    svc.update_schedule = AsyncMock(side_effect=persisting_update_schedule(schedule))
     engine = SchedulerEngine(svc=svc)
 
     original_tracked_fire = engine._tracked_fire
@@ -1811,13 +1917,8 @@ async def test_startup_missed_fire_run_once_not_double_fired_by_immediate_tick(
     svc = _make_svc()
     svc.list_schedules = AsyncMock(return_value=[schedule])
 
-    async def _persist_update_schedule(sid, **fields):
-        # Mutate the same dict list_schedules() keeps returning, mirroring
-        # a real DB: a persisted update must be visible to the next fetch.
-        if sid == schedule["id"]:
-            schedule.update(fields)
-
-    svc.update_schedule = AsyncMock(side_effect=_persist_update_schedule)
+    # Persists into the same dict list_schedules() keeps returning, mirroring a real DB.
+    svc.update_schedule = AsyncMock(side_effect=persisting_update_schedule(schedule))
     engine = SchedulerEngine(svc=svc)
 
     original_tracked_fire = engine._tracked_fire
@@ -1905,15 +2006,16 @@ async def test_startup_missed_fire_run_once_reserve_failure_skips_recovery(monke
 
     calls = {"n": 0}
 
-    async def _first_write_fails(sid, **fields):
+    _persist = persisting_update_schedule(schedule)
+
+    async def _first_write_fails(sid, **kwargs):
         # The reserve (first write) hits a transient storage failure; later
         # writes (the normal fire's own advance) succeed and persist into
         # the same dict list_schedules() keeps returning.
         calls["n"] += 1
         if calls["n"] == 1:
             raise RuntimeError("storage briefly unavailable")
-        if sid == schedule["id"]:
-            schedule.update(fields)
+        return await _persist(sid, **kwargs)
 
     svc.update_schedule = AsyncMock(side_effect=_first_write_fails)
     engine = SchedulerEngine(svc=svc)
@@ -1987,11 +2089,7 @@ async def test_startup_missed_fire_skip_records_no_recovery_and_advances(monkeyp
     svc = _make_svc()
     svc.list_schedules = AsyncMock(return_value=[schedule])
 
-    async def _persist_update_schedule(sid, **fields):
-        if sid == schedule["id"]:
-            schedule.update(fields)
-
-    svc.update_schedule = AsyncMock(side_effect=_persist_update_schedule)
+    svc.update_schedule = AsyncMock(side_effect=persisting_update_schedule(schedule))
     engine = SchedulerEngine(svc=svc)
 
     with patch.object(engine, "_tracked_fire") as mock_tracked:
@@ -2303,7 +2401,7 @@ async def test_max_runs_reached_auto_disables_schedule():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-once-1", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-once-1", trigger_context={"scheduled": True})
 
     svc.count_schedule_runs.assert_awaited_with("sched-001", chain_depth=0)
     disable_calls = [c for c in svc.update_schedule.await_args_list if c.kwargs.get("enabled") == 0]
@@ -2426,8 +2524,8 @@ async def test_fire_transfers_max_runs_claim_at_occurrence_commit():
             new=AsyncMock(side_effect=spawn),
         ),
     ):
-        await engine._fire(
-            schedule, "run-xfer", trigger_context={"scheduled": True}, max_runs_claim=claim
+        await fire_with_claim(
+            engine, schedule, "run-xfer", trigger_context={"scheduled": True}, max_runs_claim=claim
         )
 
     assert inflight_during_action == [0], (
@@ -2456,7 +2554,7 @@ async def test_max_runs_not_reached_leaves_schedule_enabled():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-once-2", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-once-2", trigger_context={"scheduled": True})
 
     disable_calls = [c for c in svc.update_schedule.await_args_list if c.kwargs.get("enabled") == 0]
     assert not disable_calls
@@ -2481,7 +2579,9 @@ async def test_max_runs_none_is_unlimited_never_checks_count():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-unlimited", trigger_context={"scheduled": True})
+        await fire_with_claim(
+            engine, schedule, "run-unlimited", trigger_context={"scheduled": True}
+        )
 
     svc.count_schedule_runs.assert_not_awaited()
     disable_calls = [c for c in svc.update_schedule.await_args_list if c.kwargs.get("enabled") == 0]
@@ -2507,7 +2607,8 @@ async def test_max_runs_chain_child_never_checked():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(
+        await fire_with_claim(
+            engine,
             schedule,
             "run-child",
             trigger_context={"scheduled": True},
@@ -2534,7 +2635,7 @@ async def test_max_runs_build_argv_exception_still_checked():
         "lionagi.studio.scheduler.subprocess.build_argv",
         side_effect=ValueError("bad action_kind"),
     ):
-        await engine._fire(schedule, "run-badargv", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-badargv", trigger_context={"scheduled": True})
 
     svc.count_schedule_runs.assert_awaited_with("sched-001", chain_depth=0)
     disable_calls = [c for c in svc.update_schedule.await_args_list if c.kwargs.get("enabled") == 0]
@@ -2879,7 +2980,7 @@ async def test_fire_command_kind_skips_li_resolution():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-cmd-001", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-cmd-001", trigger_context={"scheduled": True})
 
     resolve_mock.assert_not_called()
     svc.create_schedule_run_and_advance.assert_awaited_once()
@@ -2917,7 +3018,7 @@ async def test_fire_command_kind_nonzero_exit_records_failed_status():
             new=AsyncMock(return_value=(1, "command failed")),
         ),
     ):
-        await engine._fire(schedule, "run-cmd-002", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-cmd-002", trigger_context={"scheduled": True})
 
     failed_calls = [
         c
@@ -3007,7 +3108,7 @@ async def test_fire_exception_keeps_the_error_detail_a_prior_finalizer_wrote(sta
             new=AsyncMock(side_effect=_reaper_then_raise),
         ),
     ):
-        await engine._fire(schedule, run_id, trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, run_id, trigger_context={"scheduled": True})
 
     row = await state_db.get_schedule_run(run_id)
     assert row["error_detail"] == "TimeoutError: run exceeded its deadline"
@@ -3054,7 +3155,7 @@ async def test_fire_cancellation_keeps_the_error_detail_a_prior_finalizer_wrote(
         ),
     ):
         with pytest.raises(asyncio.CancelledError):
-            await engine._fire(schedule, run_id, trigger_context={"scheduled": True})
+            await fire_with_claim(engine, schedule, run_id, trigger_context={"scheduled": True})
 
     row = await state_db.get_schedule_run(run_id)
     assert row["status"] == "timed_out"
@@ -3106,7 +3207,7 @@ async def test_fire_completion_keeps_the_outcome_a_prior_finalizer_wrote(state_d
             new=AsyncMock(side_effect=_reaper_then_exit_nonzero),
         ),
     ):
-        await engine._fire(schedule, run_id, trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, run_id, trigger_context={"scheduled": True})
 
     row = await state_db.get_schedule_run(run_id)
     assert row["status"] == "timed_out"
@@ -3147,7 +3248,7 @@ async def test_fire_exception_records_the_real_exception_text_as_error_detail(st
             new=AsyncMock(side_effect=_raise_after_launch),
         ),
     ):
-        await engine._fire(schedule, run_id, trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, run_id, trigger_context={"scheduled": True})
 
     row = await state_db.get_schedule_run(run_id)
     assert row["status"] == "failed"
@@ -3191,7 +3292,8 @@ async def test_fire_deadline_records_one_timed_out_terminal_and_releases_slot(
             new=AsyncMock(side_effect=_deadline),
         ),
     ):
-        await engine._fire(
+        await fire_with_claim(
+            engine,
             schedule,
             run_id,
             trigger_context={"scheduled": True},

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -2592,9 +2592,12 @@ class _StatefulSvc:
     async def create_schedule_run(self, run):
         self.runs[run["id"]] = dict(run)
 
-    async def create_schedule_run_and_advance(self, run, *, schedule_id, schedule_fields):
+    async def create_schedule_run_and_advance(
+        self, run, *, schedule_id, schedule_fields, expect_next_fire_at
+    ):
         self.runs[run["id"]] = dict(run)
         self.schedule_updates.append((schedule_id, dict(schedule_fields)))
+        return True
 
     async def schedule_run_exists_since(self, schedule_id, since):
         return any(

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -725,25 +725,37 @@ async def test_a_concurrent_advance_between_events_refuses_the_later_write():
     schedule = _minimal_schedule(next_fire_at=9_000.0, poll_interval_sec=60, github_cursor=None)
     svc = _make_svc()
     stored = {"next_fire_at": schedule["next_fire_at"], "github_cursor": None}
-    written: list[int] = []
+    writes: list[tuple[str, int]] = []
+    writer = "first"
 
     advance = claiming_advance(
         stored,
-        on_write=lambda payload: written.append(
-            payload["trigger_context"]["github_events"][0]["pr_number"]
+        on_write=lambda payload: writes.append(
+            (writer, payload["trigger_context"]["github_events"][0]["pr_number"])
         ),
     )
     second_scheduler_ran = False
 
     async def _advance_then_lose_the_race(payload, **kwargs):
-        nonlocal second_scheduler_ran
+        nonlocal second_scheduler_ran, writer
         won = await advance(payload, **kwargs)
         pr = payload["trigger_context"]["github_events"][0]["pr_number"]
         if won and pr == 1 and not second_scheduler_ran:
             # The other scheduler polls here, sees the cursor this write just advanced, and
-            # takes event 2 for itself before this loop reaches it.
+            # takes event 2 for itself before this loop reaches it. It goes through the same
+            # claim-aware write rather than editing the row: moving the cursor by hand would
+            # set up the race without ever exercising the claim that has to decide it.
             second_scheduler_ran = True
-            stored["github_cursor"] = "2026-01-01T00:00:02Z"
+            writer = "second"
+            other_won = await advance(
+                {"trigger_context": {"github_events": [{"pr_number": 2}]}},
+                schedule_id=schedule["id"],
+                schedule_fields={"github_cursor": "2026-01-01T00:00:02Z"},
+                expect_next_fire_at=NO_CURSOR_CLAIM,
+                expect_github_cursor="2026-01-01T00:00:01Z",
+            )
+            writer = "first"
+            assert other_won, "the second scheduler was refused, so the race never happened"
         return won
 
     svc.create_schedule_run_and_advance = AsyncMock(side_effect=_advance_then_lose_the_race)
@@ -763,7 +775,9 @@ async def test_a_concurrent_advance_between_events_refuses_the_later_write():
         await engine._tick_github(schedule, now=10_000.0)
 
     assert second_scheduler_ran, "the interleave never happened, so nothing was tested"
-    assert written == [1], f"event 2 was written by both schedulers: {written}"
+    # The second scheduler wrote event 2; the first scheduler reached it afterwards and its
+    # claim was refused, so it appears nowhere against event 2.
+    assert writes == [("first", 1), ("second", 2)], writes
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from lionagi.state.db import NO_CURSOR_CLAIM
 from lionagi.studio.scheduler import github as gh_mod
 from lionagi.studio.scheduler.engine import SchedulerEngine
 from lionagi.studio.scheduler.github import GithubPollItem, GithubPollResult
@@ -194,7 +195,12 @@ async def test_max_runs_exhaustion_mid_batch_stops_cursor_before_undispatched(ca
     fired = 0
 
     async def _create_schedule_run_and_advance(
-        _payload, *, schedule_id, schedule_fields, expect_next_fire_at
+        _payload,
+        *,
+        schedule_id,
+        schedule_fields,
+        expect_next_fire_at,
+        expect_github_cursor=NO_CURSOR_CLAIM,
     ):
         nonlocal fired
         fired += 1
@@ -403,7 +409,12 @@ async def test_undispatched_event_is_relisted_on_next_poll(monkeypatch, caplog):
     fired = 0
 
     async def _create_schedule_run_and_advance(
-        _payload, *, schedule_id, schedule_fields, expect_next_fire_at
+        _payload,
+        *,
+        schedule_id,
+        schedule_fields,
+        expect_next_fire_at,
+        expect_github_cursor=NO_CURSOR_CLAIM,
     ):
         nonlocal fired
         fired += 1
@@ -490,7 +501,12 @@ async def test_merged_mode_truncated_scan_no_skip_no_duplicate_across_two_ticks(
     fired_prs: list[int] = []
 
     async def _create_schedule_run_and_advance(
-        payload, *, schedule_id, schedule_fields, expect_next_fire_at
+        payload,
+        *,
+        schedule_id,
+        schedule_fields,
+        expect_next_fire_at,
+        expect_github_cursor=NO_CURSOR_CLAIM,
     ):
         fired_prs.append(payload["trigger_context"]["github_events"][0]["pr_number"])
         return True
@@ -657,7 +673,7 @@ async def test_every_event_in_a_batch_is_written_though_each_one_advances_the_cu
     claimed the cursor the poll started with, only the first could ever be written and a
     multi-event batch would silently serialize into one event per poll.
     """
-    from tests._scheduler_claims import claim_holds
+    from tests._scheduler_claims import claiming_advance
 
     schedule = _minimal_schedule(next_fire_at=9_000.0, poll_interval_sec=60, github_cursor=None)
     svc = _make_svc()
@@ -668,14 +684,9 @@ async def test_every_event_in_a_batch_is_written_though_each_one_advances_the_cu
     stored = {"next_fire_at": schedule["next_fire_at"], "github_cursor": None}
     written: list[str] = []
 
-    async def _advance(payload, *, schedule_id, schedule_fields, expect_next_fire_at):
-        if not claim_holds(stored["next_fire_at"], expect_next_fire_at):
-            return False
-        stored.update(schedule_fields)
-        written.append(payload["id"])
-        return True
-
-    svc.create_schedule_run_and_advance = AsyncMock(side_effect=_advance)
+    svc.create_schedule_run_and_advance = AsyncMock(
+        side_effect=claiming_advance(stored, on_write=lambda payload: written.append(payload["id"]))
+    )
 
     items = [
         _item(1, "2026-01-01T00:00:01Z"),
@@ -697,3 +708,104 @@ async def test_every_event_in_a_batch_is_written_though_each_one_advances_the_cu
 
     assert len(written) == 3, f"expected one occurrence per event, wrote {len(written)}"
     assert stored["github_cursor"] == "2026-01-01T00:00:03Z"
+
+
+@pytest.mark.asyncio
+async def test_a_concurrent_advance_between_events_refuses_the_later_write():
+    """A second scheduler that polls mid-batch must not get a second copy of one event.
+
+    The first scheduler dispatches event 1, which advances github_cursor. A second scheduler
+    polling in that window reads the advanced cursor, so its poll starts at event 2 and its
+    claim on event 2 succeeds. The first scheduler then reaches event 2 itself. Only one of
+    them may write it, and the cursor is what decides: next_fire_at is identical for every
+    event of one poll, so claiming that instead would let both through.
+    """
+    from tests._scheduler_claims import claiming_advance
+
+    schedule = _minimal_schedule(next_fire_at=9_000.0, poll_interval_sec=60, github_cursor=None)
+    svc = _make_svc()
+    stored = {"next_fire_at": schedule["next_fire_at"], "github_cursor": None}
+    written: list[int] = []
+
+    advance = claiming_advance(
+        stored,
+        on_write=lambda payload: written.append(
+            payload["trigger_context"]["github_events"][0]["pr_number"]
+        ),
+    )
+    second_scheduler_ran = False
+
+    async def _advance_then_lose_the_race(payload, **kwargs):
+        nonlocal second_scheduler_ran
+        won = await advance(payload, **kwargs)
+        pr = payload["trigger_context"]["github_events"][0]["pr_number"]
+        if won and pr == 1 and not second_scheduler_ran:
+            # The other scheduler polls here, sees the cursor this write just advanced, and
+            # takes event 2 for itself before this loop reaches it.
+            second_scheduler_ran = True
+            stored["github_cursor"] = "2026-01-01T00:00:02Z"
+        return won
+
+    svc.create_schedule_run_and_advance = AsyncMock(side_effect=_advance_then_lose_the_race)
+
+    items = [_item(1, "2026-01-01T00:00:01Z"), _item(2, "2026-01-01T00:00:02Z")]
+    engine = SchedulerEngine(svc=svc)
+    build_argv_patch, spawn_patch = _spawn_patches()
+    with (
+        build_argv_patch,
+        spawn_patch,
+        patch.object(
+            gh_mod,
+            "github_poll",
+            new=AsyncMock(return_value=GithubPollResult(items=items, scan_complete=True)),
+        ),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert second_scheduler_ran, "the interleave never happened, so nothing was tested"
+    assert written == [1], f"event 2 was written by both schedulers: {written}"
+
+
+@pytest.mark.asyncio
+async def test_a_filtered_event_between_two_dispatched_ones_does_not_break_the_claim():
+    """The claim follows what was written, not how far the poll has read.
+
+    A filtered-out event moves the local read position without writing anything, so a claim
+    that followed the read position would name a value no transaction ever put in the row
+    and every event after the first filtered one would be refused.
+    """
+    from tests._scheduler_claims import claiming_advance
+
+    schedule = _minimal_schedule(next_fire_at=9_000.0, poll_interval_sec=60, github_cursor=None)
+    svc = _make_svc()
+    stored = {"next_fire_at": schedule["next_fire_at"], "github_cursor": None}
+    written: list[int] = []
+
+    svc.create_schedule_run_and_advance = AsyncMock(
+        side_effect=claiming_advance(
+            stored,
+            on_write=lambda payload: written.append(
+                payload["trigger_context"]["github_events"][0]["pr_number"]
+            ),
+        )
+    )
+
+    items = [
+        _item(1, "2026-01-01T00:00:01Z"),
+        _item(2, "2026-01-01T00:00:02Z", dispatchable=False),
+        _item(3, "2026-01-01T00:00:03Z"),
+    ]
+    engine = SchedulerEngine(svc=svc)
+    build_argv_patch, spawn_patch = _spawn_patches()
+    with (
+        build_argv_patch,
+        spawn_patch,
+        patch.object(
+            gh_mod,
+            "github_poll",
+            new=AsyncMock(return_value=GithubPollResult(items=items, scan_complete=True)),
+        ),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert written == [1, 3], f"the filtered event stalled the batch: wrote {written}"

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -193,9 +193,12 @@ async def test_max_runs_exhaustion_mid_batch_stops_cursor_before_undispatched(ca
     svc = _make_svc()
     fired = 0
 
-    async def _create_schedule_run_and_advance(_payload, *, schedule_id, schedule_fields):
+    async def _create_schedule_run_and_advance(
+        _payload, *, schedule_id, schedule_fields, expect_next_fire_at
+    ):
         nonlocal fired
         fired += 1
+        return True
 
     svc.create_schedule_run_and_advance = AsyncMock(side_effect=_create_schedule_run_and_advance)
     svc.count_schedule_runs = AsyncMock(side_effect=lambda *a, **k: fired)
@@ -399,9 +402,12 @@ async def test_undispatched_event_is_relisted_on_next_poll(monkeypatch, caplog):
     svc = _make_svc()
     fired = 0
 
-    async def _create_schedule_run_and_advance(_payload, *, schedule_id, schedule_fields):
+    async def _create_schedule_run_and_advance(
+        _payload, *, schedule_id, schedule_fields, expect_next_fire_at
+    ):
         nonlocal fired
         fired += 1
+        return True
 
     svc.create_schedule_run_and_advance = AsyncMock(side_effect=_create_schedule_run_and_advance)
     svc.count_schedule_runs = AsyncMock(side_effect=lambda *a, **k: fired)
@@ -483,8 +489,11 @@ async def test_merged_mode_truncated_scan_no_skip_no_duplicate_across_two_ticks(
     svc = _make_svc()
     fired_prs: list[int] = []
 
-    async def _create_schedule_run_and_advance(payload, *, schedule_id, schedule_fields):
+    async def _create_schedule_run_and_advance(
+        payload, *, schedule_id, schedule_fields, expect_next_fire_at
+    ):
         fired_prs.append(payload["trigger_context"]["github_events"][0]["pr_number"])
+        return True
 
     svc.create_schedule_run_and_advance = AsyncMock(side_effect=_create_schedule_run_and_advance)
     svc.count_schedule_runs = AsyncMock(side_effect=lambda *a, **k: len(fired_prs))

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -647,3 +647,53 @@ async def test_tick_github_network_error_leaves_health_columns_untouched():
         await engine._tick_github(schedule, now=10_000.0)
 
     svc.update_schedule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_every_event_in_a_batch_is_written_though_each_one_advances_the_cursor():
+    """One poll cycle is one due instant, however many events it carries.
+
+    Each dispatched event advances next_fire_at in its own transaction. If every event
+    claimed the cursor the poll started with, only the first could ever be written and a
+    multi-event batch would silently serialize into one event per poll.
+    """
+    from tests._scheduler_claims import claim_holds
+
+    schedule = _minimal_schedule(next_fire_at=9_000.0, poll_interval_sec=60, github_cursor=None)
+    svc = _make_svc()
+
+    # The row, kept apart from the dict the loop holds: a real write does not reach back into
+    # the caller's snapshot, and a double that mutated it would refresh the very staleness
+    # this test exists to catch.
+    stored = {"next_fire_at": schedule["next_fire_at"], "github_cursor": None}
+    written: list[str] = []
+
+    async def _advance(payload, *, schedule_id, schedule_fields, expect_next_fire_at):
+        if not claim_holds(stored["next_fire_at"], expect_next_fire_at):
+            return False
+        stored.update(schedule_fields)
+        written.append(payload["id"])
+        return True
+
+    svc.create_schedule_run_and_advance = AsyncMock(side_effect=_advance)
+
+    items = [
+        _item(1, "2026-01-01T00:00:01Z"),
+        _item(2, "2026-01-01T00:00:02Z"),
+        _item(3, "2026-01-01T00:00:03Z"),
+    ]
+    engine = SchedulerEngine(svc=svc)
+    build_argv_patch, spawn_patch = _spawn_patches()
+    with (
+        build_argv_patch,
+        spawn_patch,
+        patch.object(
+            gh_mod,
+            "github_poll",
+            new=AsyncMock(return_value=GithubPollResult(items=items, scan_complete=True)),
+        ),
+    ):
+        await engine._tick_github(schedule, now=10_000.0)
+
+    assert len(written) == 3, f"expected one occurrence per event, wrote {len(written)}"
+    assert stored["github_cursor"] == "2026-01-01T00:00:03Z"

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -14,6 +14,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests._scheduler_claims import fire_with_claim
+
 
 def _minimal_schedule(**overrides) -> dict:
     base = {
@@ -455,7 +457,8 @@ async def test_fire_releases_global_slot_on_completion(monkeypatch):
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(
+        await fire_with_claim(
+            engine,
             schedule,
             "run-001",
             trigger_context={"scheduled": True},
@@ -482,7 +485,8 @@ async def test_fire_releases_global_slot_on_exception(monkeypatch):
         "lionagi.studio.scheduler.subprocess.build_argv",
         side_effect=ValueError("bad action_kind"),
     ):
-        await engine._fire(
+        await fire_with_claim(
+            engine,
             schedule,
             "run-002",
             trigger_context={"scheduled": True},

--- a/tests/studio/test_scheduler_notify.py
+++ b/tests/studio/test_scheduler_notify.py
@@ -110,6 +110,8 @@ async def test_unregistered_scope_never_fires():
 
 from unittest.mock import AsyncMock, patch  # noqa: E402
 
+from tests._scheduler_claims import fire_inner_with_claim, fire_with_claim
+
 
 def _notify_schedule(**overrides) -> dict:
     base = {
@@ -192,7 +194,8 @@ async def test_abandoned_recovery_unregisters_only_after_terminal_write():
         "lionagi.studio.scheduler.subprocess.build_argv",
         side_effect=RuntimeError("bad argv"),
     ):
-        await engine._fire(
+        await fire_with_claim(
+            engine,
             _notify_schedule(),
             "run-notify-1",
             trigger_context={"scheduled": True},
@@ -223,7 +226,8 @@ async def test_abandonment_failure_still_unregisters():
         ),
         pytest.raises(RuntimeError, match="db down"),
     ):
-        await engine._fire_inner(
+        await fire_inner_with_claim(
+            engine,
             _notify_schedule(),
             "run-notify-3",
             trigger_context={"scheduled": True},
@@ -250,7 +254,8 @@ async def test_invalid_argv_terminal_write_failure_still_unregisters():
         ),
         pytest.raises(RuntimeError, match="terminal write failed"),
     ):
-        await engine._fire_inner(
+        await fire_inner_with_claim(
+            engine,
             _notify_schedule(),
             "run-notify-4",
             trigger_context={"scheduled": True},
@@ -276,7 +281,8 @@ async def test_occurrence_write_failure_on_invalid_argv_still_unregisters():
         ),
         pytest.raises(RuntimeError, match="occurrence failed"),
     ):
-        await engine._fire_inner(
+        await fire_inner_with_claim(
+            engine,
             _notify_schedule(),
             "run-notify-5",
             trigger_context={"scheduled": True},
@@ -304,7 +310,8 @@ async def test_cancellation_during_action_setup_still_unregisters():
         ),
         pytest.raises(asyncio.CancelledError),
     ):
-        await engine._fire_inner(
+        await fire_inner_with_claim(
+            engine,
             _notify_schedule(),
             "run-notify-6",
             trigger_context={"scheduled": True},
@@ -327,7 +334,8 @@ async def test_create_invocation_failure_does_not_leak_registration():
     engine = SchedulerEngine(svc=svc)
 
     with pytest.raises(RuntimeError, match="db down"):
-        await engine._fire_inner(
+        await fire_inner_with_claim(
+            engine,
             _notify_schedule(),
             "run-notify-2",
             trigger_context={"scheduled": True},

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -23,6 +23,21 @@ from lionagi.studio.scheduler.engine import SchedulerEngine
 from lionagi.studio.services.scheduler_state import _DBSchedulerStateService
 
 
+async def _claim_and_advance(db, run, *, schedule_id, schedule_fields):
+    """Write an occurrence holding whatever cursor the schedule currently has.
+
+    These tests predate the cursor claim and are about atomicity, so they always hold it;
+    the claim itself is covered in tests/state/test_schedule_due_cursor_claim.py.
+    """
+    current = (await db.get_schedule(schedule_id))["next_fire_at"]
+    return await db.create_schedule_run_and_advance(
+        run,
+        schedule_id=schedule_id,
+        schedule_fields=schedule_fields,
+        expect_next_fire_at=current,
+    )
+
+
 def _schedule_row(schedule_id: str, **overrides) -> dict:
     base = {
         "id": schedule_id,
@@ -73,7 +88,8 @@ async def test_crash_between_insert_and_advance_does_not_double_fire(tmp_path):
     async with StateDB(db_path) as db:
         with patch.object(AsyncConnection, "execute", _crash):
             with pytest.raises(RuntimeError, match="simulated crash"):
-                await db.create_schedule_run_and_advance(
+                await _claim_and_advance(
+                    db,
                     _run_row("run-1", sid, fired_at=1000.0),
                     schedule_id=sid,
                     schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
@@ -91,7 +107,8 @@ async def test_crash_between_insert_and_advance_does_not_double_fire(tmp_path):
     # time) and must produce exactly one durable row -- proving the
     # crashed attempt left nothing behind to double up against.
     async with StateDB(db_path) as db:
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-1", sid, fired_at=1000.0),
             schedule_id=sid,
             schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
@@ -121,7 +138,8 @@ async def test_github_path_crash_before_second_event_refires_only_second(tmp_pat
         )
 
         # Event 1: normal atomic commit.
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-event1", sid, fired_at=1000.0),
             schedule_id=sid,
             schedule_fields={"github_cursor": event1_time, "last_fired_at": 1000.0},
@@ -137,7 +155,8 @@ async def test_github_path_crash_before_second_event_refires_only_second(tmp_pat
     async with StateDB(db_path) as db:
         with patch.object(AsyncConnection, "execute", _crash):
             with pytest.raises(RuntimeError, match="simulated crash"):
-                await db.create_schedule_run_and_advance(
+                await _claim_and_advance(
+                    db,
                     _run_row("run-event2", sid, fired_at=1100.0),
                     schedule_id=sid,
                     schedule_fields={"github_cursor": event2_time, "last_fired_at": 1100.0},
@@ -159,7 +178,8 @@ async def test_github_path_crash_before_second_event_refires_only_second(tmp_pat
     # because the poll's own cursor filter -- github_cursor -- excludes it;
     # this call models the recorded outcome of that re-poll).
     async with StateDB(db_path) as db:
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-event2", sid, fired_at=1100.0),
             schedule_id=sid,
             schedule_fields={"github_cursor": event2_time, "last_fired_at": 1100.0},
@@ -194,7 +214,8 @@ async def test_missed_fire_recovery_skips_occurrence_already_in_schedule_runs(
         # still in the past relative to "now" in this test, so the
         # schedule is still seen as due -- exercising the recovery path
         # rather than the ordinary tick).
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-crashed", sid, fired_at=due_at),
             schedule_id=sid,
             schedule_fields={"next_fire_at": due_at, "last_fired_at": due_at},
@@ -365,7 +386,8 @@ async def test_recovery_refires_occurrence_committed_but_never_dispatched(tmp_pa
         # Simulate _fire_inner()'s atomic commit landing (row + cursor
         # advance both durable), then the daemon dying before
         # spawn_and_wait's on_launched callback ever stamps dispatched_at.
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row(
                 "run-orphaned",
                 sid,
@@ -436,7 +458,8 @@ async def test_recovery_never_touches_a_row_with_confirmed_dispatch(tmp_path, mo
 
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-dispatched", sid, fired_at=1000.0),
             schedule_id=sid,
             schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
@@ -475,7 +498,8 @@ async def test_recovery_tombstones_undispatched_chain_child_without_retry(tmp_pa
         # The chain-parent row must exist first -- chain_parent_id is a real
         # FK reference to schedule_runs(id). Its own status is irrelevant to
         # this test; only its existence satisfies the constraint.
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-parent", sid, fired_at=999.0),
             schedule_id=sid,
             schedule_fields={"next_fire_at": 1000.0, "last_fired_at": 999.0},
@@ -485,7 +509,8 @@ async def test_recovery_tombstones_undispatched_chain_child_without_retry(tmp_pa
         # this test isolates the chain-child-specific tombstone-without-retry
         # behavior from the ordinary top-level re-fire path.
         await db.update_schedule_run("run-parent", dispatched_at=999.5)
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row(
                 "run-chain-child",
                 sid,
@@ -519,7 +544,8 @@ async def test_tombstone_and_replace_schedule_run_is_atomic(tmp_path):
 
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-orphan", sid, fired_at=1000.0),
             schedule_id=sid,
             schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
@@ -582,7 +608,8 @@ async def test_recovery_leaves_orphan_untouched_when_refire_crashes_before_atomi
 
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row(
                 "run-orphaned", sid, fired_at=1000.0, trigger_context=orphaned_trigger_context
             ),
@@ -662,7 +689,8 @@ async def test_recovery_never_double_fires_across_two_passes(tmp_path, monkeypat
 
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-orphaned", sid, fired_at=1000.0),
             schedule_id=sid,
             schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
@@ -717,7 +745,8 @@ async def test_tombstone_and_replace_schedule_run_refuses_when_dispatch_confirme
 
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-live", sid, fired_at=1000.0),
             schedule_id=sid,
             schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
@@ -754,7 +783,8 @@ async def test_recovery_refire_is_noop_when_dispatch_confirmed_mid_race(tmp_path
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
         await db.create_invocation({"id": "inv-live", "skill": "test", "started_at": 1000.0})
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row("run-live", sid, fired_at=1000.0, invocation_id="inv-live"),
             schedule_id=sid,
             schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
@@ -844,7 +874,8 @@ async def _seed_dispatched_run_with_session(
             "status": session_status,
         }
     )
-    await db.create_schedule_run_and_advance(
+    await _claim_and_advance(
+        db,
         _run_row(run_id, sid, fired_at=1000.0, invocation_id=inv_id),
         schedule_id=sid,
         schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
@@ -932,7 +963,8 @@ async def test_reconcile_leaves_row_running_when_no_sessions_recorded(tmp_path, 
         await db.create_invocation(
             {"id": inv_id, "skill": "command", "started_at": 1000.0, "status": "running"}
         )
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row(run_id, sid, fired_at=1000.0, invocation_id=inv_id, action_kind="command"),
             schedule_id=sid,
             schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
@@ -988,7 +1020,8 @@ async def test_reconcile_finalizes_completed_empty_orphan_as_failed_not_success(
                 "status": "completed_empty",
             }
         )
-        await db.create_schedule_run_and_advance(
+        await _claim_and_advance(
+            db,
             _run_row(run_id, sid, fired_at=1000.0, invocation_id=inv_id),
             schedule_id=sid,
             schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -21,21 +21,7 @@ from lionagi.state.db import StateDB
 from lionagi.state.reasons import RunReasons
 from lionagi.studio.scheduler.engine import SchedulerEngine
 from lionagi.studio.services.scheduler_state import _DBSchedulerStateService
-
-
-async def _claim_and_advance(db, run, *, schedule_id, schedule_fields):
-    """Write an occurrence holding whatever cursor the schedule currently has.
-
-    These tests predate the cursor claim and are about atomicity, so they always hold it;
-    the claim itself is covered in tests/state/test_schedule_due_cursor_claim.py.
-    """
-    current = (await db.get_schedule(schedule_id))["next_fire_at"]
-    return await db.create_schedule_run_and_advance(
-        run,
-        schedule_id=schedule_id,
-        schedule_fields=schedule_fields,
-        expect_next_fire_at=current,
-    )
+from tests._scheduler_claims import claim_and_advance
 
 
 def _schedule_row(schedule_id: str, **overrides) -> dict:
@@ -88,7 +74,7 @@ async def test_crash_between_insert_and_advance_does_not_double_fire(tmp_path):
     async with StateDB(db_path) as db:
         with patch.object(AsyncConnection, "execute", _crash):
             with pytest.raises(RuntimeError, match="simulated crash"):
-                await _claim_and_advance(
+                await claim_and_advance(
                     db,
                     _run_row("run-1", sid, fired_at=1000.0),
                     schedule_id=sid,
@@ -107,7 +93,7 @@ async def test_crash_between_insert_and_advance_does_not_double_fire(tmp_path):
     # time) and must produce exactly one durable row -- proving the
     # crashed attempt left nothing behind to double up against.
     async with StateDB(db_path) as db:
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-1", sid, fired_at=1000.0),
             schedule_id=sid,
@@ -138,7 +124,7 @@ async def test_github_path_crash_before_second_event_refires_only_second(tmp_pat
         )
 
         # Event 1: normal atomic commit.
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-event1", sid, fired_at=1000.0),
             schedule_id=sid,
@@ -155,7 +141,7 @@ async def test_github_path_crash_before_second_event_refires_only_second(tmp_pat
     async with StateDB(db_path) as db:
         with patch.object(AsyncConnection, "execute", _crash):
             with pytest.raises(RuntimeError, match="simulated crash"):
-                await _claim_and_advance(
+                await claim_and_advance(
                     db,
                     _run_row("run-event2", sid, fired_at=1100.0),
                     schedule_id=sid,
@@ -178,7 +164,7 @@ async def test_github_path_crash_before_second_event_refires_only_second(tmp_pat
     # because the poll's own cursor filter -- github_cursor -- excludes it;
     # this call models the recorded outcome of that re-poll).
     async with StateDB(db_path) as db:
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-event2", sid, fired_at=1100.0),
             schedule_id=sid,
@@ -214,7 +200,7 @@ async def test_missed_fire_recovery_skips_occurrence_already_in_schedule_runs(
         # still in the past relative to "now" in this test, so the
         # schedule is still seen as due -- exercising the recovery path
         # rather than the ordinary tick).
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-crashed", sid, fired_at=due_at),
             schedule_id=sid,
@@ -386,7 +372,7 @@ async def test_recovery_refires_occurrence_committed_but_never_dispatched(tmp_pa
         # Simulate _fire_inner()'s atomic commit landing (row + cursor
         # advance both durable), then the daemon dying before
         # spawn_and_wait's on_launched callback ever stamps dispatched_at.
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row(
                 "run-orphaned",
@@ -458,7 +444,7 @@ async def test_recovery_never_touches_a_row_with_confirmed_dispatch(tmp_path, mo
 
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-dispatched", sid, fired_at=1000.0),
             schedule_id=sid,
@@ -498,7 +484,7 @@ async def test_recovery_tombstones_undispatched_chain_child_without_retry(tmp_pa
         # The chain-parent row must exist first -- chain_parent_id is a real
         # FK reference to schedule_runs(id). Its own status is irrelevant to
         # this test; only its existence satisfies the constraint.
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-parent", sid, fired_at=999.0),
             schedule_id=sid,
@@ -509,7 +495,7 @@ async def test_recovery_tombstones_undispatched_chain_child_without_retry(tmp_pa
         # this test isolates the chain-child-specific tombstone-without-retry
         # behavior from the ordinary top-level re-fire path.
         await db.update_schedule_run("run-parent", dispatched_at=999.5)
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row(
                 "run-chain-child",
@@ -544,7 +530,7 @@ async def test_tombstone_and_replace_schedule_run_is_atomic(tmp_path):
 
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-orphan", sid, fired_at=1000.0),
             schedule_id=sid,
@@ -608,7 +594,7 @@ async def test_recovery_leaves_orphan_untouched_when_refire_crashes_before_atomi
 
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row(
                 "run-orphaned", sid, fired_at=1000.0, trigger_context=orphaned_trigger_context
@@ -689,7 +675,7 @@ async def test_recovery_never_double_fires_across_two_passes(tmp_path, monkeypat
 
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-orphaned", sid, fired_at=1000.0),
             schedule_id=sid,
@@ -745,7 +731,7 @@ async def test_tombstone_and_replace_schedule_run_refuses_when_dispatch_confirme
 
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-live", sid, fired_at=1000.0),
             schedule_id=sid,
@@ -783,7 +769,7 @@ async def test_recovery_refire_is_noop_when_dispatch_confirmed_mid_race(tmp_path
     async with StateDB(db_path) as db:
         await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
         await db.create_invocation({"id": "inv-live", "skill": "test", "started_at": 1000.0})
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row("run-live", sid, fired_at=1000.0, invocation_id="inv-live"),
             schedule_id=sid,
@@ -874,7 +860,7 @@ async def _seed_dispatched_run_with_session(
             "status": session_status,
         }
     )
-    await _claim_and_advance(
+    await claim_and_advance(
         db,
         _run_row(run_id, sid, fired_at=1000.0, invocation_id=inv_id),
         schedule_id=sid,
@@ -963,7 +949,7 @@ async def test_reconcile_leaves_row_running_when_no_sessions_recorded(tmp_path, 
         await db.create_invocation(
             {"id": inv_id, "skill": "command", "started_at": 1000.0, "status": "running"}
         )
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row(run_id, sid, fired_at=1000.0, invocation_id=inv_id, action_kind="command"),
             schedule_id=sid,
@@ -1020,7 +1006,7 @@ async def test_reconcile_finalizes_completed_empty_orphan_as_failed_not_success(
                 "status": "completed_empty",
             }
         )
-        await _claim_and_advance(
+        await claim_and_advance(
             db,
             _run_row(run_id, sid, fired_at=1000.0, invocation_id=inv_id),
             schedule_id=sid,

--- a/tests/studio/test_scheduler_predispatch_cursor.py
+++ b/tests/studio/test_scheduler_predispatch_cursor.py
@@ -25,6 +25,7 @@ import pytest
 from lionagi.state.reasons import RunReasons
 from lionagi.studio.scheduler.engine import SchedulerEngine
 from lionagi.studio.scheduler.github import GithubPollItem, GithubPollResult
+from tests._scheduler_claims import fire_with_claim
 
 CURSOR_AT_TICK_START = "2026-07-07T09:00:00Z"
 FIRST_EVENT_AT = "2026-07-07T10:00:00Z"
@@ -302,7 +303,8 @@ async def test_cancellation_before_launch_leaves_the_run_for_startup_recovery():
         patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=_cancel_before_launch),
     ):
         with pytest.raises(asyncio.CancelledError):
-            await engine._fire(
+            await fire_with_claim(
+                engine,
                 schedule,
                 "run-cancel-pre",
                 trigger_context={"github_events": [_item(1, FIRST_EVENT_AT).event]},
@@ -334,7 +336,8 @@ async def test_cancellation_after_launch_still_records_a_cancelled_run():
         patch("lionagi.studio.scheduler.subprocess.spawn_and_wait", new=_cancel_after_launch),
     ):
         with pytest.raises(asyncio.CancelledError):
-            await engine._fire(
+            await fire_with_claim(
+                engine,
                 schedule,
                 "run-cancel-post",
                 trigger_context={"github_events": [_item(1, FIRST_EVENT_AT).event]},

--- a/tests/studio/test_scheduler_signals.py
+++ b/tests/studio/test_scheduler_signals.py
@@ -25,6 +25,7 @@ from lionagi.studio.scheduler.signals import (
     build_schedule_run_signal,
     record_handler_failure,
 )
+from tests._scheduler_claims import fire_with_claim
 
 # Helpers (mirrors tests/studio/test_scheduler_engine.py's fixtures)
 
@@ -714,7 +715,7 @@ async def test_fire_happy_path_mints_schedule_run_succeeded():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-001", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-001", trigger_context={"scheduled": True})
 
     assert len(captured) == 1
     sig = captured[0]
@@ -744,7 +745,7 @@ async def test_fire_nonzero_exit_mints_schedule_run_failed():
             new=AsyncMock(return_value=(1, "error text")),
         ),
     ):
-        await engine._fire(schedule, "run-002", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-002", trigger_context={"scheduled": True})
 
     assert len(captured) == 1
     assert captured[0].reason_code == RunReasons.FAILED_EXIT_NONZERO
@@ -779,7 +780,7 @@ async def test_fire_inner_exception_mints_schedule_run_failed():
             new=AsyncMock(side_effect=_raise_after_launch),
         ),
     ):
-        await engine._fire(schedule, "run-005", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-005", trigger_context={"scheduled": True})
 
     assert len(captured) == 1
     assert captured[0].reason_code == RunReasons.FAILED_EXCEPTION
@@ -815,7 +816,7 @@ async def test_fire_cancellation_mints_schedule_run_cancelled():
         ),
     ):
         with pytest.raises(asyncio.CancelledError):
-            await engine._fire(schedule, "run-004", trigger_context={"scheduled": True})
+            await fire_with_claim(engine, schedule, "run-004", trigger_context={"scheduled": True})
 
     assert len(captured) == 1
     assert captured[0].reason_code == RunReasons.CANCELLED_SYSTEM
@@ -846,7 +847,7 @@ async def test_fire_does_not_mint_when_guarded_write_loses_race():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-006", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-006", trigger_context={"scheduled": True})
 
     assert captured == []
 
@@ -870,7 +871,7 @@ async def test_fire_build_argv_exception_mints_schedule_run_failed():
         "lionagi.studio.scheduler.subprocess.build_argv",
         side_effect=ValueError("bad action_kind"),
     ):
-        await engine._fire(schedule, "run-010", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-010", trigger_context={"scheduled": True})
 
     assert len(captured) == 1
     sig = captured[0]
@@ -899,7 +900,7 @@ async def test_fire_build_argv_exception_does_not_mint_when_write_lost_race():
         "lionagi.studio.scheduler.subprocess.build_argv",
         side_effect=ValueError("bad action_kind"),
     ):
-        await engine._fire(schedule, "run-011", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-011", trigger_context={"scheduled": True})
 
     assert captured == []
 
@@ -939,7 +940,7 @@ async def test_broken_handler_surfaces_admin_event_and_fire_completes(tmp_path, 
         ),
     ):
         # Must not raise -- the handler bug is contained at the mint call site.
-        await engine._fire(schedule, "run-007", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-007", trigger_context={"scheduled": True})
 
     # The schedule_run's own bookkeeping (invocation/run rows, status writes,
     # max_runs check) still ran normally despite the broken handler.
@@ -985,8 +986,8 @@ async def test_handler_cancelled_error_at_exit_mint_does_not_cancel_completed_ru
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(
-            _minimal_schedule(), "run-handler-cancel", trigger_context={"scheduled": True}
+        await fire_with_claim(
+            engine, _minimal_schedule(), "run-handler-cancel", trigger_context={"scheduled": True}
         )
 
     terminal_statuses = [
@@ -1071,7 +1072,7 @@ async def test_broken_predicate_does_not_block_sibling_handler_and_surfaces_admi
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-012", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-012", trigger_context={"scheduled": True})
 
     assert len(healthy) == 1  # sibling handler ran despite the raising predicate
 
@@ -1117,10 +1118,10 @@ async def test_unrelated_fire_still_succeeds_after_a_prior_handler_failure(tmp_p
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-008", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-008", trigger_context={"scheduled": True})
         # Second, unrelated fire on the same engine/bus must still complete
         # normally -- the handler exception from the first fire must not
         # have crashed the tick loop or left the bus/engine in a bad state.
-        await engine._fire(schedule, "run-009", trigger_context={"scheduled": True})
+        await fire_with_claim(engine, schedule, "run-009", trigger_context={"scheduled": True})
 
     assert svc.create_schedule_run_and_advance.await_count == 2

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -15,6 +15,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tests._scheduler_claims import fire_with_claim
+
 
 def _minimal_schedule(**overrides) -> dict:
     base = {
@@ -594,7 +596,7 @@ async def test_fire_threshold_schedule_stamps_last_alert_at_after_run_persisted(
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-alert-1", trigger_context=_threshold_ctx())
+        await fire_with_claim(engine, schedule, "run-alert-1", trigger_context=_threshold_ctx())
 
     svc.create_schedule_run.assert_not_awaited()
     svc.create_schedule_run_and_advance.assert_awaited_once()
@@ -624,7 +626,7 @@ async def test_fire_create_invocation_failure_does_not_stamp_last_alert_at():
     )
 
     with pytest.raises(RuntimeError, match="db unavailable"):
-        await engine._fire(schedule, "run-fail-inv", trigger_context=_threshold_ctx())
+        await fire_with_claim(engine, schedule, "run-fail-inv", trigger_context=_threshold_ctx())
 
     svc.create_schedule_run.assert_not_awaited()
     assert not _last_alert_calls(svc)
@@ -653,7 +655,7 @@ async def test_fire_invalid_action_still_stamps_last_alert_at_after_failed_run_p
         "lionagi.studio.scheduler.subprocess.build_argv",
         side_effect=ValueError("bad action_kind"),
     ):
-        await engine._fire(schedule, "run-alert-2", trigger_context=_threshold_ctx())
+        await fire_with_claim(engine, schedule, "run-alert-2", trigger_context=_threshold_ctx())
 
     svc.create_schedule_run.assert_not_awaited()
     svc.create_schedule_run_and_advance.assert_awaited_once()
@@ -687,7 +689,8 @@ async def test_fire_invalid_action_releases_threshold_cooldown_claim():
         "lionagi.studio.scheduler.subprocess.build_argv",
         side_effect=ValueError("bad action_kind"),
     ):
-        await engine._fire(
+        await fire_with_claim(
+            engine,
             schedule,
             "run-alert-invalid",
             trigger_context=_threshold_ctx(),
@@ -729,7 +732,8 @@ async def test_fire_success_releases_threshold_cooldown_claim():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(
+        await fire_with_claim(
+            engine,
             schedule,
             "run-alert-success",
             trigger_context=_threshold_ctx(),
@@ -767,7 +771,9 @@ async def test_fire_chain_child_does_not_restamp_last_alert_at():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-chain-1", trigger_context=_threshold_ctx(), chain_depth=1)
+        await fire_with_claim(
+            engine, schedule, "run-chain-1", trigger_context=_threshold_ctx(), chain_depth=1
+        )
 
     assert not _last_alert_calls(svc)
 
@@ -792,7 +798,9 @@ async def test_fire_non_threshold_schedule_never_stamps_last_alert_at():
             new=AsyncMock(return_value=(0, "")),
         ),
     ):
-        await engine._fire(schedule, "run-no-threshold", trigger_context={"scheduled": True})
+        await fire_with_claim(
+            engine, schedule, "run-no-threshold", trigger_context={"scheduled": True}
+        )
 
     assert not _last_alert_calls(svc)
 


### PR DESCRIPTION
## The defect

The scheduler tick reads every enabled schedule, decides in Python which are due, and fires
them in a separate statement. Every admission gate between those two steps lives in the firing
process's own memory: the overlap set, the threshold cooldown, and the rate-limit, max-runs and
global-slot reservations. A source comment in `_maybe_fire` says as much, that no second tick can
slip between the gate and the reservation, which is true within one process and blind across two.

Nothing in the database refused a second one either. `schedule_runs` carries four indexes and
none is UNIQUE, the insert is a plain INSERT with a fresh id, and the schedule update carried no
predicate on the cursor the caller had selected on. The existing `guard_cursor_forward` option is
per-column on `github_cursor` by deliberate design and never touched `next_fire_at`.

So two schedulers reading one due row both committed, each with its own run id, and each launched
a child.

This is reachable in the default configuration rather than an exotic one. The state database is a
fixed path while the port is a flag and an environment variable, so a second daemon started on
another port shares the first one's database.

Measured against a real database before the change: two concurrent calls for one due instant,
both committed, two occurrence rows, one cursor advance.

Not observed in production. A group-by over 4,665 rows in a live database found zero duplicate
`(schedule_id, fired_at)` pairs. The near-duplicates it did find are a `github_poll` firing one
occurrence per event in a burst, each at its own instant.

## The change

The occurrence write now claims the cursor it was selected on:

- the advance runs first, inside the same transaction, with a compare-and-swap on `next_fire_at`
- the occurrence is written only if that claim holds
- a caller that lost the claim gets `False` having written nothing at all, because a loser that
  leaves a partial occurrence behind is worse than a duplicate
- the engine cancels that fire's invocation with a reason naming what happened, beside the
  existing reason for a recovery re-fire whose orphan was resolved by something else

The predicate is NULL-safe, because a schedule with no cursor is a real state and not an absence.
It is required rather than defaulted, so a new caller has to say what it is claiming instead of
silently claiming nothing. Making it required is also what surfaced every existing call site
rather than leaving some of them quietly unguarded.

## Scope

This bounds the race it names and no more. The launch-to-stamp window, where durable state reads
`dispatched_at IS NULL` while the child is already executing, is a separate gap and is unchanged
here. If the update carries no new `next_fire_at`, the cursor does not move and the next caller
holds the same claim; that is stated in `docs/internals/state-db.md` rather than left implied.

## Tests

Six new outcomes: the concurrent race, an operator moving the cursor between selection and
dispatch, a schedule whose cursor is NULL claimed on the same terms, a refused fire leaving
neither an occurrence nor a cursor move, and two controls — that the holder of the cursor still
fires, and that the other user of the shared statement builder did not gain the predicate. A
claim that refused everything would bound duplicates by firing nothing, which is what those two
controls exist to catch.

Existing tests that predate the claim now hold whatever cursor the schedule currently has,
through one helper that says so in its docstring.
