### PR TITLE
fix(cli): record lost live messages on the run's terminal row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   on the session, and the write that eventually happens adds up every deferred leg's count
   rather than reporting only its own, because each leg that observed a loss is gone by then and
   its queue with it. A session that defers twice before anything terminal accumulates across
-  both deferrals rather than the second replacing the first. And a run that failed on its own keeps its own failure: the loss is appended to the
+  both deferrals rather than the second replacing the first, and so does a session whose legs
+  tear down at the same time: each leg records what it saw under a key of its own instead of
+  rewriting a shared one, so no leg's record can replace a sibling's. And a run that failed on its own keeps its own failure: the loss is appended to the
   evidence either way and claims the reason code only when nothing else has.
   Recording that carried loss cannot cost the handoff: the deferred path's job is to defer, and
   the caller reads the status it returns to decide whether to resume, so a bookkeeping write that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- A run whose live-message persistence gave up now records that on its terminal row.
+  Under database-lock contention the retry queue defers and then abandons its pending
+  events at teardown; the count reached one line in one console tail while the session
+  closed as a clean success, so the loss was invisible to every reader of the run. The
+  session now carries a `run.completed.message_loss` reason, a summary naming how many
+  events were lost, and evidence refs naming each queue that lost them, with the
+  structured counts in the transition record. The completion-trust gate also no longer
+  demotes such a run to `completed_empty`: that conclusion is read off the transcript, and
+  this run's transcript is known to be missing part of itself.
+
+  The loss survives the two ways a run's terminal row is written by someone other than the
+  leg that saw it. A leg that hands its terminal write to a resuming leg now leaves the loss
+  on the session, and the write that eventually happens adds up every deferred leg's count
+  rather than reporting only its own, because each leg that observed a loss is gone by then and
+  its queue with it. A session that defers twice before anything terminal accumulates across
+  both deferrals rather than the second replacing the first. And a run that failed on its own keeps its own failure: the loss is appended to the
+  evidence either way and claims the reason code only when nothing else has.
+  Recording that carried loss cannot cost the handoff: the deferred path's job is to defer, and
+  the caller reads the status it returns to decide whether to resume, so a bookkeeping write that
+  fails is logged and the status stands rather than leaving a timed-out run unresumed. The carried
+  payload is validated where it is read back rather than trusted for its shape, since it was written
+  by whatever code the earlier leg was running; entries that do not fit are dropped, and the total is
+  recomputed from the entries that survive so it agrees with what it claims to sum.
+
+  A flow invocation whose children all completed no longer reports a clean success when one of
+  them lost messages. It reads the loss off the child's evidence rather than its reason code,
+  so a child that lost messages and also hit something else is still named, and the invocation
+  carries the sessions whose transcripts are incomplete.
 - The schedule list surfaces no longer carry record content. They served every column of the
   schedule row, including the command a schedule runs and its arguments, its authored spec, its
   notify command and owner key, and they served `trigger_context`, which holds whole external

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   demotes such a run to `completed_empty`: that conclusion is read off the transcript, and
   this run's transcript is known to be missing part of itself.
 
-  The loss survives the two ways a run's terminal row is written by someone other than the
+  The loss survives every way a run's terminal row is written by someone other than the
   leg that saw it. A leg that hands its terminal write to a resuming leg now leaves the loss
   on the session, and the write that eventually happens adds up every deferred leg's count
   rather than reporting only its own, because each leg that observed a loss is gone by then and
@@ -115,7 +115,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   fails is logged and the status stands rather than leaving a timed-out run unresumed. The carried
   payload is validated where it is read back rather than trusted for its shape, since it was written
   by whatever code the earlier leg was running; entries that do not fit are dropped, and the total is
-  recomputed from the entries that survive so it agrees with what it claims to sum.
+  recomputed from the entries that survive so it agrees with what it claims to sum. A leg
+  whose own terminal write never lands, because a concurrent teardown won the race or the row
+  was already terminal, keeps the loss on the session rather than discarding it with the status
+  it was about to write: the winner's record stands and the loss stays where its readers look.
 
   An invocation whose child lost messages no longer reports a clean success, on the flow path
   and the scheduled path alike. The loss is read off the child's evidence before the terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,10 +117,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   by whatever code the earlier leg was running; entries that do not fit are dropped, and the total is
   recomputed from the entries that survive so it agrees with what it claims to sum.
 
-  A flow invocation whose children all completed no longer reports a clean success when one of
-  them lost messages. It reads the loss off the child's evidence rather than its reason code,
-  so a child that lost messages and also hit something else is still named, and the invocation
-  carries the sessions whose transcripts are incomplete.
+  An invocation whose child lost messages no longer reports a clean success, on the flow path
+  and the scheduled path alike. The loss is read off the child's evidence before the terminal
+  status is decided rather than inside the all-completed arm, so a child that lost messages and
+  also failed is still named on the invocation row, and a scheduled run with an incomplete
+  transcript carries `run.completed.message_loss` instead of flattening to a clean pass.
 - The schedule list surfaces no longer carry record content. They served every column of the
   schedule row, including the command a schedule runs and its arguments, its authored spec, its
   notify command and owner key, and they served `trigger_context`, which holds whole external

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   fails is logged and the status stands rather than leaving a timed-out run unresumed. The carried
   payload is validated where it is read back rather than trusted for its shape, since it was written
   by whatever code the earlier leg was running; entries that do not fit are dropped, and the total is
-  recomputed from the entries that survive so it agrees with what it claims to sum. A leg
+  recomputed from the entries that survive so it agrees with what it claims to sum. One rule decides
+  that, shared by the reader that asks whether a row lost anything and the reader that sums how many,
+  so a payload one rejects cannot still produce a loss verdict from the other. A leg
   whose own terminal write never lands, because a concurrent teardown won the race or the row
   was already terminal, keeps the loss on the session rather than discarding it with the status
   it was about to write: the winner's record stands and the loss stays where its readers look.
@@ -126,7 +128,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   and the scheduled path alike. The loss is read off the child's evidence before the terminal
   status is decided rather than inside the all-completed arm, so a child that lost messages and
   also failed is still named on the invocation row, and a scheduled run with an incomplete
-  transcript carries `run.completed.message_loss` instead of flattening to a clean pass.
+  transcript carries `run.completed.message_loss` instead of flattening to a clean pass. That
+  holds for a flow whose children have not all reached a terminal status either, where no arm of
+  the precedence ladder claims the outcome and the clean-pass fallback used to decide it.
 - The studio scheduler's tick loop is now supervised rather than merely guarded. It caught
   `Exception`, which does not include `asyncio.CancelledError`, so a cancel escaping from anything
   the tick awaited ended the loop permanently while the process and its HTTP surface kept

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -935,6 +935,10 @@ async def _teardown_common(
     # CAS guard below (not updated_at, which this function may itself have touched).
     pre_write_status = session_row.get("status")
 
+    # Whether this teardown's own terminal write landed. Every path where it did not
+    # returns someone else's status, and that row knows nothing about this leg's loss.
+    wrote_terminal_record = False
+
     if pre_write_status in SESSION_TERMINAL_STATUSES:
         # Already terminal before this teardown attempted anything (e.g. reattached
         # to a session an earlier run already finalized) -- skip the redundant write
@@ -973,6 +977,7 @@ async def _teardown_common(
                     else {"ended_at": ended_at, "duration_ms": duration_ms}
                 ),
             )
+            wrote_terminal_record = bool(written)
             if not written:
                 # CAS miss: a concurrent teardown of the same session won the race.
                 # Read back the persisted status rather than raising past callers.
@@ -992,6 +997,25 @@ async def _teardown_common(
                 "session %s already terminal (%s); skipped duplicate status write",
                 session_id,
                 final_status,
+            )
+
+    if message_loss and not wrote_terminal_record:
+        # The row that won says the run is clean and this leg is the only one that saw
+        # the loss. Leave it where the invocation reducers look, without touching the
+        # winner's status or reason -- an earlier terminal record stands.
+        try:
+            carried = await db.get_session(session_id) or {}
+            merged = _merge_message_loss(carried.get("node_metadata") or {}, message_loss)
+            await db.merge_session_node_metadata(
+                session_id, {"message_persist_loss_json": json.dumps(merged)}
+            )
+        except Exception as exc:  # noqa: BLE001 - bookkeeping must not mask the outcome
+            _log.warning(
+                "session %s: could not record %d lost message event(s) after its "
+                "terminal row was written by another teardown: %r",
+                session_id,
+                message_loss["lost"],
+                exc,
             )
     return final_status
 

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -14,7 +14,7 @@ import uuid
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 from uuid import uuid4
 
 from lionagi._paths import RUNS_ROOT, ensure_lionagi_dir
@@ -529,6 +529,7 @@ async def _teardown_common(
     finalize_error: dict | None = None,
     artifact_write_error: dict | None = None,
     gate_rejected_evidence: list[dict] | None = None,
+    message_loss: MessageLoss | None = None,
     cwd: str | None = None,
     engine_session_uid: str | None = None,
     defer_terminal: bool = False,
@@ -541,7 +542,38 @@ async def _teardown_common(
 
     if defer_terminal:
         # A resumed leg on this same session owns the real terminal write (ADR-0035);
-        # skip the DB mutation here and let the caller's non-status bookkeeping run.
+        # skip the status mutation here and let the caller's non-status bookkeeping run.
+        #
+        # The loss is the exception, and it is not a status write. This leg is the only
+        # one that ever knows about it -- its queue is unrouted straight after this and
+        # the resuming leg builds its own -- so leaving it here means the eventual
+        # terminal write reports a clean run over a transcript missing part of itself.
+        if message_loss:
+            try:
+                # Re-merged, not just written: a session can time out twice before
+                # anything terminal, and this branch is the only writer of the field it
+                # also reads. Writing this leg's own loss alone drops every leg before
+                # it, and the terminal write has no way to tell.
+                carried = await db.get_session(session_id) or {}
+                message_loss = _merge_message_loss(carried.get("node_metadata") or {}, message_loss)
+                # Serialized, because the merge refuses a nested patch value: sqlite and
+                # postgres merge nested objects differently and it will not persist state
+                # that depends on the backend.
+                await db.merge_session_node_metadata(
+                    session_id, {"message_persist_loss_json": json.dumps(message_loss)}
+                )
+            except Exception:
+                # This path's job is to defer, and the caller reads the status it
+                # returns to decide whether to resume. Letting a bookkeeping write
+                # decide that would trade a run that resumes for one that hangs
+                # unresumed, to save an annotation. Loud, because the annotation
+                # existed to stop exactly this kind of silent loss.
+                _log.exception(
+                    "Could not record %d lost message event(s) for deferred session "
+                    "%s; the resuming leg's terminal row will not carry them",
+                    message_loss["lost"],
+                    session_id,
+                )
         return status
 
     all_msgs = await db.get_progression(session_prog_id)
@@ -550,6 +582,13 @@ async def _teardown_common(
     # Fetched before this call's own write so started_at reflects session
     # creation, not a value this same update is about to touch.
     session_before_teardown = await db.get_session(session_id) or {}
+
+    # A leg that timed out on this session recorded its loss and deferred the terminal
+    # write. This is that write, so it reports both legs' losses or the earlier one is
+    # gone: the leg that saw it is finished and its queue no longer exists.
+    message_loss = _merge_message_loss(
+        (session_before_teardown.get("node_metadata") or {}), message_loss
+    )
 
     # ended_at and duration_ms are terminal fields and must land in the same
     # atomic write as the status transition below (see the
@@ -786,7 +825,12 @@ async def _teardown_common(
             metadata = dict(metadata or {})
             metadata["completion_evidence"] = evidence
             metadata["has_assistant_output"] = has_output
-            if not has_completion_evidence(evidence) and not has_output:
+            # "No assistant response recorded" is read off the transcript, and
+            # a run that lost messages has a transcript missing exactly the
+            # kind of thing this looks for. Concluding emptiness from it states
+            # a fact about the run that is really a fact about our record, so
+            # the loss below carries the reason instead.
+            if not has_completion_evidence(evidence) and not has_output and not message_loss:
                 final_status = "completed_empty"
                 final_reason_code = RunReasons.COMPLETED_EMPTY_NO_EVIDENCE
                 base_label = evidence.get("base_ref") or "base"
@@ -855,6 +899,35 @@ async def _teardown_common(
                     "label": finalize_error.get("error", ""),
                 }
             ]
+
+    # Live-message persistence gave up. The run's own work stands, so this never
+    # manufactures a failure and never displaces a reason that is about the work --
+    # it goes last, and takes the reason code only if nothing else claimed one. The
+    # evidence ref is appended either way: a reader has to be able to find the loss
+    # on a run that also failed, or hit a finalize error, or this records it only in
+    # the case where nothing else went wrong.
+    if message_loss:
+        from lionagi.state.reasons import RunReasons
+
+        metadata = dict(metadata or {})
+        metadata["message_persist_loss"] = message_loss
+        final_evidence_refs = list(final_evidence_refs or []) + [
+            {
+                "kind": "message_persist_loss",
+                "id": queue["owner"],
+                "label": f"{queue['lost']} event(s) lost",
+            }
+            for queue in message_loss["queues"]
+        ]
+        if final_status in ("completed", "completed_empty") and (
+            final_reason_code in (None, "", RunReasons.COMPLETED_OK)
+        ):
+            final_reason_code = RunReasons.COMPLETED_MESSAGE_LOSS
+            final_reason_summary = (
+                f"Run completed; {message_loss['lost']} live message event(s) were "
+                "never written and are lost, so this session's transcript is "
+                "incomplete."
+            )
 
     from lionagi.state.db import SESSION_TERMINAL_STATUSES, TransitionRejectedError
 
@@ -975,13 +1048,14 @@ async def teardown_persist(
 
     db = ctx["db"]
     try:
-        await _flush_pending_message_events(ctx)
+        message_loss = await _flush_pending_message_events(ctx)
         final_status = await _teardown_common(
             db,
             session_id=ctx["session_id"],
             session_prog_id=ctx["session_prog_id"],
             status=status,
             exception=exception,
+            message_loss=message_loss,
             artifacts_path=ctx.get("artifacts_path"),
             artifact_contract=ctx.get("artifact_contract"),
             extras=extras,
@@ -1204,18 +1278,93 @@ def _make_message_handler(
     return _on_message
 
 
-async def _flush_pending_message_events(ctx: dict) -> bool:
+class QueueLoss(TypedDict):
+    """One retry queue that gave up, and how much it was holding."""
+
+    owner: str
+    lost: int
+
+
+class MessageLoss(TypedDict):
+    """What a teardown could not persist, summed and itemized.
+
+    Written by ``_flush_pending_message_events``, carried across a deferred leg as
+    JSON, and read by ``_teardown_common``. Spelled out because those three are in
+    different places and a bare dict makes the shape a convention rather than a
+    contract.
+    """
+
+    lost: int
+    queues: list[QueueLoss]
+
+
+def _as_message_loss(value: Any) -> MessageLoss | None:
+    """Coerce a payload parsed from the session row into a ``MessageLoss``.
+
+    The carried value crossed a persistence boundary and may have been written by
+    a leg running different code, so its shape is an assumption rather than a
+    guarantee. Entries that do not fit are dropped instead of partly trusted: the
+    total feeds a lost-event count a reader treats as exact, and an unchecked one
+    reaches ``queue["owner"]`` indexing further on. The total is recomputed here
+    rather than read, so it agrees with the entries it claims to sum.
+    """
+    if not isinstance(value, dict):
+        return None
+    raw = value.get("queues")
+    queues: list[QueueLoss] = [
+        {"owner": str(q["owner"]), "lost": q["lost"]}
+        for q in (raw if isinstance(raw, list) else [])
+        if isinstance(q, dict)
+        and q.get("owner") is not None
+        and isinstance(q.get("lost"), int)
+        and not isinstance(q["lost"], bool)
+    ]
+    if not queues:
+        return None
+    return {"lost": sum(q["lost"] for q in queues), "queues": queues}
+
+
+def _merge_message_loss(node_metadata: Any, current: MessageLoss | None) -> MessageLoss | None:
+    """This teardown's loss plus any a deferred earlier leg left on the session."""
+    if isinstance(node_metadata, str):
+        try:
+            node_metadata = json.loads(node_metadata)
+        except (TypeError, ValueError):
+            node_metadata = None
+    carried = (
+        node_metadata.get("message_persist_loss_json") if isinstance(node_metadata, dict) else None
+    )
+    if isinstance(carried, str):
+        try:
+            carried = json.loads(carried)
+        except (TypeError, ValueError):
+            carried = None
+    carried = _as_message_loss(carried)
+    if not carried:
+        return current
+    if not current:
+        return carried
+    queues = carried["queues"] + current["queues"]
+    return {"lost": sum(q["lost"] for q in queues), "queues": queues}
+
+
+async def _flush_pending_message_events(ctx: dict) -> MessageLoss | None:
     """Retry queued messages before teardown reads completion evidence.
 
-    Returns whether every queue emptied. What follows this reads the run's
-    completion evidence, so a queue that gave up here means that evidence is
-    being read against a transcript missing messages the run produced.
+    Returns what was lost, or ``None`` when every queue emptied. What follows
+    this reads the run's completion evidence, so a queue that gave up here
+    means that evidence is being read against a transcript missing messages the
+    run produced. Returning the loss rather than a bare failure flag is what
+    lets the terminal row say so: a log line lives in one console tail, and the
+    tail is not where anyone looks to find out how a run went.
     """
-    flushed = True
+    queues: list[QueueLoss] = []
     for retry_queue in ctx.get("message_retry_queues", []):
         if not await retry_queue.flush_final():
-            flushed = False
-    return flushed
+            queues.append({"owner": retry_queue.owner, "lost": retry_queue.pending_count})
+    if not queues:
+        return None
+    return {"lost": sum(q["lost"] for q in queues), "queues": queues}
 
 
 async def _reopen_session_for_resume(

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -549,18 +549,19 @@ async def _teardown_common(
         # the resuming leg builds its own -- so leaving it here means the eventual
         # terminal write reports a clean run over a transcript missing part of itself.
         if message_loss:
+            from lionagi.state.reasons import MESSAGE_LOSS_KEY_PREFIX
+
             try:
-                # Re-merged, not just written: a session can time out twice before
-                # anything terminal, and this branch is the only writer of the field it
-                # also reads. Writing this leg's own loss alone drops every leg before
-                # it, and the terminal write has no way to tell.
-                carried = await db.get_session(session_id) or {}
-                message_loss = _merge_message_loss(carried.get("node_metadata") or {}, message_loss)
+                # This leg's own loss under its own key. A session can time out twice
+                # before anything terminal, and reading the field to rewrite it would
+                # drop whichever concurrent leg wrote between the read and the write;
+                # the terminal write reads every key, so nothing needs merging here.
                 # Serialized, because the merge refuses a nested patch value: sqlite and
                 # postgres merge nested objects differently and it will not persist state
                 # that depends on the backend.
                 await db.merge_session_node_metadata(
-                    session_id, {"message_persist_loss_json": json.dumps(message_loss)}
+                    session_id,
+                    {f"{MESSAGE_LOSS_KEY_PREFIX}{uuid4().hex}": json.dumps(message_loss)},
                 )
             except Exception:
                 # This path's job is to defer, and the caller reads the status it
@@ -584,8 +585,12 @@ async def _teardown_common(
     session_before_teardown = await db.get_session(session_id) or {}
 
     # A leg that timed out on this session recorded its loss and deferred the terminal
-    # write. This is that write, so it reports both legs' losses or the earlier one is
-    # gone: the leg that saw it is finished and its queue no longer exists.
+    # write. This is that write, so it reports every leg's loss or the earlier ones are
+    # gone: the legs that saw them are finished and their queues no longer exist.
+    # This leg's own loss stays separate. If the terminal write below turns out to belong
+    # to another leg, this one records only what it saw: the earlier losses are already on
+    # the row under their own keys, and writing them again would count them twice.
+    own_message_loss = message_loss
     message_loss = _merge_message_loss(
         (session_before_teardown.get("node_metadata") or {}), message_loss
     )
@@ -999,22 +1004,23 @@ async def _teardown_common(
                 final_status,
             )
 
-    if message_loss and not wrote_terminal_record:
+    if own_message_loss and not wrote_terminal_record:
+        from lionagi.state.reasons import MESSAGE_LOSS_KEY_PREFIX
+
         # The row that won says the run is clean and this leg is the only one that saw
         # the loss. Leave it where the invocation reducers look, without touching the
         # winner's status or reason -- an earlier terminal record stands.
         try:
-            carried = await db.get_session(session_id) or {}
-            merged = _merge_message_loss(carried.get("node_metadata") or {}, message_loss)
             await db.merge_session_node_metadata(
-                session_id, {"message_persist_loss_json": json.dumps(merged)}
+                session_id,
+                {f"{MESSAGE_LOSS_KEY_PREFIX}{uuid4().hex}": json.dumps(own_message_loss)},
             )
         except Exception as exc:  # noqa: BLE001 - bookkeeping must not mask the outcome
             _log.warning(
                 "session %s: could not record %d lost message event(s) after its "
                 "terminal row was written by another teardown: %r",
                 session_id,
-                message_loss["lost"],
+                own_message_loss["lost"],
                 exc,
             )
     return final_status
@@ -1352,27 +1358,13 @@ def _as_message_loss(value: Any) -> MessageLoss | None:
 
 
 def _merge_message_loss(node_metadata: Any, current: MessageLoss | None) -> MessageLoss | None:
-    """This teardown's loss plus any a deferred earlier leg left on the session."""
-    if isinstance(node_metadata, str):
-        try:
-            node_metadata = json.loads(node_metadata)
-        except (TypeError, ValueError):
-            node_metadata = None
-    carried = (
-        node_metadata.get("message_persist_loss_json") if isinstance(node_metadata, dict) else None
-    )
-    if isinstance(carried, str):
-        try:
-            carried = json.loads(carried)
-        except (TypeError, ValueError):
-            carried = None
-    carried = _as_message_loss(carried)
+    """This teardown's loss plus every loss earlier legs left on the session row."""
+    from lionagi.state.reasons import carried_message_loss_queues
+
+    carried = carried_message_loss_queues(node_metadata)
     if not carried:
         return current
-    if not current:
-        return carried
-    queues = carried["queues"] + current["queues"]
-    return {"lost": sum(q["lost"] for q in queues), "queues": queues}
+    return _as_message_loss({"queues": carried + list((current or {}).get("queues") or [])})
 
 
 async def _flush_pending_message_events(ctx: dict) -> MessageLoss | None:

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1318,6 +1318,9 @@ def _as_message_loss(value: Any) -> MessageLoss | None:
         and q.get("owner") is not None
         and isinstance(q.get("lost"), int)
         and not isinstance(q["lost"], bool)
+        # A loss record with a zero or negative count is malformed, and summing it
+        # produces totals like "-3 event(s) lost".
+        and q["lost"] > 0
     ]
     if not queues:
         return None

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1338,19 +1338,15 @@ def _as_message_loss(value: Any) -> MessageLoss | None:
     reaches ``queue["owner"]`` indexing further on. The total is recomputed here
     rather than read, so it agrees with the entries it claims to sum.
     """
+    from lionagi.state.reasons import is_countable_queue_loss
+
     if not isinstance(value, dict):
         return None
     raw = value.get("queues")
     queues: list[QueueLoss] = [
         {"owner": str(q["owner"]), "lost": q["lost"]}
         for q in (raw if isinstance(raw, list) else [])
-        if isinstance(q, dict)
-        and q.get("owner") is not None
-        and isinstance(q.get("lost"), int)
-        and not isinstance(q["lost"], bool)
-        # A loss record with a zero or negative count is malformed, and summing it
-        # produces totals like "-3 event(s) lost".
-        and q["lost"] > 0
+        if is_countable_queue_loss(q)
     ]
     if not queues:
         return None

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -701,6 +701,19 @@ async def _resolve_invocation_terminal_flow(
                 )
 
         if fallback_status == "completed":
+            # Reached with children that exist but have not all reached a terminal status,
+            # so none of the arms above claimed the outcome. The loss is still real and this
+            # is still the clean-pass reason code, which is the one place it can hide.
+            if lost_messages:
+                return (
+                    "completed",
+                    RunReasons.COMPLETED_MESSAGE_LOSS,
+                    "Flow completed, but at least one child session lost live message "
+                    "events at teardown, so its transcript is incomplete and anything "
+                    "read from it is reading a partial record.",
+                    [{"kind": "session", "id": s["id"]} for s in lost_messages if s.get("id")],
+                    metadata,
+                )
             return (
                 "completed",
                 RunReasons.COMPLETED_OK,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -542,32 +542,25 @@ def _format_budget_preamble(
     )
 
 
-def _has_message_loss_evidence(session: dict) -> bool:
-    """Whether this session's row records that it lost live message events."""
-    refs = session.get("status_evidence_refs")
-    if isinstance(refs, str):
-        try:
-            refs = json.loads(refs)
-        except (TypeError, ValueError):
-            return False
-    if not isinstance(refs, list):
-        return False
-    return any(isinstance(ref, dict) and ref.get("kind") == "message_persist_loss" for ref in refs)
-
-
 async def _resolve_invocation_terminal_flow(
     invocation_id: str,
     *,
     fallback_status: str,
 ) -> tuple[str, str, str, list[dict], dict]:
     from lionagi.state.db import StateDB
-    from lionagi.state.reasons import RunReasons
+    from lionagi.state.reasons import RunReasons, has_message_loss_evidence
 
     async with StateDB() as db:
         sessions = await db.list_sessions_for_invocation(invocation_id)
         child_statuses = [str(s.get("status") or "") for s in sessions]
         evidence_refs = [{"kind": "session", "id": s["id"]} for s in sessions if s.get("id")]
         metadata: dict = {"child_statuses": child_statuses}
+        # Named ahead of the precedence ladder, not inside its all-completed arm: a
+        # child that lost messages and also failed carries the other status, and the
+        # loss has to survive that. Only the reason code defers, because a row has one.
+        lost_messages = [s for s in sessions if has_message_loss_evidence(s)]
+        if lost_messages:
+            metadata["message_loss_session_ids"] = [s["id"] for s in lost_messages if s.get("id")]
 
         # Precedence: timed_out > failed > aborted > cancelled > completed_empty
         # > completed. completed_empty outranks completed so one silently
@@ -617,17 +610,6 @@ async def _resolve_invocation_terminal_flow(
                     metadata,
                 )
             if all(s == "completed" for s in child_statuses):
-                # Read off the evidence rather than the reason code. A child that lost
-                # messages AND hit something else carries the other reason, because a
-                # row has one; it carries both evidence refs. Named in the metadata
-                # before any branch below can claim the reason code, or the branch that
-                # wins takes the loss out of the invocation record with it.
-                lost_messages = [s for s in sessions if _has_message_loss_evidence(s)]
-                if lost_messages:
-                    metadata = dict(metadata)
-                    metadata["message_loss_session_ids"] = [
-                        s["id"] for s in lost_messages if s.get("id")
-                    ]
                 spawn_refused = [
                     s
                     for s in sessions

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -542,6 +542,19 @@ def _format_budget_preamble(
     )
 
 
+def _has_message_loss_evidence(session: dict) -> bool:
+    """Whether this session's row records that it lost live message events."""
+    refs = session.get("status_evidence_refs")
+    if isinstance(refs, str):
+        try:
+            refs = json.loads(refs)
+        except (TypeError, ValueError):
+            return False
+    if not isinstance(refs, list):
+        return False
+    return any(isinstance(ref, dict) and ref.get("kind") == "message_persist_loss" for ref in refs)
+
+
 async def _resolve_invocation_terminal_flow(
     invocation_id: str,
     *,
@@ -604,6 +617,17 @@ async def _resolve_invocation_terminal_flow(
                     metadata,
                 )
             if all(s == "completed" for s in child_statuses):
+                # Read off the evidence rather than the reason code. A child that lost
+                # messages AND hit something else carries the other reason, because a
+                # row has one; it carries both evidence refs. Named in the metadata
+                # before any branch below can claim the reason code, or the branch that
+                # wins takes the loss out of the invocation record with it.
+                lost_messages = [s for s in sessions if _has_message_loss_evidence(s)]
+                if lost_messages:
+                    metadata = dict(metadata)
+                    metadata["message_loss_session_ids"] = [
+                        s["id"] for s in lost_messages if s.get("id")
+                    ]
                 spawn_refused = [
                     s
                     for s in sessions
@@ -670,6 +694,21 @@ async def _resolve_invocation_terminal_flow(
                         "child's own DAG already produced its result).",
                         [{"kind": "session", "id": s["id"]} for s in degraded if s.get("id")],
                         degraded_metadata,
+                    )
+                # A "completed" child may still carry COMPLETED_MESSAGE_LOSS: its work
+                # stands, but part of its transcript was never written. Last of these
+                # branches because it is the only one not about work the flow failed to
+                # do -- and still ahead of a clean pass, which is what this would
+                # otherwise flatten to.
+                if lost_messages:
+                    return (
+                        "completed",
+                        RunReasons.COMPLETED_MESSAGE_LOSS,
+                        "All child sessions completed, but at least one lost live "
+                        "message events at teardown, so its transcript is incomplete "
+                        "and anything read from it is reading a partial record.",
+                        [{"kind": "session", "id": s["id"]} for s in lost_messages if s.get("id")],
+                        metadata,
                     )
                 return (
                     "completed",

--- a/lionagi/hooks/_message_retry.py
+++ b/lionagi/hooks/_message_retry.py
@@ -45,6 +45,11 @@ class MessagePersistRetryQueue:
     def pending_count(self) -> int:
         return len(self._pending)
 
+    @property
+    def owner(self) -> str:
+        """What this queue's events belong to, for a report that names them."""
+        return self._owner
+
     async def submit(self, event: PendingMessageEvent) -> bool:
         """Queue ``event`` and persist pending events in their original order."""
         async with self._lock:

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -253,6 +253,43 @@ def entity_table(entity_type: str) -> str:
     return ENTITY_TYPE_TO_TABLE[canonical]
 
 
+#: Prefix for the node_metadata keys a teardown writes when it observed live-message
+#: loss but does not own the session's terminal row. One key per observing leg, never a
+#: shared one: legs tear down concurrently, and the database merges a patch key by key,
+#: so a leg that rewrote a shared value would replace a sibling's record instead of
+#: adding to it. Keys are left in place once folded into a terminal row -- clearing them
+#: would race the next leg's write -- and their number is bounded by how many teardowns
+#: one session has.
+MESSAGE_LOSS_KEY_PREFIX: Final = "message_persist_loss:"
+
+
+def carried_message_loss_queues(node_metadata: Any) -> list[Any]:
+    """Every queue loss left on a session row, across the legs that recorded them.
+
+    Entries are returned as found. They crossed a persistence boundary and may have been
+    written by a leg running different code, so the caller validates before summing.
+    """
+    if isinstance(node_metadata, str):
+        try:
+            node_metadata = json.loads(node_metadata)
+        except (TypeError, ValueError):
+            return []
+    if not isinstance(node_metadata, dict):
+        return []
+    queues: list[Any] = []
+    for key, value in node_metadata.items():
+        if not (isinstance(key, str) and key.startswith(MESSAGE_LOSS_KEY_PREFIX)):
+            continue
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except (TypeError, ValueError):
+                continue
+        if isinstance(value, dict) and isinstance(value.get("queues"), list):
+            queues.extend(value["queues"])
+    return queues
+
+
 def has_message_loss_evidence(session: Any) -> bool:
     """Whether a session row records that it lost live message events.
 
@@ -273,18 +310,4 @@ def has_message_loss_evidence(session: Any) -> bool:
         return True
     # A leg whose own terminal write never landed -- it deferred, or lost the race to a
     # concurrent teardown -- leaves the loss here instead, and no evidence ref exists.
-    node_metadata = session.get("node_metadata")
-    if isinstance(node_metadata, str):
-        try:
-            node_metadata = json.loads(node_metadata)
-        except (TypeError, ValueError):
-            return False
-    if not isinstance(node_metadata, dict):
-        return False
-    carried = node_metadata.get("message_persist_loss_json")
-    if isinstance(carried, str):
-        try:
-            carried = json.loads(carried)
-        except (TypeError, ValueError):
-            return False
-    return isinstance(carried, dict) and bool(carried.get("queues"))
+    return bool(carried_message_loss_queues(session.get("node_metadata")))

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from typing import Final
+import json
+from typing import Any, Final
 
 # Canonical singular entity types (ADR-0057); validated at write time in
 # StateDB.update_status().
@@ -250,3 +251,22 @@ def entity_table(entity_type: str) -> str:
     """Resolve entity_type (including aliases) to its SQLite table name."""
     canonical = validate_entity_type(entity_type)
     return ENTITY_TYPE_TO_TABLE[canonical]
+
+
+def has_message_loss_evidence(session: Any) -> bool:
+    """Whether a session row records that it lost live message events.
+
+    Reads the evidence refs rather than the reason code: a row carries one reason and
+    a session that lost messages may have failed for something else entirely.
+    """
+    if not isinstance(session, dict):
+        return False
+    refs = session.get("status_evidence_refs")
+    if isinstance(refs, str):
+        try:
+            refs = json.loads(refs)
+        except (TypeError, ValueError):
+            return False
+    if not isinstance(refs, list):
+        return False
+    return any(isinstance(ref, dict) and ref.get("kind") == "message_persist_loss" for ref in refs)

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -267,6 +267,24 @@ def has_message_loss_evidence(session: Any) -> bool:
             refs = json.loads(refs)
         except (TypeError, ValueError):
             return False
-    if not isinstance(refs, list):
+    if isinstance(refs, list) and any(
+        isinstance(ref, dict) and ref.get("kind") == "message_persist_loss" for ref in refs
+    ):
+        return True
+    # A leg whose own terminal write never landed -- it deferred, or lost the race to a
+    # concurrent teardown -- leaves the loss here instead, and no evidence ref exists.
+    node_metadata = session.get("node_metadata")
+    if isinstance(node_metadata, str):
+        try:
+            node_metadata = json.loads(node_metadata)
+        except (TypeError, ValueError):
+            return False
+    if not isinstance(node_metadata, dict):
         return False
-    return any(isinstance(ref, dict) and ref.get("kind") == "message_persist_loss" for ref in refs)
+    carried = node_metadata.get("message_persist_loss_json")
+    if isinstance(carried, str):
+        try:
+            carried = json.loads(carried)
+        except (TypeError, ValueError):
+            return False
+    return isinstance(carried, dict) and bool(carried.get("queues"))

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -263,12 +263,27 @@ def entity_table(entity_type: str) -> str:
 MESSAGE_LOSS_KEY_PREFIX: Final = "message_persist_loss:"
 
 
-def carried_message_loss_queues(node_metadata: Any) -> list[Any]:
-    """Every queue loss left on a session row, across the legs that recorded them.
+def is_countable_queue_loss(entry: Any) -> bool:
+    """Whether one queue-loss entry can be counted.
 
-    Entries are returned as found. They crossed a persistence boundary and may have been
-    written by a leg running different code, so the caller validates before summing.
+    The entry crossed a persistence boundary and may have been written by a leg running
+    different code, so its shape is an assumption. Shared rather than repeated per reader:
+    a reader that decides a row lost messages and a reader that sums how many have to
+    agree, or a payload one rejects still produces a loss verdict from the other.
     """
+    return (
+        isinstance(entry, dict)
+        and entry.get("owner") is not None
+        and isinstance(entry.get("lost"), int)
+        and not isinstance(entry["lost"], bool)
+        # Zero or negative is malformed, not a small loss: summing it produces totals
+        # like "-3 event(s) lost", and counting it makes a clean run report a loss.
+        and entry["lost"] > 0
+    )
+
+
+def carried_message_loss_queues(node_metadata: Any) -> list[Any]:
+    """Every countable queue loss left on a session row, across the legs that recorded them."""
     if isinstance(node_metadata, str):
         try:
             node_metadata = json.loads(node_metadata)
@@ -286,7 +301,7 @@ def carried_message_loss_queues(node_metadata: Any) -> list[Any]:
             except (TypeError, ValueError):
                 continue
         if isinstance(value, dict) and isinstance(value.get("queues"), list):
-            queues.extend(value["queues"])
+            queues.extend(q for q in value["queues"] if is_countable_queue_loss(q))
     return queues
 
 

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -77,6 +77,10 @@ class RunReasons:
     # unlike COMPLETED_FINALIZE_ERROR, a raised write failure is a real failure
     # (status -> failed); distinct from FAILED_MISSING_ARTIFACT's post-hoc gap
     FAILED_ARTIFACT_WRITE = "run.failed.artifact_write"
+    # live-message persistence gave up at teardown: the run's own work stands,
+    # but its transcript is missing messages it produced, so every later read
+    # of that transcript is reading an incomplete record
+    COMPLETED_MESSAGE_LOSS = "run.completed.message_loss"
     TIMED_OUT_DEADLINE = "run.timed_out.deadline"
     ABORTED_USER = "run.aborted.user"
     CANCELLED_SIGINT = "run.cancelled.sigint"

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -22,7 +22,7 @@ from lionagi.state.db import (
     CursorClaim,
     StateDB,
 )
-from lionagi.state.reasons import RunReasons
+from lionagi.state.reasons import RunReasons, has_message_loss_evidence
 from lionagi.studio.scheduler import coordination as _coordination
 
 _log = logging.getLogger(__name__)
@@ -386,6 +386,11 @@ async def resolve_invocation_terminal(
         metadata["exit_code"] = exit_code
     if exception is not None:
         metadata["exception_class"] = type(exception).__name__
+    # Same placement as the flow reducer: ahead of the ladder, so a child that lost
+    # messages and also failed still reports the loss on the invocation row.
+    lost_messages = [s for s in sessions if has_message_loss_evidence(s)]
+    if lost_messages:
+        metadata["message_loss_session_ids"] = [s["id"] for s in lost_messages if s.get("id")]
 
     # Precedence: timed_out > failed > aborted > cancelled > completed_empty
     # > completed. completed_empty outranks completed so one silently empty
@@ -444,6 +449,18 @@ async def resolve_invocation_terminal(
                 metadata,
             )
         if all(s == "completed" for s in child_statuses):
+            # Ahead of the clean pass this would otherwise flatten to: the work stands,
+            # but part of a transcript was never written and anything read from it is
+            # reading a partial record.
+            if lost_messages:
+                return (
+                    "completed",
+                    RunReasons.COMPLETED_MESSAGE_LOSS,
+                    "All child sessions completed, but at least one lost live message "
+                    "events at teardown, so its transcript is incomplete.",
+                    [{"kind": "session", "id": s["id"]} for s in lost_messages if s.get("id")],
+                    metadata,
+                )
             return (
                 "completed",
                 RunReasons.COMPLETED_OK,

--- a/lionagi/studio/services/workflow_run.py
+++ b/lionagi/studio/services/workflow_run.py
@@ -87,13 +87,14 @@ async def _teardown_run_persist(
 
     db = ctx["db"]
     try:
-        await _flush_pending_message_events(ctx)
+        message_loss = await _flush_pending_message_events(ctx)
         final_status = await _teardown_common(
             db,
             session_id=ctx["session_id"],
             session_prog_id=ctx["session_prog_id"],
             status=status,
             exception=exception,
+            message_loss=message_loss,
             artifacts_path=None,
             artifact_contract=None,
         )

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -4899,6 +4899,50 @@ async def test_a_losing_teardown_does_not_double_count_an_earlier_legs_loss(
     assert carried["lost"] == 11, carried
 
 
+async def test_a_nonterminal_child_that_lost_messages_is_not_a_clean_pass(
+    temp_db_path: Path,
+):
+    """No arm of the ladder claims an outcome when a child is still running, so the
+    fallback decides it. That fallback is the clean-pass reason code, which is the one
+    place a loss can be reported as a run that went fine."""
+    from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
+    from lionagi.state.reasons import RunReasons
+
+    invocation_id = "inv-loss-under-a-nonterminal-child"
+
+    async with StateDB() as db:
+        await db.create_invocation({"id": invocation_id, "skill": "flow", "started_at": 0.0})
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", invocation_id=invocation_id)
+    ctx = env._live_persist
+    assert ctx is not None
+    ctx["message_retry_queues"].append(await _dead_queue_events(ctx["session_id"]))
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        await db.create_progression("prog-still-running")
+        await db.create_session(
+            {
+                "id": "sess-still-running",
+                "progression_id": "prog-still-running",
+                "invocation_id": invocation_id,
+                "status": "running",
+            }
+        )
+
+    status, reason_code, _summary, evidence, metadata = await _resolve_invocation_terminal_flow(
+        invocation_id, fallback_status="completed"
+    )
+
+    assert status == "completed"
+    assert reason_code == RunReasons.COMPLETED_MESSAGE_LOSS, (
+        "the fallback must not report a clean pass over an incomplete transcript"
+    )
+    assert metadata["message_loss_session_ids"] == [ctx["session_id"]]
+    assert [e["id"] for e in evidence] == [ctx["session_id"]]
+
+
 async def test_a_losing_child_is_named_when_a_sibling_fails(
     temp_db_path: Path,
 ):

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -4729,6 +4729,47 @@ async def test_child_message_loss_surfaces_at_invocation_not_flattened_to_ok(
     assert {e["id"] for e in evidence} == {ctx["session_id"]}
 
 
+async def test_a_losing_child_is_named_when_a_sibling_fails(
+    temp_db_path: Path,
+):
+    """The precedence ladder returns on the first status that matches, and every arm
+    above the all-completed one used to return before the loss was ever looked for. A
+    failure alongside an incomplete transcript is the case that most needs both."""
+    from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
+    from lionagi.state.reasons import RunReasons
+
+    invocation_id = "inv-loss-beside-a-failure"
+
+    async with StateDB() as db:
+        await db.create_invocation({"id": invocation_id, "skill": "flow", "started_at": 0.0})
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", invocation_id=invocation_id)
+    ctx = env._live_persist
+    assert ctx is not None
+    ctx["message_retry_queues"].append(await _dead_queue_events(ctx["session_id"]))
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        await db.create_progression("prog-failed-sibling")
+        await db.create_session(
+            {
+                "id": "sess-failed-sibling",
+                "progression_id": "prog-failed-sibling",
+                "invocation_id": invocation_id,
+                "status": "failed",
+            }
+        )
+
+    status, reason_code, _summary, _evidence, metadata = await _resolve_invocation_terminal_flow(
+        invocation_id, fallback_status="completed"
+    )
+
+    assert status == "failed"
+    assert reason_code == RunReasons.FAILED_EXCEPTION, "the failure outranks the record"
+    assert metadata["message_loss_session_ids"] == [ctx["session_id"]]
+
+
 async def test_a_losing_child_is_named_even_when_another_reason_wins(
     temp_db_path: Path,
 ):

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1840,6 +1840,56 @@ async def test_stop_no_artifact_no_commits_flips_to_completed_empty(
     assert v is None
 
 
+async def test_lost_messages_stop_the_gate_calling_a_run_empty(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """The gate reads "no assistant response recorded" off the transcript, and a
+    run that lost messages has a transcript missing exactly that. Concluding
+    emptiness from it states a fact about the run that is really a fact about
+    our record, so the loss carries the reason instead."""
+    import logging
+
+    from lionagi.hooks._message_retry import MessagePersistRetryQueue, PendingMessageEvent
+
+    class _RefusingDB:
+        async def _persist_live_message(self, message, **kwargs):
+            raise RuntimeError("database is locked")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+
+    env = _minimal_env()
+    env.cwd = str(repo)
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    queue = MessagePersistRetryQueue(
+        _RefusingDB(), logger=logging.getLogger("test"), owner="branch b-1"
+    )
+    for i in range(4):
+        await queue.submit(
+            PendingMessageEvent(
+                message={"id": f"m{i}", "role": "assistant", "content": "x"},
+                session_id=ctx["session_id"],
+            )
+        )
+    ctx["message_retry_queues"].append(queue)
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed", (
+        "same repo state as the demotion test above; the only difference is "
+        "that the transcript this conclusion would rest on is known incomplete"
+    )
+    assert s["status_reason_code"] == "run.completed.message_loss"
+
+
 async def test_stop_failed_operation_evidence_wins_over_completed_empty_demotion(
     temp_db_path: Path,
     tmp_path: Path,
@@ -4613,3 +4663,99 @@ async def test_execute_dag_bounds_control_log_drain_on_hanging_update_session(
         monkeypatch.setattr(ctx["db"], "update_session", real_update_session)
         monkeypatch.setattr(ctx["db"], "merge_session_node_metadata", real_merge)
         await stop_live_persist(env, status="completed")
+
+
+def _dead_queue_events(session_id: str, count: int = 4):
+    """A retry queue driven past its limit against a database that never accepts."""
+    import logging
+
+    from lionagi.hooks._message_retry import MessagePersistRetryQueue, PendingMessageEvent
+
+    class _RefusingDB:
+        async def _persist_live_message(self, message, **kwargs):
+            raise RuntimeError("database is locked")
+
+    async def build():
+        queue = MessagePersistRetryQueue(
+            _RefusingDB(), logger=logging.getLogger("test"), owner=f"branch {session_id}"
+        )
+        for i in range(count):
+            await queue.submit(
+                PendingMessageEvent(
+                    message={"id": f"m{i}", "role": "assistant", "content": "x"},
+                    session_id=session_id,
+                )
+            )
+        return queue
+
+    return build()
+
+
+async def test_child_message_loss_surfaces_at_invocation_not_flattened_to_ok(
+    temp_db_path: Path,
+):
+    """A completed child carrying COMPLETED_MESSAGE_LOSS must not read as a clean pass
+    at the invocation. The reducer names every other completed-but-degraded reason and
+    named none for this one, so a flow whose child lost its transcript reported that all
+    child sessions completed successfully."""
+    from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
+    from lionagi.state.reasons import RunReasons
+
+    invocation_id = "inv-child-message-loss"
+
+    async with StateDB() as db:
+        await db.create_invocation({"id": invocation_id, "skill": "flow", "started_at": 0.0})
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", invocation_id=invocation_id)
+    ctx = env._live_persist
+    assert ctx is not None
+    ctx["message_retry_queues"].append(await _dead_queue_events(ctx["session_id"]))
+
+    assert await stop_live_persist(env, status="completed") == "completed"
+
+    async with StateDB() as db:
+        child = await db.get_session(ctx["session_id"])
+    assert child["status_reason_code"] == RunReasons.COMPLETED_MESSAGE_LOSS
+
+    status, reason_code, summary, evidence, metadata = await _resolve_invocation_terminal_flow(
+        invocation_id, fallback_status="completed"
+    )
+
+    assert status == "completed", "the child's work stands"
+    assert reason_code == RunReasons.COMPLETED_MESSAGE_LOSS
+    assert "incomplete" in summary
+    assert metadata["message_loss_session_ids"] == [ctx["session_id"]]
+    assert {e["id"] for e in evidence} == {ctx["session_id"]}
+
+
+async def test_a_losing_child_is_named_even_when_another_reason_wins(
+    temp_db_path: Path,
+):
+    """Only one branch can claim the reason code. The child that lost its transcript is
+    still named in the metadata, or the reason that wins buries it."""
+    from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
+    from lionagi.state.reasons import RunReasons
+
+    invocation_id = "inv-loss-and-finalize-error"
+
+    async with StateDB() as db:
+        await db.create_invocation({"id": invocation_id, "skill": "flow", "started_at": 0.0})
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", invocation_id=invocation_id)
+    ctx = env._live_persist
+    assert ctx is not None
+    ctx["message_retry_queues"].append(await _dead_queue_events(ctx["session_id"]))
+    env._finalize_error = {"error_class": "TimeoutError", "error": "team lock timed out"}
+
+    await stop_live_persist(env, status="completed")
+
+    _status, reason_code, _summary, _evidence, metadata = await _resolve_invocation_terminal_flow(
+        invocation_id, fallback_status="completed"
+    )
+
+    assert reason_code == RunReasons.COMPLETED_FINALIZE_ERROR, "the work outranks the record"
+    assert metadata["message_loss_session_ids"] == [ctx["session_id"]], (
+        "and the loss is still findable"
+    )

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -4729,6 +4729,54 @@ async def test_child_message_loss_surfaces_at_invocation_not_flattened_to_ok(
     assert {e["id"] for e in evidence} == {ctx["session_id"]}
 
 
+async def test_a_leg_that_loses_the_terminal_write_race_still_records_its_loss(
+    temp_db_path: Path,
+    monkeypatch,
+):
+    """The winner's row says the run is clean and knows nothing about this leg's loss.
+
+    Recording it only inside the guarded transition means a concurrent teardown winning
+    the compare-and-swap discards it, and the terminal row reads clean while part of the
+    transcript is gone. The status still belongs to the winner; only the loss is kept.
+    """
+    from lionagi.state.reasons import RunReasons, has_message_loss_evidence
+
+    invocation_id = "inv-cas-loser"
+
+    async with StateDB() as db:
+        await db.create_invocation({"id": invocation_id, "skill": "flow", "started_at": 0.0})
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", invocation_id=invocation_id)
+    ctx = env._live_persist
+    assert ctx is not None
+    ctx["message_retry_queues"].append(await _dead_queue_events(ctx["session_id"]))
+
+    real_update_status = ctx["db"].update_status
+
+    async def lose_the_race(entity_type, entity_id, **kwargs):
+        if entity_type == "session" and entity_id == ctx["session_id"]:
+            return False
+        return await real_update_status(entity_type, entity_id, **kwargs)
+
+    monkeypatch.setattr(ctx["db"], "update_status", lose_the_race)
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        row = await db.get_session(ctx["session_id"])
+    assert row["status_reason_code"] != RunReasons.COMPLETED_MESSAGE_LOSS, (
+        "the winner's record stands"
+    )
+    assert has_message_loss_evidence(row), "and the loss is still on the row"
+
+    from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
+
+    _status, _rc, _summary, _evidence, metadata = await _resolve_invocation_terminal_flow(
+        invocation_id, fallback_status="completed"
+    )
+    assert metadata["message_loss_session_ids"] == [ctx["session_id"]]
+
+
 async def test_a_losing_child_is_named_when_a_sibling_fails(
     temp_db_path: Path,
 ):

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -4777,6 +4777,128 @@ async def test_a_leg_that_loses_the_terminal_write_race_still_records_its_loss(
     assert metadata["message_loss_session_ids"] == [ctx["session_id"]]
 
 
+async def test_concurrent_losing_teardowns_keep_both_losses(
+    temp_db_path: Path,
+    monkeypatch,
+):
+    """Two teardowns of one session, both losing the terminal write, each holding a
+    different loss. Both read the row before either writes, so a merge that rewrites
+    one shared value replaces the other leg's loss instead of adding to it."""
+    from lionagi.cli._runs import _merge_message_loss, _teardown_common
+
+    invocation_id = "inv-two-losers"
+
+    async with StateDB() as db:
+        await db.create_invocation({"id": invocation_id, "skill": "flow", "started_at": 0.0})
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", invocation_id=invocation_id)
+    ctx = env._live_persist
+    assert ctx is not None
+    db = ctx["db"]
+    session_id = ctx["session_id"]
+
+    real_update_status = db.update_status
+
+    async def lose_the_race(entity_type, entity_id, **kwargs):
+        if entity_type == "session" and entity_id == session_id:
+            return False
+        return await real_update_status(entity_type, entity_id, **kwargs)
+
+    monkeypatch.setattr(db, "update_status", lose_the_race)
+
+    # Hold each leg at its write until the other arrives: by then both have read the
+    # row, and neither read can see the loss the other is about to record.
+    real_merge = db.merge_session_node_metadata
+    both_arrived = asyncio.Event()
+    arrivals = 0
+
+    async def gated_merge(sid, patch):
+        nonlocal arrivals
+        arrivals += 1
+        if arrivals >= 2:
+            both_arrived.set()
+        await asyncio.wait_for(both_arrived.wait(), timeout=10)
+        await real_merge(sid, patch)
+
+    monkeypatch.setattr(db, "merge_session_node_metadata", gated_merge)
+
+    async def teardown(owner: str, lost: int):
+        return await _teardown_common(
+            db,
+            session_id=session_id,
+            session_prog_id=ctx["session_prog_id"],
+            status="completed",
+            exception=None,
+            artifacts_path=ctx["artifacts_path"],
+            artifact_contract=ctx["artifact_contract"],
+            message_loss={"lost": lost, "queues": [{"owner": owner, "lost": lost}]},
+        )
+
+    await asyncio.gather(teardown("branch one", 4), teardown("branch two", 7))
+    assert arrivals == 2, "both legs must reach the write or the race is not exercised"
+
+    async with StateDB() as reader:
+        row = await reader.get_session(session_id)
+    carried = _merge_message_loss(row["node_metadata"], None)
+    assert carried is not None, "neither leg's loss survived"
+    assert sorted(q["owner"] for q in carried["queues"]) == ["branch one", "branch two"]
+    assert carried["lost"] == 11, carried
+
+
+async def test_a_losing_teardown_does_not_double_count_an_earlier_legs_loss(
+    temp_db_path: Path,
+    monkeypatch,
+):
+    """A deferred leg's loss is already on the row under its own key, and the terminal
+    write folds it into what it reports. A teardown that then loses the terminal write
+    has to record only what it saw, or the carried loss is written a second time."""
+    from lionagi.cli._runs import _merge_message_loss, _teardown_common
+
+    invocation_id = "inv-no-double-count"
+
+    async with StateDB() as db:
+        await db.create_invocation({"id": invocation_id, "skill": "flow", "started_at": 0.0})
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", invocation_id=invocation_id)
+    ctx = env._live_persist
+    assert ctx is not None
+    db = ctx["db"]
+    session_id = ctx["session_id"]
+
+    async def teardown(owner: str, lost: int, **kwargs):
+        return await _teardown_common(
+            db,
+            session_id=session_id,
+            session_prog_id=ctx["session_prog_id"],
+            status="completed",
+            exception=None,
+            artifacts_path=ctx["artifacts_path"],
+            artifact_contract=ctx["artifact_contract"],
+            message_loss={"lost": lost, "queues": [{"owner": owner, "lost": lost}]},
+            **kwargs,
+        )
+
+    await teardown("deferred", 4, defer_terminal=True)
+
+    real_update_status = db.update_status
+
+    async def lose_the_race(entity_type, entity_id, **kwargs):
+        if entity_type == "session" and entity_id == session_id:
+            return False
+        return await real_update_status(entity_type, entity_id, **kwargs)
+
+    monkeypatch.setattr(db, "update_status", lose_the_race)
+    await teardown("live", 7)
+
+    async with StateDB() as reader:
+        row = await reader.get_session(session_id)
+    carried = _merge_message_loss(row["node_metadata"], None)
+    assert sorted(q["owner"] for q in carried["queues"]) == ["deferred", "live"], carried
+    assert carried["lost"] == 11, carried
+
+
 async def test_a_losing_child_is_named_when_a_sibling_fails(
     temp_db_path: Path,
 ):

--- a/tests/hooks/test_message_retry.py
+++ b/tests/hooks/test_message_retry.py
@@ -636,6 +636,30 @@ def _carry(payload: Any, leg: str = "leg-1") -> dict[str, Any]:
     return {f"{MESSAGE_LOSS_KEY_PREFIX}{leg}": dumps(payload)}
 
 
+def test_a_row_is_only_evidence_of_loss_when_the_count_can_be_read():
+    """The reader that decides a row lost messages and the reader that sums how many
+    have to agree: a payload one rejects must not still produce a loss verdict from the
+    other, or a run carries a message-loss reason with nothing to count."""
+    from lionagi.cli._runs import _merge_message_loss
+    from lionagi.state.reasons import has_message_loss_evidence
+
+    for payload in (
+        {"lost": 5, "queues": [{"owner": "a", "lost": "many"}]},
+        {"lost": 5, "queues": [{"owner": "a", "lost": 0}]},
+        {"lost": 5, "queues": [{"owner": "a", "lost": -3}]},
+        {"lost": 5, "queues": [{"owner": "a", "lost": True}]},
+        {"lost": 5, "queues": [{"lost": 2}]},
+    ):
+        row = {"node_metadata": _carry(payload)}
+        assert _merge_message_loss(row["node_metadata"], None) is None, payload
+        assert not has_message_loss_evidence(row), payload
+
+    # Control: a well-formed payload is still evidence, and still counts.
+    row = {"node_metadata": _carry({"queues": [{"owner": "a", "lost": 2}]})}
+    assert has_message_loss_evidence(row)
+    assert _merge_message_loss(row["node_metadata"], None)["lost"] == 2
+
+
 def test_a_carried_payload_with_a_non_list_queues_field_is_dropped_not_walked():
     from lionagi.cli._runs import _merge_message_loss
 

--- a/tests/hooks/test_message_retry.py
+++ b/tests/hooks/test_message_retry.py
@@ -208,11 +208,14 @@ async def test_the_run_teardown_reports_whether_its_queues_emptied():
 
     logger = logging.getLogger("test")
     lost = await _deferred_queue(_RefusingDB(), logger)
-    assert await _flush_pending_message_events({"message_retry_queues": [lost]}) is False
+    assert await _flush_pending_message_events({"message_retry_queues": [lost]}) == {
+        "lost": 4,
+        "queues": [{"owner": "b1", "lost": 4}],
+    }
 
     healthy = MessagePersistRetryQueue(_FakeDB(fail_ids=set()), logger=logger, owner="b2")
     await healthy.submit(_event("good-1"))
-    assert await _flush_pending_message_events({"message_retry_queues": [healthy]}) is True
+    assert await _flush_pending_message_events({"message_retry_queues": [healthy]}) is None
 
 
 async def test_both_teardown_paths_over_one_queue_report_the_loss_once(caplog):
@@ -238,7 +241,7 @@ async def test_both_teardown_paths_over_one_queue_report_the_loss_once(caplog):
 
     with caplog.at_level(logging.ERROR, logger="test"):
         assert await bus.flush_message_retries() is False
-        assert await _flush_pending_message_events({"message_retry_queues": [queue]}) is False
+        assert await _flush_pending_message_events({"message_retry_queues": [queue]}) is not None
 
     losses = [rec for rec in caplog.records if rec.levelno >= logging.ERROR]
     assert len(losses) == 1, (
@@ -302,3 +305,381 @@ async def test_a_recovery_between_teardowns_does_not_swallow_a_later_loss(caplog
     assert len(losses) == 2, (
         "the second loss has the same count as the first and is still a different loss"
     )
+
+
+# The loss reaching the run's terminal record. Until this, the return value
+# above was read by nothing: both teardowns awaited it and dropped it, so a run
+# that lost messages closed as "run.completed.ok / Run completed successfully."
+
+
+async def _closed_out(tmp_path, sid: str, queues: list, **kwargs) -> dict:
+    """Take one session through the real teardown and read back what it wrote.
+
+    ``teardown_persist`` closes the handle it was given, so the read-back opens
+    its own -- the row is what a later reader sees, which is the whole subject
+    here.
+    """
+    import json
+
+    from sqlalchemy import text
+
+    from lionagi.cli._runs import teardown_persist
+    from lionagi.state.db import StateDB
+
+    path = tmp_path / f"{sid}.db"
+    db = StateDB(path)
+    await db.open()
+    await db.create_progression(f"prog-{sid}")
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": f"prog-{sid}",
+            "status": "running",
+            "started_at": 1_700_000_000.0,
+        }
+    )
+    final = await teardown_persist(
+        {
+            "db": db,
+            "session_id": sid,
+            "session_prog_id": f"prog-{sid}",
+            "message_retry_queues": queues,
+        },
+        **kwargs,
+    )
+
+    reader = StateDB(path)
+    await reader.open()
+    try:
+        row = await reader.get_session(sid)
+        async with reader._read() as conn:
+            result = await conn.execute(
+                text(
+                    "SELECT metadata FROM status_transitions "
+                    "WHERE entity_id = :sid ORDER BY created_at DESC LIMIT 1"
+                ),
+                {"sid": sid},
+            )
+            recorded = result.scalar()
+    finally:
+        await reader.close()
+    if isinstance(recorded, str):
+        recorded = json.loads(recorded)
+    return {"final": final, "row": row, "transition_metadata": recorded or {}}
+
+
+async def _healthy_queue(owner: str = "b2"):
+    queue = MessagePersistRetryQueue(
+        _FakeDB(fail_ids=set()), logger=logging.getLogger("test"), owner=owner
+    )
+    await queue.submit(_event("good-1"))
+    return queue
+
+
+async def test_a_run_that_lost_messages_does_not_close_as_a_clean_success(tmp_path):
+    """What the reported incident looked like from the row: events gone, and the
+    session saying the run completed successfully."""
+    queue = await _deferred_queue(_RefusingDB(), logging.getLogger("test"))
+
+    out = await _closed_out(tmp_path, "sess-loss", [queue], status="completed")
+
+    assert out["final"] == "completed", "the run's own work stands; this is not a failure"
+    assert out["row"]["status_reason_code"] == "run.completed.message_loss"
+    assert "4 live message event(s) were never written" in out["row"]["status_reason_summary"]
+
+
+async def test_the_terminal_row_names_which_queue_lost_how_many(tmp_path):
+    """A count with no owner cannot be chased. Two queues, only one losing."""
+    lost = await _deferred_queue(_RefusingDB(), logging.getLogger("test"))
+
+    out = await _closed_out(
+        tmp_path, "sess-loss-refs", [await _healthy_queue(), lost], status="completed"
+    )
+
+    assert out["row"]["status_evidence_refs"] == [
+        {"kind": "message_persist_loss", "id": "b1", "label": "4 event(s) lost"}
+    ], "the queue that emptied contributes nothing to name"
+
+
+async def test_a_run_that_lost_nothing_is_untouched(tmp_path):
+    """The control. A clean run must still read clean, or the annotation above
+    is noise on every row rather than a signal on the affected ones."""
+    out = await _closed_out(tmp_path, "sess-clean", [await _healthy_queue()], status="completed")
+
+    assert out["row"]["status_reason_code"] == "run.completed.ok"
+    assert out["row"]["status_evidence_refs"] in (None, [])
+    assert "message_persist_loss" not in out["transition_metadata"]
+
+
+async def test_a_failed_run_keeps_its_own_failure(tmp_path):
+    """The loss annotates; it never overwrites why a run actually failed."""
+    queue = await _deferred_queue(_RefusingDB(), logging.getLogger("test"))
+
+    out = await _closed_out(
+        tmp_path,
+        "sess-failed",
+        [queue],
+        status="failed",
+        exception=RuntimeError("the real cause"),
+    )
+
+    assert out["final"] == "failed"
+    assert out["row"]["status_reason_code"] == "run.failed.exception"
+    assert out["transition_metadata"]["message_persist_loss"]["lost"] == 4, (
+        "annotated, so the loss is still findable on a run that failed for its own reasons"
+    )
+
+
+async def test_the_structured_loss_is_recorded_for_a_reader_that_wants_the_shape(tmp_path):
+    """reason_summary is prose. The audit trail carries the numbers."""
+    queue = await _deferred_queue(_RefusingDB(), logging.getLogger("test"))
+
+    out = await _closed_out(tmp_path, "sess-loss-meta", [queue], status="completed")
+
+    assert out["transition_metadata"]["message_persist_loss"] == {
+        "lost": 4,
+        "queues": [{"owner": "b1", "lost": 4}],
+    }
+
+
+# The deferred leg. A timed-out leg defers its terminal write to the leg that resumes
+# the session, and its queue is unrouted right after. It is the only thing that ever
+# knew about its own loss, so if it does not leave it behind the resumed leg's clean
+# terminal write is the only record and the loss is gone.
+
+
+async def _teardown_on(path, sid: str, queues: list, **kwargs):
+    from lionagi.cli._runs import teardown_persist
+    from lionagi.state.db import StateDB
+
+    db = StateDB(path)
+    await db.open()
+    existing = await db.get_session(sid)
+    if existing is None:
+        await db.create_progression(f"prog-{sid}")
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": f"prog-{sid}",
+                "status": "running",
+                "started_at": 1_700_000_000.0,
+            }
+        )
+    return await teardown_persist(
+        {
+            "db": db,
+            "session_id": sid,
+            "session_prog_id": f"prog-{sid}",
+            "message_retry_queues": queues,
+        },
+        **kwargs,
+    )
+
+
+async def _session_row(path, sid: str) -> dict:
+    from lionagi.state.db import StateDB
+
+    reader = StateDB(path)
+    await reader.open()
+    try:
+        return await reader.get_session(sid)
+    finally:
+        await reader.close()
+
+
+async def test_a_deferred_legs_loss_reaches_the_terminal_write_that_resumes_it(tmp_path):
+    path = tmp_path / "deferred.db"
+    sid = "sess-deferred"
+    logger = logging.getLogger("test")
+
+    await _teardown_on(
+        path,
+        sid,
+        [await _deferred_queue(_RefusingDB(), logger)],
+        status="timed_out",
+        defer_terminal=True,
+    )
+    row = await _session_row(path, sid)
+    assert row["status"] == "running", "the deferred leg writes no terminal status"
+
+    await _teardown_on(path, sid, [], status="completed")
+
+    row = await _session_row(path, sid)
+    assert row["status_reason_code"] == "run.completed.message_loss"
+    assert "4 live message event(s) were never written" in row["status_reason_summary"]
+
+
+async def test_both_legs_losses_are_added_up_rather_than_one_replacing_the_other(tmp_path):
+    path = tmp_path / "two-legs.db"
+    sid = "sess-two-legs"
+    logger = logging.getLogger("test")
+
+    await _teardown_on(
+        path,
+        sid,
+        [await _deferred_queue(_RefusingDB(), logger)],
+        status="timed_out",
+        defer_terminal=True,
+    )
+    await _teardown_on(
+        path, sid, [await _deferred_queue(_RefusingDB(), logger)], status="completed"
+    )
+
+    row = await _session_row(path, sid)
+    assert "8 live message event(s) were never written" in row["status_reason_summary"]
+    assert len(row["status_evidence_refs"]) == 2, "one ref per queue that lost"
+
+
+async def test_a_second_deferred_leg_adds_to_the_carried_loss_rather_than_replacing_it(
+    tmp_path,
+):
+    """Two timeouts before anything terminal. The second deferral is the case a
+    deferred-then-terminal test cannot reach: it both reads and writes the carried
+    payload, so a leg that only writes its own loss drops every leg before it."""
+    path = tmp_path / "three-legs.db"
+    sid = "sess-three-legs"
+    logger = logging.getLogger("test")
+
+    for _ in range(2):
+        await _teardown_on(
+            path,
+            sid,
+            [await _deferred_queue(_RefusingDB(), logger)],
+            status="timed_out",
+            defer_terminal=True,
+        )
+    await _teardown_on(
+        path, sid, [await _deferred_queue(_RefusingDB(), logger)], status="completed"
+    )
+
+    row = await _session_row(path, sid)
+    assert "12 live message event(s) were never written" in row["status_reason_summary"]
+    assert len(row["status_evidence_refs"]) == 3, "one ref per queue that lost"
+
+
+async def test_a_deferred_leg_that_lost_nothing_leaves_nothing_behind(tmp_path):
+    """The control. Without it the resumed write could report a loss on every session
+    that was ever deferred."""
+    path = tmp_path / "deferred-clean.db"
+    sid = "sess-deferred-clean"
+
+    await _teardown_on(path, sid, [await _healthy_queue()], status="timed_out", defer_terminal=True)
+    await _teardown_on(path, sid, [], status="completed")
+
+    row = await _session_row(path, sid)
+    assert row["status_reason_code"] == "run.completed.ok"
+    assert row["status_evidence_refs"] in (None, [])
+
+
+async def test_the_loss_is_recorded_on_a_run_that_failed_for_its_own_reasons(tmp_path):
+    """The reason code belongs to the failure; the evidence still names the loss, or a
+    reader can only find it on runs where nothing else went wrong."""
+    out = await _closed_out(
+        tmp_path,
+        "sess-failed-with-loss",
+        [await _deferred_queue(_RefusingDB(), logging.getLogger("test"))],
+        status="failed",
+        exception=RuntimeError("the real cause"),
+    )
+
+    assert out["row"]["status_reason_code"] == "run.failed.exception"
+    kinds = {ref["kind"] for ref in (out["row"]["status_evidence_refs"] or [])}
+    assert "message_persist_loss" in kinds
+
+
+async def test_a_failed_loss_record_does_not_cost_the_deferred_leg_its_handoff(
+    tmp_path, monkeypatch, caplog
+):
+    """The annotation must never decide whether a timed-out run gets resumed.
+
+    The caller reads this status to choose the auto-resume path, so a bookkeeping
+    write that raises here would trade a run that resumes for one that hangs
+    unresumed. Losing the record is the lesser failure, and it is logged rather
+    than swallowed because silent loss is what the record exists to stop.
+    """
+    from lionagi.state.db import StateDB
+
+    path = tmp_path / "carry-fails.db"
+    sid = "sess-carry-fails"
+    logger = logging.getLogger("test")
+
+    async def _refuse(self, *args, **kwargs):
+        raise RuntimeError("node metadata write refused")
+
+    monkeypatch.setattr(StateDB, "merge_session_node_metadata", _refuse)
+
+    with caplog.at_level(logging.ERROR, logger="lionagi.cli"):
+        final = await _teardown_on(
+            path,
+            sid,
+            [await _deferred_queue(_RefusingDB(), logger)],
+            status="timed_out",
+            defer_terminal=True,
+        )
+
+    assert final == "timed_out", "the caller reads this to decide whether to resume"
+    row = await _session_row(path, sid)
+    assert row["status"] == "running", "the deferred leg still writes no terminal status"
+    assert any("lost message event" in r.getMessage() for r in caplog.records)
+
+
+# The carried loss payload crosses a persistence boundary, so its shape is an
+# assumption. These pin what a drifted one is allowed to do to the count.
+
+
+def _carry(payload: Any) -> dict[str, Any]:
+    """A session row whose node metadata carries `payload` as the loss JSON."""
+    from json import dumps
+
+    return {"message_persist_loss_json": dumps(payload)}
+
+
+def test_a_carried_payload_with_a_non_list_queues_field_is_dropped_not_walked():
+    from lionagi.cli._runs import _merge_message_loss
+
+    # list("ab") would otherwise yield character entries and q.get() would raise.
+    merged = _merge_message_loss(_carry({"lost": 9, "queues": "ab"}), None)
+    assert merged is None
+
+
+def test_a_queue_entry_with_a_non_numeric_lost_is_dropped_rather_than_summed():
+    from lionagi.cli._runs import _merge_message_loss
+
+    merged = _merge_message_loss(
+        _carry({"lost": 5, "queues": [{"owner": "a", "lost": "many"}, {"owner": "b", "lost": 2}]}),
+        None,
+    )
+    assert merged == {"lost": 2, "queues": [{"owner": "b", "lost": 2}]}
+
+
+def test_a_carried_total_that_disagrees_with_its_entries_is_recomputed_not_believed():
+    from lionagi.cli._runs import _merge_message_loss
+
+    merged = _merge_message_loss(_carry({"lost": 999, "queues": [{"owner": "a", "lost": 3}]}), None)
+    assert merged["lost"] == 3, "the total must agree with the entries it claims to sum"
+
+
+def test_a_boolean_lost_does_not_pass_as_a_count():
+    from lionagi.cli._runs import _merge_message_loss
+
+    assert _merge_message_loss(_carry({"queues": [{"owner": "a", "lost": True}]}), None) is None
+
+
+def test_node_metadata_that_parses_to_a_non_mapping_does_not_raise():
+    from lionagi.cli._runs import _merge_message_loss
+
+    current = {"lost": 1, "queues": [{"owner": "live", "lost": 1}]}
+    assert _merge_message_loss("[1, 2]", current) == current
+
+
+def test_a_well_formed_carry_still_sums_with_this_legs_own_loss():
+    from lionagi.cli._runs import _merge_message_loss
+
+    merged = _merge_message_loss(
+        _carry({"lost": 4, "queues": [{"owner": "deferred", "lost": 4}]}),
+        {"lost": 1, "queues": [{"owner": "live", "lost": 1}]},
+    )
+    assert merged == {
+        "lost": 5,
+        "queues": [{"owner": "deferred", "lost": 4}, {"owner": "live", "lost": 1}],
+    }

--- a/tests/hooks/test_message_retry.py
+++ b/tests/hooks/test_message_retry.py
@@ -665,6 +665,24 @@ def test_a_boolean_lost_does_not_pass_as_a_count():
     assert _merge_message_loss(_carry({"queues": [{"owner": "a", "lost": True}]}), None) is None
 
 
+def test_a_non_positive_lost_is_dropped_rather_than_subtracted_from_the_total():
+    from lionagi.cli._runs import _merge_message_loss
+
+    merged = _merge_message_loss(
+        _carry(
+            {
+                "queues": [
+                    {"owner": "a", "lost": -3},
+                    {"owner": "b", "lost": 0},
+                    {"owner": "c", "lost": 2},
+                ]
+            }
+        ),
+        None,
+    )
+    assert merged == {"lost": 2, "queues": [{"owner": "c", "lost": 2}]}
+
+
 def test_node_metadata_that_parses_to_a_non_mapping_does_not_raise():
     from lionagi.cli._runs import _merge_message_loss
 

--- a/tests/hooks/test_message_retry.py
+++ b/tests/hooks/test_message_retry.py
@@ -627,11 +627,13 @@ async def test_a_failed_loss_record_does_not_cost_the_deferred_leg_its_handoff(
 # assumption. These pin what a drifted one is allowed to do to the count.
 
 
-def _carry(payload: Any) -> dict[str, Any]:
-    """A session row whose node metadata carries `payload` as the loss JSON."""
+def _carry(payload: Any, leg: str = "leg-1") -> dict[str, Any]:
+    """Node metadata carrying `payload` under one leg's own loss key."""
     from json import dumps
 
-    return {"message_persist_loss_json": dumps(payload)}
+    from lionagi.state.reasons import MESSAGE_LOSS_KEY_PREFIX
+
+    return {f"{MESSAGE_LOSS_KEY_PREFIX}{leg}": dumps(payload)}
 
 
 def test_a_carried_payload_with_a_non_list_queues_field_is_dropped_not_walked():

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from datetime import datetime, timezone
@@ -97,6 +98,58 @@ async def test_resolve_terminal_completed_ok():
         svc, "inv-1", fallback_status="completed"
     )
     assert status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_resolve_terminal_message_loss_child_is_not_a_clean_pass():
+    """A scheduled run whose child lost part of its transcript reported that all child
+    sessions completed successfully. The flow reducer names this reason; this one, which
+    is what scheduled runs go through, mapped every all-completed set to a clean pass."""
+    from lionagi.state.reasons import RunReasons
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = [
+        {"id": "s1", "status": "completed"},
+        {
+            "id": "s2",
+            "status": "completed",
+            "status_evidence_refs": [{"kind": "message_persist_loss", "id": "branch s2"}],
+        },
+    ]
+    status, rc, rs, refs, meta = await resolve_invocation_terminal(
+        svc, "inv-1", fallback_status="completed"
+    )
+    assert status == "completed", "the work stands"
+    assert rc == RunReasons.COMPLETED_MESSAGE_LOSS
+    assert "incomplete" in rs
+    assert [r["id"] for r in refs] == ["s2"]
+    assert meta["message_loss_session_ids"] == ["s2"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_terminal_names_a_losing_child_when_a_sibling_fails():
+    """The precedence ladder returns on the first match, so the loss has to be read
+    before it, not inside the all-completed arm. Evidence refs arrive serialized from
+    some readers, which is the form this row uses."""
+    from lionagi.state.reasons import RunReasons
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = [
+        {
+            "id": "s1",
+            "status": "completed",
+            "status_evidence_refs": json.dumps([{"kind": "message_persist_loss", "id": "b"}]),
+        },
+        {"id": "s2", "status": "failed"},
+    ]
+    status, rc, _rs, _refs, meta = await resolve_invocation_terminal(
+        svc, "inv-1", fallback_status="completed"
+    )
+    assert status == "failed"
+    assert rc == RunReasons.FAILED_EXCEPTION, "the failure outranks the record"
+    assert meta["message_loss_session_ids"] == ["s1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Under database-lock contention the live-message retry queue defers, then abandons its pending events at teardown. The count reached one line in one console tail while the session closed as a clean success, so the loss was invisible to every reader of the run.

The session now carries a `run.completed.message_loss` reason, a summary naming how many events were lost, and evidence refs naming each queue that lost them, with the structured counts in the transition record. The completion-trust gate no longer demotes such a run to `completed_empty` either: that conclusion is read off the transcript, and this run's transcript is known to be missing part of itself.

## The loss survives a terminal row written by someone else

Two ways that happens, and both are covered.

**A leg that hands its terminal write to a resuming leg** leaves the loss on the session, and the write that eventually happens adds up every deferred leg's count rather than reporting only its own. The leg that observed each loss is gone by then, and its queue with it.

That accumulation holds across repeated deferrals. The deferred path is the only writer of a field it also reads, so it re-merges what is already stored before writing. A session that times out twice before anything terminal reports both losses; previously the second deferral overwrote the first and the terminal row silently reported a smaller number than the truth. Reproduced at three legs losing four events each: eight reported out of twelve.

Recording the carried loss cannot cost the handoff. The caller reads the deferring path's status to decide whether to resume, so a bookkeeping write that fails is logged and the status stands, rather than trading a run that resumes for one that hangs unresumed.

**A run that failed on its own** keeps its own failure. The loss is appended to the evidence either way and claims the reason code only when nothing else has.

## Tests

Deferred-then-terminal, deferred-twice-then-terminal, a deferred leg that lost nothing (without which a resumed write could report a loss on every deferred session), a loss on a run that failed for its own reasons, and a failed record not costing the handoff. Plus pins on what a drifted carried payload is allowed to do to the count: a non-list `queues` field is dropped rather than walked, and a queue entry with a non-numeric `lost` is dropped rather than summed.

Removing the re-merge from the deferred path reddens the multi-leg test and nothing else in the file.

## Relationship to the earlier attempt

This supersedes an earlier PR carrying the same change, re-cut with a single parent on current `main` so the repeated changelog collisions with the landing cluster dissolve. The tree is that branch's head plus the multi-leg accumulation fix and its regression test.



## Verification bound

The concurrent-teardown test runs against SQLite, so what it exercises is the `json_patch` merge. The Postgres `jsonb ||` path for the same merge is covered by the dialect-parity tests in `tests/state/test_dual_backend.py`, which start a container and skip when Docker is unavailable. They skipped here, on `could not start Postgres container`, so that path is not one I have observed pass on this machine.


## Design notes on the per-leg loss records

Each teardown that observed loss writes its own key rather than rewriting a shared one, which is what removes the lost update. Three consequences worth naming, since each is a deliberate trade rather than an oversight.

Cumulative teardown work is now linear rather than quadratic: a leg writes only what it saw, with no read of the accumulated list, and the whole set is read once at the terminal write.

The keys are not compacted after that terminal write folds them in. Clearing them would race the next teardown's write, which is the lost update this change exists to remove. The growth is bounded by the number of teardowns that actually lost messages rather than by teardowns: both write sites are guarded on a non-empty loss, so a session that never loses a message never writes a key.

The assistant-output lookup still runs when a loss is present, even though the loss already decides the branch below it. Its result is persisted as `has_assistant_output`, so gating it would leave that field absent on exactly the runs whose transcript is known to be incomplete, which are the runs where a reader most needs it.
