### PR TITLE
ci: run the workflow on every pull request, whatever its base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,17 @@ on:
   # PR that has since changed state, and if a job is ever made conditional on
   # draft it will not have run at all. Listing the defaults back is mandatory:
   # naming types replaces them rather than adding to them.
+  #
+  # And no branches filter, the same principle a third time. A PR based on any
+  # branch other than main or develop raised no event, so nothing here ever ran
+  # on it. Its
+  # base is unprotected, so the required checks do not apply either: the PR reads
+  # mergeable with no suite behind it, and merging it carries never-tested code
+  # into the parent branch, where the parent's own suite structurally cannot see
+  # it. That failure is silent, which is why the filter goes rather than the
+  # branch list growing.
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
-    branches: [ main, develop ]
   workflow_dispatch:
     inputs:
       python-matrix:


### PR DESCRIPTION
## What

`ci.yml`'s `pull_request` trigger carried `branches: [ main, develop ]`. A PR based on any other branch raised no event, so nothing in this workflow ever ran on it. Deletes the filter.

## Why it matters more than a missing report

A PR filtered out this way has an unprotected base, so the repository's required status checks do not apply to it either. It reads `MERGEABLE` / `CLEAN` with no suite behind it at all, and merging it carries never-tested code into the parent branch, where the parent's own green suite structurally cannot see it. The failure is silent in both directions: nothing runs, and nothing says so.

Measured on the open PRs: every PR whose base is not `main` has exactly one check-run on it, `Vercel Preview Comments`, success. Controls in the same read: PRs based on `main` carry 21 and 23.

## Why deletion rather than a longer branch list

The file already argues this principle twice, in its own comments: no `paths-ignore` on `push`, because the hygiene lint must gate a notebook-only change; no `paths-ignore` on `pull_request` and an explicit `types` list, because the suite has to report on every PR. The branch filter is the same principle violated by a third route two lines below. A branch list has to be maintained to stay correct, and it fails silently when it is not.

## Side effects

- `push` keeps its branch list. A push run is only meaningful on the trunk branches.
- `concurrency.group` is `${{ github.workflow }}-${{ github.ref }}`; for a `pull_request` event `github.ref` is `refs/pull/N/merge`, unique per PR, so no PR cancels another's run.
- The cost is CI minutes on stacked PRs, which is the correct cost: those are exactly the PRs that have been merging untested.

Validated at the parse and at the raw document: `pull_request` now has only `types`, and exactly one `branches:` line survives in the file, the `push` one.
