### PR TITLE
ci: test every supported version on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,10 +185,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # PRs: oldest + newest only. Full matrix on main/develop pushes. This
-        # saves runner minutes rather than wall-clock time, because the legs run
-        # in parallel and the ones dropped were not the slowest.
-        python-version: ${{ fromJSON((github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.python-matrix == 'endpoints')) && '["3.10","3.14"]' || '["3.10","3.11","3.12","3.13","3.14"]') }}
+        # The full supported set on every event, pull_request included. This
+        # used to be oldest + newest on PRs, which made the gate's population a
+        # strict subset of the supported population: a failure exclusive to
+        # 3.11, 3.12 or 3.13 could not be seen before merge and reached main by
+        # construction, which is what happened. It is the same silent-population
+        # defect the paths-ignore, types and branches notes above each describe,
+        # and it survived those three passes because it was shaped like a cost
+        # decision rather than a filter. The cost it saved was runner minutes,
+        # which are free for a public repository on standard runners; the legs
+        # run in parallel, so wall-clock is the slowest leg either way. The
+        # `endpoints` choice stays, as an explicit manual diagnostic.
+        python-version: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.python-matrix == 'endpoints') && '["3.10","3.14"]' || '["3.10","3.11","3.12","3.13","3.14"]') }}
     # Force every `uv` call (venv, sync, run) onto the matrix interpreter; the
     # repo's .python-version (3.10) otherwise pins all legs to 3.10.
     env:


### PR DESCRIPTION
## What

The test matrix was oldest + newest (`3.10`, `3.14`) on `pull_request`, and the
full supported set (`3.10` through `3.14`) on pushes to `main`. This makes it
the full set on every event.

## Why

A gate whose population is a strict subset of the supported population cannot
see a failure that lives outside the subset. A failure exclusive to 3.11, 3.12
or 3.13 was invisible before merge and reached `main` by construction.

That is not hypothetical. A change whose test fixture races on the slower
interpreters passed a PR run consisting of exactly `test (3.10)` and
`test (3.14)`, merged, and left `main` failing for ten consecutive runs of this
workflow. Nothing in the PR's output indicated that three of the five supported
versions had not been tried.

This is the same defect the `paths-ignore`, `types` and branches-filter notes in
this file each describe: a filtered-out population reads as green, and the
failure is silent. It survived those three passes because it was shaped like a
cost decision rather than like a filter.

## The cost argument, since it is the reason this was set up that way

The previous comment was accurate that the reduction saves runner minutes rather
than wall-clock time, because the legs run in parallel and the dropped ones were
not the slowest. Runner minutes on GitHub-hosted standard runners are free for a
public repository, so the saving is not one anybody is paying, and the axis that
does matter to a person waiting on a PR barely moves.

If queue contention ever becomes measurable, that is a reason to revisit with
the measurement in hand.

## Scope

One expression. The `pull_request` term is removed from the condition that
selects the reduced set; everything else is unchanged. The `workflow_dispatch`
`endpoints` choice still selects oldest + newest, which is its purpose as a
manual diagnostic.

## Self-demonstrating

`pull_request` runs the workflow from the PR head, so this PR's own checks show
the result: five `test (…)` jobs rather than two.
