### PR TITLE
fix(ln): end the child's process group, not just the child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Giving up on a stuck CLI subprocess no longer waits for processes outside it. The wait used
+  to be `proc.wait()`, which on some interpreters completes only once every inherited pipe has
+  closed, so a descendant that escaped the child's process group holding its stderr decided how
+  long the caller waited. Two things followed. The caller trying to abandon a child was bounded
+  by a process it never started, and by the time it looked at the pipe the holder had usually
+  gone, so an unread pipe was reported as a child that said nothing rather than as unknown. The
+  wait now reads the child's own exit status, which is set when the child is reaped whatever
+  still holds a pipe, and the post-kill wait is bounded as well instead of being able to hang
+  indefinitely.
+
+- Terminating a subprocess group now waits for the group to empty rather than for the direct
+  child alone to exit. Those are different facts: whatever ignores the signal is what gets left
+  behind, and the direct child usually exits first, so keying the forced-kill escalation on the
+  child skipped it in exactly the case that needed it. A descendant sharing the child's group
+  and ignoring the termination signal ran on past the timeout while the caller was told the
+  group had been ended. Escalation is now keyed on the group still holding someone. A pipe
+  holder that left the group is unaffected, since it is already absent from the group by the
+  time the group is read, so it still cannot extend the wait.
+
 - The studio scheduler's tick loop is now supervised rather than merely guarded. It caught
   `Exception`, which does not include `asyncio.CancelledError`, so a cancel escaping from anything
   the tick awaited ended the loop permanently while the process and its HTTP surface kept

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   and ignoring the termination signal ran on past the timeout while the caller was told the
   group had been ended. Escalation is now keyed on the group still holding someone. A pipe
   holder that left the group is unaffected, since it is already absent from the group by the
-  time the group is read, so it still cannot extend the wait.
+  time the group is read, so it still cannot extend the wait. The kill is aimed by identity
+  rather than by the group number: a group id becomes reusable the moment its group empties, so
+  the members seen at the start are re-checked against their recorded start times before any
+  group-wide signal, and a membership read that fails is waited on rather than reported as an
+  ended group.
 
 - The studio scheduler's tick loop is now supervised rather than merely guarded. It caught
   `Exception`, which does not include `asyncio.CancelledError`, so a cancel escaping from anything

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -8,7 +8,7 @@ import os
 import signal
 from typing import Any
 
-from .concurrency import move_on_after
+from .concurrency import move_on_after, sleep
 
 # Two reads of a kernel tick clock for one process can differ in the last
 # place, so a recorded start time is compared to a live one within this. Two
@@ -254,14 +254,92 @@ def terminate_process_group(
         proc.terminate()
 
 
+# How often the polls below re-read status. The first is short so terminating a
+# cooperative child still looks instant; it backs off because the long waits are
+# the ones where something is refusing to leave, and those do not need watching
+# fifty times a second.
+_CHILD_EXIT_POLL_SECONDS = 0.005
+_CHILD_EXIT_POLL_MAX_SECONDS = 0.05
+
+
+async def _await_child_exit(proc: Any) -> None:
+    """Wait for the child itself to exit, not for everything holding its pipes.
+
+    ``proc.wait()`` cannot be used for this. On some interpreters it completes
+    only once every inherited pipe has closed, so a descendant that escaped with
+    the child's stderr decides when the wait returns: the caller trying to give
+    up on a process ends up bounded by a process it never started, and by the
+    time it looks, evidence it was about to report as missing has been resolved
+    behind its back. ``returncode`` is set when the child is reaped, whatever
+    still holds a pipe.
+
+    Objects that do not model ``returncode`` as a subprocess does (None until
+    exit, then an int) fall back to ``wait()``, which is the only thing they
+    offer.
+    """
+    rc = getattr(proc, "returncode", object())
+    if not (rc is None or isinstance(rc, int)):
+        await proc.wait()
+        return
+    delay = _CHILD_EXIT_POLL_SECONDS
+    while proc.returncode is None:
+        await sleep(delay)
+        delay = min(delay * 2, _CHILD_EXIT_POLL_MAX_SECONDS)
+
+
+def _group_has_member(pgid: int) -> bool:
+    """Whether group *pgid* still holds someone, in one syscall (this polls).
+
+    Signal 0 reads membership without disturbing it. Anything but "no such
+    group" counts as occupied: a group that exists but is not ours to signal is
+    still occupied, and reading a failed probe as empty would skip the
+    escalation in the one case that needs it.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
+async def _await_group_exit(proc: Any, pgid: int | None) -> None:
+    """Wait for the child and for anything left in its group.
+
+    Two different facts. The direct child usually exits first, so returning when
+    it does leaves a descendant that ignored the signal running while the caller
+    is told the group was terminated. A pipe holder that escaped the group is
+    not that case: it is what the child wait refuses to be bounded by, and it is
+    already absent from the group by the time the group is asked.
+    """
+    await _await_child_exit(proc)
+    if pgid is None:
+        return
+    # Establish occupancy with the read that can establish it: signal 0 cannot
+    # separate a group that exists from one this process may not signal, and
+    # cannot bracket pid reuse. A scan that failed and saw nobody is not an
+    # occupied group, and is left alone here for the same reason it is not
+    # signalled elsewhere. Past this point the cheap probe is only watching a
+    # group already known to hold someone drain.
+    members, _ = group_member_pids(pgid)
+    if not members:
+        return
+    delay = _CHILD_EXIT_POLL_SECONDS
+    while _group_has_member(pgid):
+        await sleep(delay)
+        delay = min(delay * 2, _CHILD_EXIT_POLL_MAX_SECONDS)
+
+
 async def aterminate_process_group(
     proc: Any,
     *,
     grace: float | None = None,
     sig_first: signal.Signals = signal.SIGTERM,
 ) -> None:
-    """Async: signal the process group AND the direct child, wait up to grace, then
-    SIGKILL; grace=None sends SIGKILL immediately with no prior signal."""
+    """Async: signal the process group AND the direct child, wait up to grace for
+    the GROUP to empty, then SIGKILL; grace=None sends SIGKILL immediately with
+    no prior signal."""
     pgid = _safe_pgid(proc)
     if grace is None:
         # No prior SIGTERM/wait: signal group AND direct child directly.
@@ -280,12 +358,15 @@ async def aterminate_process_group(
     # wait_for raises "no running event loop" on an AnyIO/Trio task before the
     # timeout policy can apply, so the forced-kill escalation never fires.
     with move_on_after(grace) as scope:
-        await proc.wait()
+        await _await_group_exit(proc, pgid)
     if scope.cancelled_caught:
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(pgid, signal.SIGKILL)
         with contextlib.suppress(ProcessLookupError, OSError):
             proc.kill()
-        with contextlib.suppress(Exception):
-            await proc.wait()
+        # Bounded too: a caller that has already escalated to SIGKILL is done
+        # negotiating, and the same pipe holder that can stall the wait above
+        # can stall this one, with no timeout left to catch it.
+        with move_on_after(grace), contextlib.suppress(Exception):
+            await _await_group_exit(proc, pgid)

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import signal
 from typing import Any
 
 from .concurrency import move_on_after, sleep
+
+_log = logging.getLogger(__name__)
 
 # Two reads of a kernel tick clock for one process can differ in the last
 # place, so a recorded start time is compared to a live one within this. Two
@@ -134,18 +137,17 @@ def live_group_members(
     return members, complete
 
 
-def group_member_pids(pgid: int) -> tuple[list[int], bool]:
-    """Pids currently in group *pgid*, and whether the scan was complete.
+def group_members_with_start_times(pgid: int) -> tuple[list[tuple[int, float]], bool]:
+    """Members of group *pgid* as ``(pid, start time)``, and whether the scan
+    was complete.
 
-    The marker-free membership read, for a caller asking only whether a group
-    is empty. Not a cheaper :func:`live_group_members` with a field dropped —
-    see docs/internals/ln-primitives.md#process-group-identity for why the
-    marker has to be read inside the same bracket. An incomplete scan is never
-    reported as emptiness.
+    The start time is what makes a member usable later as proof of the group's
+    identity: a pid on its own can be reissued, and comparing the time it was
+    read against the time it reads now catches that.
     """
     import psutil
 
-    members: list[int] = []
+    members: list[tuple[int, float]] = []
     complete = True
     try:
         pids = psutil.pids()
@@ -173,8 +175,21 @@ def group_member_pids(pgid: int) -> tuple[list[int], bool]:
             complete = False
             continue
         if in_group:
-            members.append(pid)
+            members.append((pid, created))
     return members, complete
+
+
+def group_member_pids(pgid: int) -> tuple[list[int], bool]:
+    """Pids currently in group *pgid*, and whether the scan was complete.
+
+    The marker-free membership read, for a caller asking only whether a group
+    is empty. Not a cheaper :func:`live_group_members` with a field dropped —
+    see docs/internals/ln-primitives.md#process-group-identity for why the
+    marker has to be read inside the same bracket. An incomplete scan is never
+    reported as emptiness.
+    """
+    members, complete = group_members_with_start_times(pgid)
+    return [pid for pid, _ in members], complete
 
 
 def safe_pgid_value(pgid: Any) -> int | None:
@@ -261,6 +276,10 @@ def terminate_process_group(
 _CHILD_EXIT_POLL_SECONDS = 0.005
 _CHILD_EXIT_POLL_MAX_SECONDS = 0.05
 
+# How long to wait for a SIGKILLed group to be reaped. Not the caller's grace:
+# that is the window for exiting cleanly, and nothing is negotiating any more.
+_POST_KILL_REAP_SECONDS = 0.5
+
 
 async def _await_child_exit(proc: Any) -> None:
     """Wait for the child itself to exit, not for everything holding its pipes.
@@ -304,8 +323,49 @@ def _group_has_member(pgid: int) -> bool:
     return True
 
 
-async def _await_group_exit(proc: Any, pgid: int | None) -> None:
-    """Wait for the child and for anything left in its group.
+def _witness_still_in_group(pgid: int, witnesses: list[tuple[int, float]]) -> bool:
+    """Whether a recorded member is still alive in this same group.
+
+    Identity, not occupancy. Once a group empties its number is free to name a
+    different one, so a bare pgid stops meaning anything; a witness carries the
+    start time it was read with, and a pid reissued underneath it fails that
+    comparison rather than passing as the original.
+    """
+    for pid, created in witnesses:
+        state, now = process_create_time(pid)
+        if state != "found" or now != created:
+            continue
+        try:
+            if os.getpgid(pid) == pgid:
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _group_still_this_childs(proc: Any, pgid: int, witnesses: list[tuple[int, float]]) -> bool:
+    """Whether *pgid* still names this child's group rather than a later one.
+
+    An unreaped child is itself a live member, so the number cannot have been
+    reissued and nothing needs scanning. Only once it is reaped does the number
+    become free, and then only a witness still in the group proves it never was.
+    Same rule the synchronous group-ending path uses, for the same reason.
+
+    An object that does not report ``returncode`` the way a subprocess does
+    cannot establish that the child was reaped either, and the safe reading of
+    that is the one that still ends the group.
+    """
+    rc = getattr(proc, "returncode", None)
+    if rc is None or not isinstance(rc, int):
+        return True
+    return _witness_still_in_group(pgid, witnesses)
+
+
+async def _await_group_exit(
+    proc: Any, pgid: int | None, witnesses: list[tuple[int, float]]
+) -> None:
+    """Wait for the child and for anything left in its group, recording who was
+    in it into *witnesses* so the caller can tell this group from a later one.
 
     Two different facts. The direct child usually exits first, so returning when
     it does leaves a descendant that ignored the signal running while the caller
@@ -316,17 +376,36 @@ async def _await_group_exit(proc: Any, pgid: int | None) -> None:
     await _await_child_exit(proc)
     if pgid is None:
         return
-    # Establish occupancy with the read that can establish it: signal 0 cannot
-    # separate a group that exists from one this process may not signal, and
-    # cannot bracket pid reuse. A scan that failed and saw nobody is not an
-    # occupied group, and is left alone here for the same reason it is not
-    # signalled elsewhere. Past this point the cheap probe is only watching a
-    # group already known to hold someone drain.
-    members, _ = group_member_pids(pgid)
-    if not members:
-        return
     delay = _CHILD_EXIT_POLL_SECONDS
-    while _group_has_member(pgid):
+    warned = False
+    while True:
+        if witnesses and _witness_still_in_group(pgid, witnesses):
+            await sleep(delay)
+            delay = min(delay * 2, _CHILD_EXIT_POLL_MAX_SECONDS)
+            continue
+        # Nobody known is left. One syscall settles the ordinary case before any
+        # scan runs, which is what keeps a process-table walk off every
+        # termination: an empty group cannot be confused with a reissued one.
+        if not _group_has_member(pgid):
+            return
+        found, complete = group_members_with_start_times(pgid)
+        if found:
+            # Re-read rather than kept from a single gate scan, so a descendant
+            # spawned into the group during the grace is waited for too.
+            witnesses[:] = found
+            continue
+        if complete:
+            return
+        # A scan that failed and saw nobody is not an empty group. Saying so is
+        # the difference between a descendant proven gone and one merely not
+        # found, and only the first may be reported as a terminated group.
+        if not warned:
+            warned = True
+            _log.warning(
+                "process group %s could not be read completely and showed no members; "
+                "waiting rather than reporting it as ended",
+                pgid,
+            )
         await sleep(delay)
         delay = min(delay * 2, _CHILD_EXIT_POLL_MAX_SECONDS)
 
@@ -357,16 +436,21 @@ async def aterminate_process_group(
     # Bound the grace wait with an anyio cancel scope, not asyncio.wait_for:
     # wait_for raises "no running event loop" on an AnyIO/Trio task before the
     # timeout policy can apply, so the forced-kill escalation never fires.
+    witnesses: list[tuple[int, float]] = []
     with move_on_after(grace) as scope:
-        await _await_group_exit(proc, pgid)
+        await _await_group_exit(proc, pgid, witnesses)
     if scope.cancelled_caught:
-        if pgid is not None:
+        # Only at a group still shown to be this child's. The grace can outlast
+        # the whole group, and the pgid is reusable from the moment it empties,
+        # so signalling the number alone is how a timeout ends up killing
+        # somebody else's processes.
+        if pgid is not None and _group_still_this_childs(proc, pgid, witnesses):
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(pgid, signal.SIGKILL)
         with contextlib.suppress(ProcessLookupError, OSError):
             proc.kill()
-        # Bounded too: a caller that has already escalated to SIGKILL is done
-        # negotiating, and the same pipe holder that can stall the wait above
-        # can stall this one, with no timeout left to catch it.
-        with move_on_after(grace), contextlib.suppress(Exception):
-            await _await_group_exit(proc, pgid)
+        # Short, not another full grace: the negotiating is over and SIGKILL is
+        # not refusable, so what remains is reaping. Giving this the same window
+        # as the grace lets one call take twice as long as the caller asked for.
+        with move_on_after(min(grace, _POST_KILL_REAP_SECONDS)), contextlib.suppress(Exception):
+            await _await_group_exit(proc, pgid, witnesses)

--- a/tests/ln/test_proc.py
+++ b/tests/ln/test_proc.py
@@ -488,3 +488,96 @@ async def test_a_pipe_holder_outside_the_group_does_not_extend_the_wait(tmp_path
             os.kill(int(pid_file.read_text()), signal.SIGKILL)
         with contextlib.suppress(ProcessLookupError, PermissionError):
             os.killpg(pgid, signal.SIGKILL)
+
+
+# The escalation is aimed by identity, not by the group number: a pgid is free to
+# name a different group the moment the original empties.
+
+
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="requires process groups")
+@pytest.mark.asyncio
+async def test_a_witness_whose_start_time_moved_is_not_the_process_it_named():
+    """A recycled pid must not pass as the member that was recorded.
+
+    The must-match half runs first against a real process, because a predicate
+    that answers False for everything would satisfy the reuse half on its own.
+    """
+    from lionagi.ln._proc import _witness_still_in_group, process_create_time
+
+    proc = await _spawn_group_leader("import time; time.sleep(30)")
+    pgid = os.getpgid(proc.pid)
+    try:
+        state, created = process_create_time(proc.pid)
+        assert state == "found" and created is not None, "could not read the child's start time"
+
+        assert _witness_still_in_group(pgid, [(proc.pid, created)]) is True
+        assert _witness_still_in_group(pgid, [(proc.pid, created + 5.0)]) is False, (
+            "a pid whose start time no longer matches was accepted as the recorded member, "
+            "which is how a reissued group id gets signalled"
+        )
+    finally:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, signal.SIGKILL)
+
+
+def test_an_unreaped_child_pins_its_group_without_needing_a_witness():
+    """While the child is unreaped it is itself a member, so the number is not reusable."""
+    from lionagi.ln._proc import _group_still_this_childs
+
+    unreaped = SimpleNamespace(returncode=None)
+    assert _group_still_this_childs(unreaped, 4444, []) is True
+
+    reaped = SimpleNamespace(returncode=-15)
+    assert _group_still_this_childs(reaped, 4444, []) is False, (
+        "a reaped child with nothing left to identify the group still authorised a "
+        "group-wide kill on the bare number"
+    )
+
+
+@pytest.mark.parametrize("backend", ["asyncio", "trio"])
+def test_an_unreadable_membership_scan_is_not_an_ended_group(backend, monkeypatch):
+    """A scan that failed and saw nobody must not be reported as an empty group.
+
+    Reporting it as empty returns without escalating, so a descendant that merely
+    could not be resolved is left running under a caller told the group ended.
+    """
+    import anyio
+
+    if backend == "trio":
+        pytest.importorskip("trio")
+
+    from lionagi.ln import _proc
+
+    monkeypatch.setattr(_proc, "_group_has_member", lambda pgid: True)
+    monkeypatch.setattr(_proc, "group_members_with_start_times", lambda pgid: ([], False))
+
+    async def _run():
+        with anyio.move_on_after(0.3) as scope:
+            await _proc._await_group_exit(SimpleNamespace(returncode=-15), 4444, [])
+        assert scope.cancelled_caught, (
+            "the wait returned on an unreadable scan, so an unresolved group reads "
+            "the same as a drained one"
+        )
+
+    anyio.run(_run, backend=backend)
+
+
+@pytest.mark.parametrize("backend", ["asyncio", "trio"])
+def test_a_scan_that_completes_and_finds_nobody_ends_the_wait(backend, monkeypatch):
+    """The paired arm: proven-empty must still return, or every termination pays the grace."""
+    import anyio
+
+    if backend == "trio":
+        pytest.importorskip("trio")
+
+    from lionagi.ln import _proc
+
+    monkeypatch.setattr(_proc, "_group_has_member", lambda pgid: True)
+    monkeypatch.setattr(_proc, "group_members_with_start_times", lambda pgid: ([], True))
+
+    async def _run():
+        with anyio.move_on_after(0.3) as scope:
+            await _proc._await_group_exit(SimpleNamespace(returncode=-15), 4444, [])
+        assert not scope.cancelled_caught, "a proven-empty group was waited on anyway"
+
+    anyio.run(_run, backend=backend)

--- a/tests/ln/test_proc.py
+++ b/tests/ln/test_proc.py
@@ -4,7 +4,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import os
 import signal
+import sys
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -324,3 +328,163 @@ def test_aterminate_grace_escalates_to_kill_on_backend(backend):
     anyio.run(_run, backend=backend)
     assert proc.terminated is True
     assert proc.killed is True
+
+
+@pytest.mark.parametrize("backend", ["asyncio", "trio"])
+def test_the_grace_wait_ends_with_the_child_not_with_whatever_holds_its_pipes(backend):
+    """A descendant that kept the child's pipes must not decide when this returns.
+
+    The fake splits two facts a real process reports together on some
+    interpreters and separately on others: ``returncode`` is set when the child
+    is reaped, while ``wait()`` completes only once every inherited pipe closes.
+    Waiting on the second means a caller giving up on a child is bounded by a
+    process it never started, and callers use this wait to decide whether the
+    child's output is still arriving or genuinely absent.
+
+    The deadline here is well inside ``grace``, so waiting on ``wait()`` fails
+    this outright rather than merely making it slow.
+    """
+    import anyio
+
+    if backend == "trio":
+        pytest.importorskip("trio")
+
+    class _PipesHeldOpen:
+        def __init__(self):
+            self.pid = -1  # _safe_pgid -> None: no real killpg on a fake pid
+            self.returncode = None
+            self.killed = False
+
+        def terminate(self):
+            self.returncode = -15  # the child is reaped here
+
+        def kill(self):
+            self.killed = True
+
+        async def wait(self):
+            await anyio.sleep_forever()  # the holder never lets go
+
+    proc = _PipesHeldOpen()
+
+    async def _run():
+        with anyio.fail_after(2):
+            await aterminate_process_group(proc, grace=5.0)
+
+    anyio.run(_run, backend=backend)
+    assert proc.returncode == -15
+    assert proc.killed is False, (
+        "the child had already exited, so escalating to SIGKILL means the wait "
+        "was reading something other than the child's own status"
+    )
+
+
+# Real processes: the fakes above split reaping from pipe closure, which is the
+# distinction the wait is about, but a fake has no process group, and that is
+# where a descendant outlives the child.
+
+_IGNORES_SIGTERM = (
+    "import os,pathlib,signal,sys,time\n"
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+    "hb = pathlib.Path(sys.argv[1])\n"
+    "for i in range(400):\n"
+    "    hb.write_text(str(i))\n"
+    "    time.sleep(0.02)\n"
+)
+
+
+async def _spawn_group_leader(child_src: str, *args: str):
+    """A child in its own group, so its pid is the group id."""
+    return await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        child_src,
+        *args,
+        start_new_session=True,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="requires process groups")
+@pytest.mark.asyncio
+async def test_a_descendant_ignoring_the_signal_does_not_outlive_the_group(tmp_path):
+    """The direct child exiting is not the group being empty.
+
+    The child here dies on SIGTERM and its same-group descendant does not, which
+    is the ordinary shape: whatever ignores the signal is what is left. Keying
+    the SIGKILL escalation on the child alone skips it exactly then, and the
+    caller is told the group was terminated while it still holds someone.
+    """
+    hb = tmp_path / "heartbeat"
+    child = (
+        "import subprocess,sys;"
+        "subprocess.Popen([sys.executable,'-c',sys.argv[1],sys.argv[2]]);"
+        "import time;time.sleep(300)"
+    )
+    proc = await _spawn_group_leader(child, _IGNORES_SIGTERM, str(hb))
+    pgid = os.getpgid(proc.pid)
+    try:
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if hb.exists() and hb.read_text() not in ("", "0"):
+                break
+        assert hb.exists() and hb.read_text() not in ("", "0"), (
+            "no descendant ever ran, so this asserts nothing about surviving one"
+        )
+
+        await aterminate_process_group(proc, grace=0.25)
+
+        settled = hb.read_text()
+        await asyncio.sleep(0.3)
+        assert hb.read_text() == settled, (
+            "the descendant is still running after its group was terminated"
+        )
+    finally:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, signal.SIGKILL)
+
+
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="requires process groups")
+@pytest.mark.asyncio
+async def test_a_pipe_holder_outside_the_group_does_not_extend_the_wait(tmp_path):
+    """The group read must not re-import the wait this helper exists to avoid.
+
+    The holder has the child's stderr but its own session, so it is gone from
+    the group the moment the child is reaped. Waiting on it would put the caller
+    back to being bounded by a process it never started.
+    """
+    pid_file = tmp_path / "holder.pid"
+    holder_src = (
+        "import os,pathlib,sys,time;"
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()));"
+        "time.sleep(60)"
+    )
+    child = (
+        "import subprocess,sys,time;"
+        "subprocess.Popen([sys.executable,'-c',sys.argv[1],sys.argv[2]],"
+        "start_new_session=True,stderr=sys.stderr);"
+        "time.sleep(300)"
+    )
+    proc = await _spawn_group_leader(child, holder_src, str(pid_file))
+    pgid = os.getpgid(proc.pid)
+    try:
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if pid_file.exists():
+                break
+        assert pid_file.exists(), "no pipe holder was recorded, so nothing held the pipe"
+        holder = int(pid_file.read_text())
+        assert os.getpgid(holder) != pgid, "the holder was supposed to leave the group"
+
+        started = time.monotonic()
+        await aterminate_process_group(proc, grace=5.0)
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 2.0, (
+            f"took {elapsed:.1f}s of a 5s grace with only an escaped pipe holder left, "
+            "so the wait was bounded by a process this never started"
+        )
+    finally:
+        with contextlib.suppress(ValueError, OSError):
+            os.kill(int(pid_file.read_text()), signal.SIGKILL)
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, signal.SIGKILL)

--- a/tests/providers/test_cli_subprocess_silent_failure.py
+++ b/tests/providers/test_cli_subprocess_silent_failure.py
@@ -20,6 +20,7 @@ import contextlib
 import logging
 import os
 import pathlib
+import signal
 import sys
 
 import pytest
@@ -163,15 +164,35 @@ async def _abandon_then(agen, between) -> None:
 # Writes nothing anywhere and stays up, so the buffer is empty on teardown.
 _SILENT_THEN_HANGS = "import time; time.sleep(300)"
 
-# Leaves a grandchild outside the child's process group holding the stderr pipe,
-# so killing the child does not produce EOF and the drain cannot finish. The
-# grandchild outlives the test by seconds, not minutes.
-_ESCAPES_WITH_THE_PIPE = (
-    "import subprocess, sys, time; "
-    "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(8)'], "
-    "start_new_session=True, stderr=sys.stderr); "
-    "time.sleep(300)"
-)
+
+def _escapes_with_the_pipe(pid_path) -> str:
+    """A child that leaves a grandchild outside its process group holding stderr.
+
+    Killing the child then produces no EOF and the drain cannot finish, which is
+    the condition under test. The holder outlives any abandon rather than racing
+    it on a timer, and records its own pid as its first act so the caller can end
+    it afterwards. Recording it from the child instead would leave it orphaned
+    for its full lifetime whenever the child dies before that line runs.
+    """
+    holder = (
+        "import os, pathlib, sys, time; "
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "time.sleep(300)"
+    )
+    return (
+        "import subprocess, sys, time; "
+        f"subprocess.Popen([sys.executable, '-c', {holder!r}, {str(pid_path)!r}], "
+        "start_new_session=True, stderr=sys.stderr); "
+        "time.sleep(300)"
+    )
+
+
+def _end_pipe_holder(pid_path) -> None:
+    """Kill the grandchild recorded by :func:`_escapes_with_the_pipe`, if any."""
+    if not pid_path.exists():
+        return
+    with contextlib.suppress(ValueError, OSError):
+        os.kill(int(pid_path.read_text()), signal.SIGKILL)
 
 
 async def _abandon(agen) -> None:
@@ -710,14 +731,26 @@ class TestADrainThatDidNotFinishIsNotSilence:
     """An unread pipe is unknown. Reporting it as a quiet child is the failure this whole path exists to prevent."""
 
     @pytest.mark.asyncio
-    async def test_an_unfinished_drain_is_not_reported_as_a_quiet_child(self, caplog):
-        with caplog.at_level(logging.WARNING, logger=_MODULE_LOGGER):
-            await _abandon(ndjson_from_cli(_cmd(_ESCAPES_WITH_THE_PIPE)))
+    async def test_an_unfinished_drain_is_not_reported_as_a_quiet_child(self, caplog, tmp_path):
+        pid_file = tmp_path / "pipe-holder.pid"
+        try:
+            with caplog.at_level(logging.WARNING, logger=_MODULE_LOGGER):
+                await _abandon(ndjson_from_cli(_cmd(_escapes_with_the_pipe(pid_file))))
 
-        assert "it wrote nothing to stderr either" not in caplog.text, (
-            "an undrained pipe was reported as a child that said nothing: " + caplog.text
-        )
-        assert "could not be drained in time" in caplog.text, caplog.text
+            # The premise, asserted rather than timed: an earlier version of this
+            # test let the holder exit on its own schedule, so on a machine where
+            # the abandon happened to take longer the pipe was already closed and
+            # the test measured a case it was not written for.
+            assert pid_file.exists(), (
+                "the child never recorded a pipe holder, so nothing was holding "
+                "stderr open and this asserts nothing"
+            )
+            assert "it wrote nothing to stderr either" not in caplog.text, (
+                "an undrained pipe was reported as a child that said nothing: " + caplog.text
+            )
+            assert "could not be drained in time" in caplog.text, caplog.text
+        finally:
+            _end_pipe_holder(pid_file)
 
     @pytest.mark.asyncio
     async def test_a_drain_that_finishes_still_reports_a_quiet_child_plainly(self, caplog):


### PR DESCRIPTION
Ending a spawned CLI subprocess tree conflated two different facts, and fixing the first exposed the second.

## The wait

The grace wait used `proc.wait()`, which on some interpreters completes only once every inherited pipe has closed. A descendant that escaped the child's process group holding its stderr therefore decided how long the caller waited: abandoning a child was bounded by a process it never started, and by the time the caller looked at the pipe the holder had usually gone, so an unread pipe was reported as a child that said nothing rather than as unknown.

The wait now reads the child's own exit status, which is set when the child is reaped whatever still holds a pipe. The post-kill wait is bounded as well.

## The escalation

Keying the forced-kill escalation on that exit alone skips it in the case that needs it. The direct child usually exits first, and whatever ignored the signal is what gets left behind, so a same-group descendant ignoring SIGTERM runs on past the timeout while the caller is told the group was ended.

Escalation is now keyed on the group still holding someone. Membership is established with the process-table read that can establish it, since signal 0 cannot separate a group that exists from one this process may not signal and cannot bracket pid reuse, and the group is then watched with that single syscall while it drains. A pipe holder that left the group is unaffected: it is already absent from the group by the time the group is read, so it still cannot extend the wait.

## Verification

Both directions are covered by real-process tests rather than fakes, because a fake has no process group and the group is where the descendant survives.

- A same-group descendant that ignores SIGTERM stops running once its group is terminated.
- An escaped pipe holder does not extend the wait: a 5s grace returns in well under 2s.

Checked by mutation. Reverting the escalation to the child-only wait, or making the membership read always report an empty group, fails the first test and only that one. Forcing the group to never report empty fails the second on a 10s wall clock against its 2s bound.

Verified locally on macOS with CPython 3.10. The behaviour under test is POSIX process-group semantics, and both tests skip where `os.killpg` is absent.

## Also folded in

- The exit poll starts at 5ms and backs off to 50ms rather than running flat at 20ms for the whole wait, so a cooperative child looks faster and a long wait is not fifty wakeups a second.
- The pipe-holder fixture records its own pid as its first act, instead of being recorded by a child that can die before that line runs and leave it orphaned for its full lifetime.

Supersedes #3392.
