### PR TITLE
ci: stop installing apt packages during the browser install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,9 +399,14 @@ jobs:
     - name: Install frontend dependencies
       working-directory: apps/studio/frontend
       run: npm ci
+    # No --with-deps: it runs apt on the runner, which has hung for the whole
+    # 15-minute job budget when an Ubuntu mirror is unreachable, and the runner
+    # image already ships Chrome and the shared libraries Chromium needs. If one
+    # is ever genuinely missing, the e2e step below fails immediately and names
+    # it, which is a better failure than a silent timeout.
     - name: Install Playwright browsers
       working-directory: apps/studio/frontend
-      run: npx playwright install chromium --with-deps
+      run: npx playwright install chromium
     # Builds the SPA, boots a seeded daemon + `vite preview` on temp/free-port
     # infrastructure (never the real ~/.lionagi), and runs the Chromium smoke
     # specs against it -- see apps/studio/frontend/e2e/ and tests/e2e_studio/.


### PR DESCRIPTION
## What

The studio e2e job installed its browser with `playwright install --with-deps`. That flag runs apt on the runner before fetching the browser. When an Ubuntu mirror is unreachable, apt retries it for the rest of the 15-minute job budget and the runner kills the job.

## Why now

Measured over 25 consecutive CI runs on this workflow:

| outcome | count | job duration |
|---|---|---|
| success | 18 | 1.4 – 4.2 min |
| cancelled | 6 | 15.3 min, every time |
| failure | 1 | — |

The cancellations are not slow runs. Every one of them sits exactly at the job's `timeout-minutes: 15`, and all six are the same step. The job log shows the normal apt `Get:` sequence and then repeating `Ign:` lines against the Ubuntu mirror until the runner terminates the process. `ci-gate` then fails with `studio-e2e=cancelled` while every other job is green, so a single unreachable mirror blocks the whole PR.

## Why dropping the flag is the fix rather than caching

Caching the browser download does not help: `--with-deps` runs apt whether or not the browser is already cached. Raising the timeout would hide the hang and weaken the only guard against a genuinely stuck job.

The `ubuntu-latest` image already ships Chrome and the shared libraries Chromium needs, so the flag was not buying anything here.

## How this verifies itself

This PR's own `studio-e2e` run is the test. A green run without `--with-deps` shows the runner image really does carry the libraries. If a library is genuinely missing, the e2e step fails immediately and names it, which is both a cheap answer and a better failure mode than a silent timeout.

Note: `ci-gate` on this branch will stay red until the separate `test (3.11)` / `test (3.12)` breakage on `main` is fixed. `studio-e2e` is the check to read here.