### PR TITLE
fix(studio): project the single-run route instead of serving the joined row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Writable StateDB migration now fails closed when a table's columns cannot be
   inspected, preserving the prior schema-version stamp instead of recording an
   upgrade whose additive column reconciliation did not complete.
+- The single-run route `GET /api/schedules/runs/{run_id}` now serves an allow-list
+  instead of the joined row. It was the last schedule surface returning every column
+  the join carries, including the action arguments, resume packets, lease holders and
+  capability references the list surfaces already withhold, and its nested chain
+  children carried the same columns again. The raw failure text stays: reaching it is
+  the reason this route exists. The trigger payload that produced the run is no longer
+  served at all, and is dropped from the client's declared run type, since nothing read
+  it and it carries whole external event bodies.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   later release. It remains available and functional on `li agent`, which is
   the surface that implements it.
 
+### Removed
+
+- `trigger_context` from every run object the schedule surfaces serve, and from the
+  run type the web client declares. It held the whole external event body that
+  produced a run, no client read it, and the single-run route was the last surface
+  still sending it.
+
 ## [0.35.0] - 2026-08-12
 
 A broad correctness release across the orchestration engine, the MCP surface,

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -446,11 +446,12 @@ export interface RunOutcome {
   summary_reported: boolean;
 }
 
+/** One run as the single-run route serves it. Wider than the slice row by the raw
+ * failure text; the trigger payload that produced the run is not served at all. */
 export interface ScheduleRunSummary {
   id: string;
   schedule_id: string;
   invocation_id: string | null;
-  trigger_context: Record<string, unknown>;
   action_kind: string;
   status: "running" | "completed" | "failed" | "skipped" | "cancelled";
   exit_code: number | null;
@@ -463,8 +464,8 @@ export interface ScheduleRunSummary {
 
 /**
  * A run as the /schedules/summary slice serves it. Narrower than ScheduleRunSummary on
- * purpose: the summary surface carries no trigger_context and no error_detail, only a
- * translatable classification of the failure.
+ * purpose: the summary surface carries no error_detail, only a translatable
+ * classification of the failure.
  */
 export interface ScheduleRunSliceRow {
   id: string;

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -557,6 +557,12 @@ def _run_summary(row: dict[str, Any]) -> dict[str, Any]:
 # A run view adds the reconciled outcome and the joined session facts on top of the
 # occurrence row. These are the additions any list surface serves; the rest of the join
 # (leases, capabilities, library references, resume packets) stays private.
+#
+# `artifacts` and `session_ids` carry host paths and raw session ids, and they are here
+# because `li schedule runs` and `li schedule status` print them (studio/cli.py). They
+# reach the wire on these routes either way -- before this list existed the routes
+# returned the joined row verbatim -- so naming them is what turns a pass-through into
+# a decision, and what makes withholding them later a one-line change in one place.
 _RUN_VIEW_FIELDS = _RUN_SUMMARY_FIELDS + ("duration_ms", "artifacts", "session_ids")
 
 

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -598,6 +598,26 @@ def _run_view(row: dict[str, Any]) -> dict[str, Any]:
     return view
 
 
+# The single-run route is the documented reader of the raw failure text -- the list
+# surfaces serve a classification instead -- which is why error_detail is here and off
+# _RUN_SUMMARY_FIELDS. trigger_context stays private on the list surfaces' reasoning:
+# whole external event payloads, and no client reads it.
+_RUN_RECORD_FIELDS = _RUN_VIEW_FIELDS + ("error_detail",)
+
+
+def _run_record(row: dict[str, Any]) -> dict[str, Any]:
+    """One run as the single-run route serves it.
+
+    chain_children is a list surface nested inside a record, so it takes the run-list
+    projection; absent rather than empty on a run that is itself a child.
+    """
+    record = _run_view(row)
+    record.update({name: row[name] for name in _RUN_RECORD_FIELDS if name in row})
+    if "chain_children" in row:
+        record["chain_children"] = [_run_summary(child) for child in row["chain_children"]]
+    return record
+
+
 # The schedule columns the list surfaces serve. The table carries roughly twice this
 # many: authored specs, flow YAML, shell commands and their arguments, notification
 # targets, poll cursors, ownership keys and lease bookkeeping. None of those has a
@@ -1264,7 +1284,9 @@ async def get_schedule_run_route(run_id: str) -> dict[str, Any]:
     data = await get_schedule_run(run_id)
     if data is None:
         raise HTTPException(status_code=404, detail=f"Schedule run '{run_id}' not found")
-    return data
+    # The service returns the joined row; the wire gets the projection. Applying it here
+    # rather than in the service keeps the in-process readers of the full row whole.
+    return _run_record(data)
 
 
 @studio_route(

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -608,11 +608,20 @@ _RUN_RECORD_FIELDS = _RUN_VIEW_FIELDS + ("error_detail",)
 def _run_record(row: dict[str, Any]) -> dict[str, Any]:
     """One run as the single-run route serves it.
 
+    Built directly rather than on top of _run_view, because that one sanitises a
+    reported outcome summary and this surface must not. error_detail is the raw text
+    only when the occurrence is the layer that won; when a session or invocation
+    reported the failure instead, the summary IS the text, and replacing it with a
+    class would leave this route -- the one place raw text is reachable -- with no text
+    at all for exactly those runs.
+
     chain_children is a list surface nested inside a record, so it takes the run-list
     projection; absent rather than empty on a run that is itself a child.
     """
-    record = _run_view(row)
-    record.update({name: row[name] for name in _RUN_RECORD_FIELDS if name in row})
+    record = {name: row[name] for name in _RUN_RECORD_FIELDS if name in row}
+    record["error_class"] = _error_class_for(row)
+    if "outcome" in row:
+        record["outcome"] = row["outcome"]
     if "chain_children" in row:
         record["chain_children"] = [_run_summary(child) for child in row["chain_children"]]
     return record

--- a/tests/apps_studio_server/test_schedule_runs_route.py
+++ b/tests/apps_studio_server/test_schedule_runs_route.py
@@ -50,6 +50,7 @@ async def _seed_run(
     error_detail: str | None = None,
     chain_depth: int = 0,
     run_id: str | None = None,
+    chain_parent_id: str | None = None,
 ) -> str:
     resolved_run_id = run_id or str(uuid.uuid4())
     async with StateDB() as db:
@@ -62,6 +63,7 @@ async def _seed_run(
                 "action_args": {"prompt": "ping"},
                 "status": status,
                 "chain_depth": chain_depth,
+                "chain_parent_id": chain_parent_id,
                 "fired_at": fired_at,
                 "error_detail": error_detail,
             }
@@ -911,3 +913,94 @@ def test_no_list_surface_serves_a_private_run_column(tmp_path, monkeypatch):
         assert resp.status_code == 200, path
         leaked = sorted(_keys_anywhere(resp.json()) & set(_PRIVATE_RUN_COLUMNS))
         assert not leaked, f"{path} serves {leaked}"
+
+
+# The single-run route is the one surface that was never projected: it returned the
+# joined row, and its chain_children the raw child rows, so every private run column
+# reached the wire on a route the API answers without a token.
+def _seed_chained_run_with_private_columns(monkeypatch, db_path: Path) -> tuple[str, str]:
+    _patch_db(monkeypatch, db_path)
+
+    async def seed():
+        schedule_id = await _seed_schedule()
+        fired = time.time()
+        parent_id = await _seed_run(schedule_id, status="completed", fired_at=fired)
+        child_id = await _seed_run(
+            schedule_id,
+            status="completed",
+            fired_at=fired + 1,
+            chain_depth=1,
+            chain_parent_id=parent_id,
+        )
+        async with StateDB() as db:
+            for rid in (parent_id, child_id):
+                await db.update_schedule_run(rid, resume_packet={"cursor": "/private/host/state"})
+        return parent_id, child_id
+
+    return asyncio.run(seed())
+
+
+def test_the_record_path_really_carries_the_private_run_columns(tmp_path, monkeypatch):
+    """Positive control for the record sweep, and it has to be the record path's own
+    read: the list control above proves nothing about the row this route builds, which
+    comes from a different service function and adds the child rows."""
+    parent_id, _ = _seed_chained_run_with_private_columns(monkeypatch, tmp_path / "state.db")
+
+    from lionagi.studio.services.schedules import get_schedule_run
+
+    row = asyncio.run(get_schedule_run(parent_id))
+    unset = sorted(name for name in _PRIVATE_RUN_COLUMNS if not row.get(name))
+    assert not unset, f"the record read did not carry {unset}; the sweep would prove nothing"
+    assert row["chain_children"], "no child row; the nested half of the sweep would prove nothing"
+    child_unset = sorted(
+        name for name in _PRIVATE_RUN_COLUMNS if not row["chain_children"][0][name]
+    )
+    assert not child_unset, f"the child row did not carry {child_unset}"
+
+
+def test_the_single_run_record_serves_no_private_run_column(tmp_path, monkeypatch):
+    parent_id, child_id = _seed_chained_run_with_private_columns(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    for run_id in (parent_id, child_id):
+        body = client.get(f"/api/schedules/runs/{run_id}").json()
+        leaked = sorted(_keys_anywhere(body) & set(_PRIVATE_RUN_COLUMNS))
+        assert not leaked, f"the record for {run_id} serves {leaked}"
+
+
+def test_the_single_run_record_serves_no_trigger_payload(tmp_path, monkeypatch):
+    """trigger_context carries whole external event payloads and no client reads it.
+    Named separately from the sweep because it is the one field this route used to serve
+    that the web client still declared, so dropping it is a client-visible decision."""
+    parent_id, _ = _seed_chained_run_with_private_columns(monkeypatch, tmp_path / "state.db")
+
+    body = _make_client().get(f"/api/schedules/runs/{parent_id}").json()
+
+    assert "trigger_context" not in _keys_anywhere(body)
+
+
+def test_the_run_allow_list_serves_everything_the_client_declares():
+    """Every field the web client declares on a run must survive the record projection.
+
+    Containment rather than equality: the served set is wider, because the CLI renders a
+    duration and artifact paths that no web view reads.
+    """
+    import re as _re
+    from pathlib import Path as _Path
+
+    from lionagi.studio.services.schedules import _RUN_RECORD_FIELDS
+
+    source = _Path("apps/studio/frontend/src/lib/types.ts")
+    if not source.exists():  # the frontend is not vendored into every checkout
+        pytest.skip("frontend source not present")
+
+    block = _re.search(
+        r"^export interface ScheduleRunSummary[^{]*\{(.*?)^\}", source.read_text(), _re.S | _re.M
+    )
+    assert block, "ScheduleRunSummary interface not found"
+    declared = _re.findall(r"^\s{2}(\w+)\??:", block.group(1), _re.M)
+    assert declared, "no fields parsed from the client interface"
+
+    # outcome and error_class are computed by the projection rather than named in it.
+    served = set(_RUN_RECORD_FIELDS) | {"outcome", "error_class"}
+    assert not [name for name in declared if name not in served]

--- a/tests/apps_studio_server/test_schedule_runs_route.py
+++ b/tests/apps_studio_server/test_schedule_runs_route.py
@@ -867,3 +867,47 @@ def test_the_record_route_serves_the_persisted_execution_root(tmp_path, monkeypa
     assert '_studio(f"/{_quote(schedule_id)}")' in create.group(0), (
         "the read-back moved; re-derive which route this test is about"
     )
+
+
+# The run-side counterpart to the private-schedule-column sweep above. The run join
+# carries more than the view names, and the routes that serve a view returned the joined
+# row verbatim before the view existed, so the allow-list is the only thing standing
+# between these columns and the wire.
+_PRIVATE_RUN_COLUMNS = ("action_args", "resume_packet")
+
+
+def _seed_run_with_private_columns(monkeypatch, db_path: Path) -> str:
+    _patch_db(monkeypatch, db_path)
+
+    async def seed():
+        schedule_id = await _seed_schedule()
+        run_id = await _seed_run(schedule_id, status="completed", fired_at=time.time())
+        async with StateDB() as db:
+            await db.update_schedule_run(run_id, resume_packet={"cursor": "/private/host/state"})
+        return schedule_id
+
+    return asyncio.run(seed())
+
+
+def test_the_seeded_run_really_carries_the_private_run_columns(tmp_path, monkeypatch):
+    """Positive control: without this the sweep below passes on a run that never had
+    the columns, which is the shape a broken seeder fails in."""
+    schedule_id = _seed_run_with_private_columns(monkeypatch, tmp_path / "state.db")
+
+    from lionagi.studio.services.schedules import list_schedule_run_views
+
+    rows = asyncio.run(list_schedule_run_views(schedule_id))
+    assert len(rows) == 1
+    unset = sorted(name for name in _PRIVATE_RUN_COLUMNS if not rows[0].get(name))
+    assert not unset, f"the join did not carry {unset}; the sweep would prove nothing"
+
+
+def test_no_list_surface_serves_a_private_run_column(tmp_path, monkeypatch):
+    schedule_id = _seed_run_with_private_columns(monkeypatch, tmp_path / "state.db")
+    client = _make_client()
+
+    for path in _list_surfaces(schedule_id):
+        resp = client.get(path)
+        assert resp.status_code == 200, path
+        leaked = sorted(_keys_anywhere(resp.json()) & set(_PRIVATE_RUN_COLUMNS))
+        assert not leaked, f"{path} serves {leaked}"

--- a/tests/apps_studio_server/test_schedule_runs_route.py
+++ b/tests/apps_studio_server/test_schedule_runs_route.py
@@ -963,8 +963,10 @@ def test_the_single_run_record_serves_no_private_run_column(tmp_path, monkeypatc
     client = _make_client()
 
     for run_id in (parent_id, child_id):
-        body = client.get(f"/api/schedules/runs/{run_id}").json()
-        leaked = sorted(_keys_anywhere(body) & set(_PRIVATE_RUN_COLUMNS))
+        resp = client.get(f"/api/schedules/runs/{run_id}")
+        # A 404 body carries no private key either, so it would pass the sweep below.
+        assert resp.status_code == 200, run_id
+        leaked = sorted(_keys_anywhere(resp.json()) & set(_PRIVATE_RUN_COLUMNS))
         assert not leaked, f"the record for {run_id} serves {leaked}"
 
 
@@ -974,36 +976,39 @@ def test_the_single_run_record_serves_no_trigger_payload(tmp_path, monkeypatch):
     that the web client still declared, so dropping it is a client-visible decision."""
     parent_id, _ = _seed_chained_run_with_private_columns(monkeypatch, tmp_path / "state.db")
 
-    body = _make_client().get(f"/api/schedules/runs/{parent_id}").json()
+    resp = _make_client().get(f"/api/schedules/runs/{parent_id}")
 
-    assert "trigger_context" not in _keys_anywhere(body)
+    assert resp.status_code == 200
+    assert "trigger_context" not in _keys_anywhere(resp.json())
 
 
-def test_the_run_allow_list_serves_everything_the_client_declares():
-    """Every field the web client declares on a run must survive the record projection.
+def test_the_record_serves_every_field_the_client_declares(tmp_path, monkeypatch):
+    """Asserted against a real response, not against the field list.
 
-    Containment rather than equality: the served set is wider, because the CLI renders a
-    duration and artifact paths that no web view reads.
+    Comparing the client's names to the projection's names says only that the two lists
+    agree; a projection that names a field and never emits it passes that. Optional
+    fields are excluded: the client marks them optional because a run need not have one.
     """
     import re as _re
     from pathlib import Path as _Path
 
-    from lionagi.studio.services.schedules import _RUN_RECORD_FIELDS
-
     source = _Path("apps/studio/frontend/src/lib/types.ts")
     if not source.exists():  # the frontend is not vendored into every checkout
         pytest.skip("frontend source not present")
-
     block = _re.search(
         r"^export interface ScheduleRunSummary[^{]*\{(.*?)^\}", source.read_text(), _re.S | _re.M
     )
     assert block, "ScheduleRunSummary interface not found"
-    declared = _re.findall(r"^\s{2}(\w+)\??:", block.group(1), _re.M)
-    assert declared, "no fields parsed from the client interface"
+    declared = _re.findall(r"^\s{2}(\w+)(\??):", block.group(1), _re.M)
+    required = [name for name, optional in declared if not optional]
+    assert required, "no required fields parsed from the client interface"
 
-    # outcome and error_class are computed by the projection rather than named in it.
-    served = set(_RUN_RECORD_FIELDS) | {"outcome", "error_class"}
-    assert not [name for name in declared if name not in served]
+    parent_id, _ = _seed_chained_run_with_private_columns(monkeypatch, tmp_path / "state.db")
+    resp = _make_client().get(f"/api/schedules/runs/{parent_id}")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert not [name for name in required if name not in body]
 
 
 def test_the_single_run_record_keeps_a_session_reported_summary(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_schedule_runs_route.py
+++ b/tests/apps_studio_server/test_schedule_runs_route.py
@@ -1004,3 +1004,31 @@ def test_the_run_allow_list_serves_everything_the_client_declares():
     # outcome and error_class are computed by the projection rather than named in it.
     served = set(_RUN_RECORD_FIELDS) | {"outcome", "error_class"}
     assert not [name for name in declared if name not in served]
+
+
+def test_the_single_run_record_keeps_a_session_reported_summary(tmp_path, monkeypatch):
+    """The record route is the one place raw failure text is reachable, and when a
+    session is the winning layer the summary IS that text: the occurrence carries no
+    error_detail of its own, so classifying the summary here would leave this route with
+    nothing to show for exactly those runs. The list surface for the same run still
+    classifies it, which is what makes the split real rather than a leak."""
+    session = {
+        "id": "sess-1",
+        "status": _terminal_session_status(),
+        "status_reason_summary": f"PermissionError: {_RAW_ERROR_SENTINEL}",
+    }
+    schedule_id, run_id = _seed_run_linked_to(
+        monkeypatch,
+        tmp_path / "state.db",
+        invocation={"id": "inv-1", "status": _terminal_invocation_status()},
+        sessions=[session],
+    )
+    client = _make_client()
+
+    body = client.get(f"/api/schedules/runs/{run_id}").json()
+    assert body["outcome"]["source"] == "session"
+    assert _RAW_ERROR_SENTINEL in body["outcome"]["summary"]
+    assert body.get("error_detail") is None, "the occurrence has no text of its own here"
+
+    listed = client.get(f"/api/schedules/{schedule_id}/runs")
+    assert _RAW_ERROR_SENTINEL not in listed.text, "the list surface still classifies it"


### PR DESCRIPTION
## What

`GET /api/schedules/runs/{run_id}` returned the joined `schedule_runs` row verbatim, and for a chain parent the raw child rows under it. That is every column the join carries, including the action arguments, resume packets, lease holders, concurrency keys and capability/library references the list surfaces already withhold. Every other schedule surface is projected onto a named allow-list. This was the one left.

The API answers without a token when `LIONAGI_STUDIO_AUTH_TOKEN` is unset, so on these routes the projection is the boundary rather than the auth gate. That is the decision this repo already made for the list surfaces, recorded in the comment above `_RUN_SUMMARY_FIELDS`; this change applies it to the route that had not been covered.

## How

- `_RUN_RECORD_FIELDS = _RUN_VIEW_FIELDS + ("error_detail",)` and `_run_record()`, applied in the route rather than in the service, so in-process readers of the full row are unaffected.
- The raw failure text stays. Reaching it is the reason this route exists: the list surfaces serve a translatable classification, and opening one run is the documented way to get the text behind it. Two existing tests pin that and still pass.
- Nested `chain_children` take the run-list projection, and remain absent rather than empty on a run that is itself a child, matching what the service produces.
- `trigger_context` is no longer served. It carries whole external event payloads and nothing reads it: the web client declared the field and never referenced it, so it is dropped from `ScheduleRunSummary` too rather than leaving the type assert something the route does not send.

## Tests

- a positive control that the record read really carries the private columns, in the parent and in the child; without it the sweep passes on a row that never had them
- the sweep itself, at any nesting depth, on both parent and child
- a named check that the trigger payload is gone
- containment: every field the web client declares survives the projection

Mutation arm: removing the projection from the route reddens exactly the two sweeps and nothing else.

37 tests in `tests/apps_studio_server/test_schedule_runs_route.py` pass. `tests/studio/test_schedule_run_view_service.py`, `tests/studio/test_schedule_runs_regression.py` and `tests/apps_studio_server/test_daemon_api_gate.py` pass. Frontend `tsc --noEmit` is clean and the 95 schedules component tests pass.

The first commit is a test-only pin for the private run columns on the list surfaces; it was written alongside that projection work and rides along here.
