### PR TITLE
test(mcp): write the notify shim's manifest atomically

### DIFF
--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -696,6 +696,15 @@ from lionagi.state.lifecycle.callbacks import (
 )
 
 
+def _write_manifest(manifest, payload):
+    # Atomic, because the test polls this file from another process while this one
+    # writes it. write_text truncates on open, so a poll landing in that window reads
+    # an empty file. The CLI this shim stands in for writes its manifest the same way.
+    tmp = manifest.parent / (manifest.name + ".tmp")
+    tmp.write_text(json.dumps(payload))
+    os.replace(tmp, manifest)
+
+
 async def main():
     argv = sys.argv[1:]
     template = argv[argv.index("--notify") + 1]
@@ -703,7 +712,7 @@ async def main():
     run_dir = config.run_dir(run_id)
     run_dir.mkdir(parents=True, exist_ok=True)
     manifest = run_dir / "run.json"
-    manifest.write_text(json.dumps({"status": "running"}))
+    _write_manifest(manifest, {"status": "running"})
 
     registry = TerminalCallbackRegistry(budget_seconds=1.0)
     register_flow_notify_scope(
@@ -728,7 +737,7 @@ async def main():
             occurred_at=time.time(),
         )
     )
-    manifest.write_text(json.dumps({"status": "completed"}))
+    _write_manifest(manifest, {"status": "completed"})
     print("terminal manifest written", flush=True)
 
 


### PR DESCRIPTION
## What

`tests/mcp/test_notify_hook.py::test_outer_notify_timeout_keeps_an_attempt_record_after_delivery` fails intermittently on CI with `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.

The test's shim subprocess writes `run.json` with `Path.write_text`, which truncates the file on open and then writes. The parent process polls that same file every 50ms while the shim runs. A poll landing inside the truncation window reads an empty file, and the poll's `json.loads` raises instead of treating it as "not ready yet".

Test-only. No library behaviour changes.

## Why the shim, not the reader

The shim stands in for the CLI, and the CLI writes its manifest through `_atomic_write_json` (tmp file in the destination directory, then `os.replace`). The shim was modelling something weaker than the component it substitutes for, and that difference is the whole bug. It now writes the same way.

## Evidence

Verified by opening the window rather than repeating the run, since repeating a rare race at fixed settings only measures those settings:

- non-atomic write with a 0.3s sleep between truncate and write: the test fails with exactly the CI error
- atomic write with the same 0.3s sleep: the test passes

Both arms run against the same poll loop, unchanged.

## Scope

Enumerated the construct rather than patching the one site. Of the 16 manifest `write_text` calls under `tests/`, this shim's two are the only ones a second process reads concurrently; every other one writes a fixture before the code under test runs, so there is no window to land in.

62 tests in the file pass.
