### PR TITLE
test(providers): make the pipe holder outlive the abandon it is testing

### DIFF
--- a/tests/providers/test_cli_subprocess_silent_failure.py
+++ b/tests/providers/test_cli_subprocess_silent_failure.py
@@ -20,6 +20,7 @@ import contextlib
 import logging
 import os
 import pathlib
+import signal
 import sys
 
 import pytest
@@ -163,15 +164,30 @@ async def _abandon_then(agen, between) -> None:
 # Writes nothing anywhere and stays up, so the buffer is empty on teardown.
 _SILENT_THEN_HANGS = "import time; time.sleep(300)"
 
-# Leaves a grandchild outside the child's process group holding the stderr pipe,
-# so killing the child does not produce EOF and the drain cannot finish. The
-# grandchild outlives the test by seconds, not minutes.
-_ESCAPES_WITH_THE_PIPE = (
-    "import subprocess, sys, time; "
-    "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(8)'], "
-    "start_new_session=True, stderr=sys.stderr); "
-    "time.sleep(300)"
-)
+
+def _escapes_with_the_pipe(pid_path) -> str:
+    """A child that leaves a grandchild outside its process group holding stderr.
+
+    Killing the child then produces no EOF and the drain cannot finish, which is
+    the condition under test. The holder outlives any abandon rather than racing
+    it on a timer, and it writes its pid out so the caller can end it afterwards
+    instead of leaving an orphan behind on whatever machine ran the suite.
+    """
+    return (
+        "import pathlib, subprocess, sys, time; "
+        "p = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(300)'], "
+        "start_new_session=True, stderr=sys.stderr); "
+        f"pathlib.Path({str(pid_path)!r}).write_text(str(p.pid)); "
+        "time.sleep(300)"
+    )
+
+
+def _end_pipe_holder(pid_path) -> None:
+    """Kill the grandchild recorded by :func:`_escapes_with_the_pipe`, if any."""
+    if not pid_path.exists():
+        return
+    with contextlib.suppress(ValueError, OSError):
+        os.kill(int(pid_path.read_text()), signal.SIGKILL)
 
 
 async def _abandon(agen) -> None:
@@ -710,14 +726,26 @@ class TestADrainThatDidNotFinishIsNotSilence:
     """An unread pipe is unknown. Reporting it as a quiet child is the failure this whole path exists to prevent."""
 
     @pytest.mark.asyncio
-    async def test_an_unfinished_drain_is_not_reported_as_a_quiet_child(self, caplog):
-        with caplog.at_level(logging.WARNING, logger=_MODULE_LOGGER):
-            await _abandon(ndjson_from_cli(_cmd(_ESCAPES_WITH_THE_PIPE)))
+    async def test_an_unfinished_drain_is_not_reported_as_a_quiet_child(self, caplog, tmp_path):
+        pid_file = tmp_path / "pipe-holder.pid"
+        try:
+            with caplog.at_level(logging.WARNING, logger=_MODULE_LOGGER):
+                await _abandon(ndjson_from_cli(_cmd(_escapes_with_the_pipe(pid_file))))
 
-        assert "it wrote nothing to stderr either" not in caplog.text, (
-            "an undrained pipe was reported as a child that said nothing: " + caplog.text
-        )
-        assert "could not be drained in time" in caplog.text, caplog.text
+            # The premise, asserted rather than timed: an earlier version of this
+            # test let the holder exit on its own schedule, so on a machine where
+            # the abandon happened to take longer the pipe was already closed and
+            # the test measured a case it was not written for.
+            assert pid_file.exists(), (
+                "the child never recorded a pipe holder, so nothing was holding "
+                "stderr open and this asserts nothing"
+            )
+            assert "it wrote nothing to stderr either" not in caplog.text, (
+                "an undrained pipe was reported as a child that said nothing: " + caplog.text
+            )
+            assert "could not be drained in time" in caplog.text, caplog.text
+        finally:
+            _end_pipe_holder(pid_file)
 
     @pytest.mark.asyncio
     async def test_a_drain_that_finishes_still_reports_a_quiet_child_plainly(self, caplog):


### PR DESCRIPTION
## What

`test_an_unfinished_drain_is_not_reported_as_a_quiet_child` is the only failing
test on main, and it fails on both 3.11 and 3.12. Ten consecutive Continuous
Integration runs on main have failed on it; the last success was
2026-08-19T04:14Z.

## Why it fails

The test needs the child's stderr pipe held open by a process outside the child,
so that killing the child produces no EOF and the drain cannot finish. It
arranged that with a grandchild that slept for a fixed eight seconds, while the
abandon path under test runs on its own clock. The two clocks were independent:
where the abandon takes longer than the holder's eight seconds, the grandchild
exits first, the pipe closes, the drain completes normally, and the assertion
then fires against a case the test was never written for. The reported failure
is the honest message for the situation the test accidentally created.

## The change

Test-side only, one file.

- The holder stays up until the test ends it, so the pipe is held open for the
  whole abandon rather than for eight seconds.
- The child writes the holder's pid out and the test asserts that the pid file
  exists. If no holder was ever recorded, the test now says so rather than
  passing while asserting nothing.
- The test kills the holder in a `finally`, so no process is left running on the
  machine that ran the suite.

## Verification

- Target test on 3.12: passes, three consecutive runs.
- Control: the pre-change file, same interpreter, same worktree, reproduces the
  exact failure standing on main (`an undrained pipe was reported as a child
  that said nothing`). The green above is therefore discriminating rather than
  incidental.
- Whole file: 69 tests pass on 3.11 and on 3.12.
- Process check before and after the runs: no leftover holder process.

## Not in this PR

This test points at a product-side question — the abandon path's completion time
and its drain-status truthfulness are currently influenced by processes outside
the abandoned child. That is a behaviour change and follows as its own PR. This
one restores the test's premise so main is green in the meantime.
