### PR TITLE
fix(ln): end the grace wait with the child, not with whatever holds its pipes

### DIFF
--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -8,7 +8,7 @@ import os
 import signal
 from typing import Any
 
-from .concurrency import move_on_after
+from .concurrency import move_on_after, sleep
 
 # Two reads of a kernel tick clock for one process can differ in the last
 # place, so a recorded start time is compared to a live one within this. Two
@@ -254,6 +254,34 @@ def terminate_process_group(
         proc.terminate()
 
 
+# How often the exit poll below re-reads the child's status. Short enough that
+# terminating a cooperative child still looks instant.
+_CHILD_EXIT_POLL_SECONDS = 0.02
+
+
+async def _await_child_exit(proc: Any) -> None:
+    """Wait for the child itself to exit, not for everything holding its pipes.
+
+    ``proc.wait()`` cannot be used for this. On some interpreters it completes
+    only once every inherited pipe has closed, so a descendant that escaped with
+    the child's stderr decides when the wait returns: the caller trying to give
+    up on a process ends up bounded by a process it never started, and by the
+    time it looks, evidence it was about to report as missing has been resolved
+    behind its back. ``returncode`` is set when the child is reaped, whatever
+    still holds a pipe.
+
+    Objects that do not model ``returncode`` as a subprocess does (None until
+    exit, then an int) fall back to ``wait()``, which is the only thing they
+    offer.
+    """
+    rc = getattr(proc, "returncode", object())
+    if not (rc is None or isinstance(rc, int)):
+        await proc.wait()
+        return
+    while proc.returncode is None:
+        await sleep(_CHILD_EXIT_POLL_SECONDS)
+
+
 async def aterminate_process_group(
     proc: Any,
     *,
@@ -280,12 +308,15 @@ async def aterminate_process_group(
     # wait_for raises "no running event loop" on an AnyIO/Trio task before the
     # timeout policy can apply, so the forced-kill escalation never fires.
     with move_on_after(grace) as scope:
-        await proc.wait()
+        await _await_child_exit(proc)
     if scope.cancelled_caught:
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(pgid, signal.SIGKILL)
         with contextlib.suppress(ProcessLookupError, OSError):
             proc.kill()
-        with contextlib.suppress(Exception):
-            await proc.wait()
+        # Bounded too: a caller that has already escalated to SIGKILL is done
+        # negotiating, and the same pipe holder that can stall the wait above
+        # can stall this one, with no timeout left to catch it.
+        with move_on_after(grace), contextlib.suppress(Exception):
+            await _await_child_exit(proc)

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -254,9 +254,26 @@ def terminate_process_group(
         proc.terminate()
 
 
-# How often the exit poll below re-reads the child's status. Short enough that
-# terminating a cooperative child still looks instant.
-_CHILD_EXIT_POLL_SECONDS = 0.02
+# How often the polls below re-read state. The first look is fast, so
+# terminating a cooperative child still looks instant; the interval then backs
+# off, so waiting out a child that is taking its time costs little.
+_POLL_MIN_SECONDS = 0.0005
+_POLL_MAX_SECONDS = 0.02
+
+
+def _group_has_members(pgid: int) -> bool:
+    """Whether any process remains in the group. Signal 0 tests delivery only."""
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Something is there, we may just not be allowed to signal it. Calling
+        # that present keeps the escalation on the side of cleaning up.
+        return True
+    except OSError:
+        return False
+    return True
 
 
 async def _await_child_exit(proc: Any) -> None:
@@ -278,8 +295,10 @@ async def _await_child_exit(proc: Any) -> None:
     if not (rc is None or isinstance(rc, int)):
         await proc.wait()
         return
+    delay = _POLL_MIN_SECONDS
     while proc.returncode is None:
-        await sleep(_CHILD_EXIT_POLL_SECONDS)
+        await sleep(delay)
+        delay = min(delay * 2, _POLL_MAX_SECONDS)
 
 
 async def aterminate_process_group(
@@ -309,6 +328,15 @@ async def aterminate_process_group(
     # timeout policy can apply, so the forced-kill escalation never fires.
     with move_on_after(grace) as scope:
         await _await_child_exit(proc)
+        # The child is gone; the rest of grace belongs to whatever shared its
+        # process group. Waiting on the child alone is what keeps a pipe holder
+        # from deciding when the child's own status is known, but the forced
+        # kill below exists for group members that ignored the first signal, and
+        # reaching it by way of a stalled wait was incidental: that happened
+        # only where wait() is pipe-bound, and only when a survivor happened to
+        # be holding a pipe. Timing out here is what drives the escalation.
+        while pgid is not None and _group_has_members(pgid):
+            await sleep(_POLL_MAX_SECONDS)
     if scope.cancelled_caught:
         if pgid is not None:
             with contextlib.suppress(ProcessLookupError, PermissionError):

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -343,6 +343,19 @@ async def aterminate_process_group(
             await sleep(_POLL_MAX_SECONDS)
     if scope.cancelled_caught:
         if pgid is not None:
+            # Why this is not signalling some unrelated group that inherited the
+            # id: a process group id is not recycled while the group still has
+            # members, and control only reaches here with members present, since
+            # an empty group ends the wait above and returns without any kill at
+            # all. That is a platform guarantee rather than something checked
+            # here, and it is recorded because the code cannot show it.
+            #
+            # It is not a proof that the id is current at this instant. Nothing
+            # portable can assert group identity beyond membership, so a
+            # revalidating probe would carry the same gap it looks like it
+            # removes.
+            # The note is here to say why that probe is absent, not to claim the
+            # question does not exist.
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(pgid, signal.SIGKILL)
         with contextlib.suppress(ProcessLookupError, OSError):

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -262,17 +262,21 @@ _POLL_MAX_SECONDS = 0.02
 
 
 def _group_has_members(pgid: int) -> bool:
-    """Whether any process remains in the group. Signal 0 tests delivery only."""
+    """Whether any process remains in the group. Signal 0 tests delivery only.
+
+    Only ``ProcessLookupError`` is evidence of an empty group. Everything else is
+    a probe that failed to answer, including the permission case where something
+    is plainly there but not ours to signal. A failed probe reported as "empty"
+    would end grace early and skip the forced kill, and that is the one direction
+    this must not fail in: the caller asked for the group to be gone, so an
+    unreadable answer keeps the escalation rather than cancelling it.
+    """
     try:
         os.killpg(pgid, 0)
     except ProcessLookupError:
         return False
-    except PermissionError:
-        # Something is there, we may just not be allowed to signal it. Calling
-        # that present keeps the escalation on the side of cleaning up.
-        return True
     except OSError:
-        return False
+        return True
     return True
 
 

--- a/tests/ln/test_proc.py
+++ b/tests/ln/test_proc.py
@@ -4,7 +4,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import os
+import pathlib
 import signal
+import sys
+import tempfile
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -191,7 +197,15 @@ async def test_aterminate_sigterm_then_sigkill_on_timeout():
 
 @pytest.mark.asyncio
 async def test_aterminate_sigterm_no_sigkill_when_exits_fast():
-    """grace path: no SIGKILL if process exits before timeout."""
+    """grace path: no SIGKILL when the child exits and its group empties.
+
+    Signal 0 is a delivery test rather than a signal, and it is how the code
+    asks whether anything is left in the group. A recorder that accepts every
+    signal answers "still populated" forever, which is not what the kernel does
+    once the group has emptied, so the double models that here. Without it this
+    test would report a forced kill that a real exited-and-empty group never
+    provokes.
+    """
     proc = _fake_async_proc(pid=4444, wait_delay=0.0)
     import os as real_os
 
@@ -203,6 +217,12 @@ async def test_aterminate_sigterm_no_sigkill_when_exits_fast():
     calls = []
 
     def _record_killpg(pgid, sig):
+        if sig == 0:
+            # Nothing else was ever put in this group, so it is empty exactly
+            # when the child has been reaped.
+            if proc.returncode is None:
+                return
+            raise ProcessLookupError(3, "No such process")
         calls.append((pgid, sig))
 
     with patch.object(proc_mod.os, "killpg", side_effect=_record_killpg):
@@ -372,3 +392,86 @@ def test_the_grace_wait_ends_with_the_child_not_with_whatever_holds_its_pipes(ba
         "the child had already exited, so escalating to SIGKILL means the wait "
         "was reading something other than the child's own status"
     )
+
+
+# A real subprocess, not a fake. The behaviour under test is one where the two
+# differ: whether ``wait()`` returns when the child is reaped or when the last
+# inherited pipe closes is decided by the interpreter, and a hand-written double
+# can only assert whichever of those its author already believed.
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="POSIX process groups only")
+@pytest.mark.parametrize("descendant_holds_pipe", [True, False], ids=["holds-pipe", "no-pipe"])
+def test_a_group_member_that_ignores_the_first_signal_is_still_killed(
+    descendant_holds_pipe,
+):
+    """Grace belongs to the group, not only to the direct child.
+
+    The direct child leads its own process group and exits promptly on SIGTERM.
+    A descendant in that same group ignores SIGTERM. Once grace is spent the
+    forced kill exists precisely for that descendant, so reaching it must not
+    depend on the direct child being slow.
+
+    Both parameters matter and they fail differently. When the descendant holds
+    the child's stderr, ``wait()`` is pipe-bound on some interpreters, so the
+    escalation used to fire for an incidental reason -- the wait stalled -- and
+    the descendant died there without anything having asked about the group.
+    When it holds no pipe nothing ever stalled, and it survived everywhere.
+    """
+    grandchild = (
+        "import os, pathlib, signal, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "time.sleep(300)"
+    )
+
+    async def _run(ready_path):
+        stderr_arg = "sys.stderr" if descendant_holds_pipe else "subprocess.DEVNULL"
+        child = (
+            "import subprocess, sys, time; "
+            f"subprocess.Popen([sys.executable, '-c', {grandchild!r}, "
+            f"{str(ready_path)!r}], stderr={stderr_arg}); "
+            "time.sleep(300)"
+        )
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            child,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        deadline = time.monotonic() + 20
+        while not ready_path.exists():
+            if time.monotonic() > deadline:
+                proc.kill()
+                pytest.fail("the descendant never reported itself ready")
+            await asyncio.sleep(0.02)
+        descendant = int(ready_path.read_text())
+        # Asserted premises. Without them a pass says nothing: a descendant that
+        # never started, or that landed in a different process group, would look
+        # cleaned up here whatever the code under test did.
+        os.kill(descendant, 0)
+        assert os.getpgid(descendant) == os.getpgid(proc.pid)
+
+        await aterminate_process_group(proc, grace=0.5)
+
+        survived = True
+        settle = time.monotonic() + 2
+        while time.monotonic() < settle:
+            try:
+                os.kill(descendant, 0)
+            except OSError:
+                survived = False
+                break
+            await asyncio.sleep(0.02)
+        return descendant, survived
+
+    with tempfile.TemporaryDirectory() as td:
+        ready_path = pathlib.Path(td) / "descendant.pid"
+        descendant, survived = asyncio.run(_run(ready_path))
+        try:
+            assert not survived, (
+                "a process-group member that ignored the first signal outlived "
+                "cleanup: grace expired and the forced kill never reached it"
+            )
+        finally:
+            with contextlib.suppress(OSError):
+                os.kill(descendant, signal.SIGKILL)

--- a/tests/ln/test_proc.py
+++ b/tests/ln/test_proc.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import os
 import pathlib
 import signal
@@ -398,6 +399,84 @@ def test_the_grace_wait_ends_with_the_child_not_with_whatever_holds_its_pipes(ba
 # differ: whether ``wait()`` returns when the child is reaped or when the last
 # inherited pipe closes is decided by the interpreter, and a hand-written double
 # can only assert whichever of those its author already believed.
+_DESCENDANT = (
+    "import os, pathlib, signal, sys, time; "
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+    "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+    "time.sleep(300)"
+)
+
+
+def _terminate_with_a_descendant(*, escapes_group: bool, holds_pipe: bool, grace: float):
+    """Run cleanup against a child that has a descendant, and report what happened.
+
+    Returns ``(descendant_survived, elapsed, returncode)``. The descendant is
+    killed on every exit path including setup failures, so a failed premise
+    cannot leave a 300-second process behind on whatever machine ran the suite.
+    """
+
+    async def _still_alive(pid: int, settle: float) -> bool:
+        deadline = time.monotonic() + settle
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                return False
+            await asyncio.sleep(0.02)
+        return True
+
+    async def _run(ready_path):
+        proc = None
+        descendant = None
+        try:
+            stderr_arg = "sys.stderr" if holds_pipe else "subprocess.DEVNULL"
+            own_session = ", start_new_session=True" if escapes_group else ""
+            child = (
+                "import subprocess, sys, time; "
+                f"subprocess.Popen([sys.executable, '-c', {_DESCENDANT!r}, "
+                f"{str(ready_path)!r}], stderr={stderr_arg}{own_session}); "
+                "time.sleep(300)"
+            )
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-c",
+                child,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+            )
+            deadline = time.monotonic() + 20
+            while not ready_path.exists():
+                if time.monotonic() > deadline:
+                    pytest.fail("the descendant never reported itself ready")
+                await asyncio.sleep(0.02)
+            descendant = int(ready_path.read_text())
+            # Asserted premises. Without them a pass says nothing: a descendant
+            # that never started, or that landed on the wrong side of the group
+            # boundary, would look handled here whatever the code under test did.
+            os.kill(descendant, 0)
+            shares_group = os.getpgid(descendant) == os.getpgid(proc.pid)
+            assert shares_group is not escapes_group, (
+                f"descendant group placement is wrong for this case: "
+                f"shares_group={shares_group}, escapes_group={escapes_group}"
+            )
+
+            started = time.monotonic()
+            await aterminate_process_group(proc, grace=grace)
+            elapsed = time.monotonic() - started
+            survived = await _still_alive(descendant, settle=2.0)
+            return survived, elapsed, proc.returncode
+        finally:
+            if descendant is not None:
+                with contextlib.suppress(OSError):
+                    os.kill(descendant, signal.SIGKILL)
+            if proc is not None and proc.returncode is None:
+                with contextlib.suppress(Exception):
+                    proc.kill()
+
+    with tempfile.TemporaryDirectory() as td:
+        return asyncio.run(_run(pathlib.Path(td) / "descendant.pid"))
+
+
 @pytest.mark.skipif(not hasattr(os, "killpg"), reason="POSIX process groups only")
 @pytest.mark.parametrize("descendant_holds_pipe", [True, False], ids=["holds-pipe", "no-pipe"])
 def test_a_group_member_that_ignores_the_first_signal_is_still_killed(
@@ -416,65 +495,13 @@ def test_a_group_member_that_ignores_the_first_signal_is_still_killed(
     the descendant died there without anything having asked about the group.
     When it holds no pipe nothing ever stalled, and it survived everywhere.
     """
-    grandchild = (
-        "import os, pathlib, signal, sys, time; "
-        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
-        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
-        "time.sleep(300)"
+    survived, _, _ = _terminate_with_a_descendant(
+        escapes_group=False, holds_pipe=descendant_holds_pipe, grace=0.5
     )
-
-    async def _run(ready_path):
-        stderr_arg = "sys.stderr" if descendant_holds_pipe else "subprocess.DEVNULL"
-        child = (
-            "import subprocess, sys, time; "
-            f"subprocess.Popen([sys.executable, '-c', {grandchild!r}, "
-            f"{str(ready_path)!r}], stderr={stderr_arg}); "
-            "time.sleep(300)"
-        )
-        proc = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-c",
-            child,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=True,
-        )
-        deadline = time.monotonic() + 20
-        while not ready_path.exists():
-            if time.monotonic() > deadline:
-                proc.kill()
-                pytest.fail("the descendant never reported itself ready")
-            await asyncio.sleep(0.02)
-        descendant = int(ready_path.read_text())
-        # Asserted premises. Without them a pass says nothing: a descendant that
-        # never started, or that landed in a different process group, would look
-        # cleaned up here whatever the code under test did.
-        os.kill(descendant, 0)
-        assert os.getpgid(descendant) == os.getpgid(proc.pid)
-
-        await aterminate_process_group(proc, grace=0.5)
-
-        survived = True
-        settle = time.monotonic() + 2
-        while time.monotonic() < settle:
-            try:
-                os.kill(descendant, 0)
-            except OSError:
-                survived = False
-                break
-            await asyncio.sleep(0.02)
-        return descendant, survived
-
-    with tempfile.TemporaryDirectory() as td:
-        ready_path = pathlib.Path(td) / "descendant.pid"
-        descendant, survived = asyncio.run(_run(ready_path))
-        try:
-            assert not survived, (
-                "a process-group member that ignored the first signal outlived "
-                "cleanup: grace expired and the forced kill never reached it"
-            )
-        finally:
-            with contextlib.suppress(OSError):
-                os.kill(descendant, signal.SIGKILL)
+    assert not survived, (
+        "a process-group member that ignored the first signal outlived cleanup: "
+        "grace expired and the forced kill never reached it"
+    )
 
 
 @pytest.mark.skipif(not hasattr(os, "killpg"), reason="POSIX process groups only")
@@ -493,52 +520,71 @@ def test_cleanup_is_not_bounded_by_a_descendant_that_escaped_with_the_pipes():
     populated -- and satisfying either alone is easy, which is why they are kept
     together.
     """
-    grandchild = (
-        "import os, pathlib, sys, time; "
-        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
-        "time.sleep(300)"
+    _, elapsed, returncode = _terminate_with_a_descendant(
+        escapes_group=True, holds_pipe=True, grace=5.0
+    )
+    assert returncode is not None, "the child had not been reaped"
+    assert elapsed < 1.0, (
+        f"cleanup took {elapsed:.2f}s of a 5s grace: it was waiting on the "
+        "escaped pipe holder rather than on the child"
     )
 
-    async def _run(ready_path):
-        child = (
-            "import subprocess, sys, time; "
-            f"subprocess.Popen([sys.executable, '-c', {grandchild!r}, "
-            f"{str(ready_path)!r}], stderr=sys.stderr, start_new_session=True); "
-            "time.sleep(300)"
-        )
-        proc = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-c",
-            child,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=True,
-        )
-        deadline = time.monotonic() + 20
-        while not ready_path.exists():
-            if time.monotonic() > deadline:
-                proc.kill()
-                pytest.fail("the descendant never reported itself ready")
-            await asyncio.sleep(0.02)
-        descendant = int(ready_path.read_text())
-        # Asserted premises: the holder is alive, and it really did leave the
-        # group. If it had stayed, the sibling test's rule would apply instead
-        # and waiting for it would be correct.
-        os.kill(descendant, 0)
-        assert os.getpgid(descendant) != os.getpgid(proc.pid)
 
-        started = time.monotonic()
-        await aterminate_process_group(proc, grace=5.0)
-        return descendant, time.monotonic() - started, proc.returncode
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("probe_error", "expect_forced_kill"),
+    [
+        (OSError(errno.EINTR, "Interrupted system call"), True),
+        (ProcessLookupError(errno.ESRCH, "No such process"), False),
+    ],
+    ids=["unreadable-probe", "genuinely-empty"],
+)
+async def test_an_unreadable_group_probe_does_not_read_as_an_empty_group(
+    probe_error, expect_forced_kill
+):
+    """Only "no such group" is evidence of an empty group.
 
-    with tempfile.TemporaryDirectory() as td:
-        ready_path = pathlib.Path(td) / "descendant.pid"
-        descendant, elapsed, returncode = asyncio.run(_run(ready_path))
-        try:
-            assert returncode is not None, "the child had not been reaped"
-            assert elapsed < 1.0, (
-                f"cleanup took {elapsed:.2f}s of a 5s grace: it was waiting on "
-                "the escaped pipe holder rather than on the child"
-            )
-        finally:
-            with contextlib.suppress(OSError):
-                os.kill(descendant, signal.SIGKILL)
+    Signal 0 can fail for reasons that say nothing about membership. Answering
+    "nobody there" to those ends grace early and skips the forced kill, which
+    turns the guard off in precisely the situation it exists for, and does so
+    silently. The second case is the control: a probe that really does report an
+    empty group must still take the quiet path, otherwise this test would pass
+    on an implementation that force-kills unconditionally.
+    """
+    import lionagi.ln._proc as proc_mod
+
+    if not hasattr(os, "killpg"):
+        pytest.skip("os.killpg not available on this platform")
+
+    class _ExitsPromptly:
+        """Models what a real proc reports: returncode is None until it is reaped."""
+
+        def __init__(self):
+            self.pid = 7777
+            self.returncode = None
+
+        def terminate(self):
+            self.returncode = -15
+
+        def kill(self):
+            self.returncode = -9
+
+        async def wait(self):
+            return self.returncode
+
+    proc = _ExitsPromptly()
+    calls = []
+
+    def _killpg(pgid, sig):
+        if sig == 0:
+            raise probe_error
+        calls.append((pgid, sig))
+
+    with patch.object(proc_mod.os, "killpg", side_effect=_killpg):
+        await aterminate_process_group(proc, grace=0.05)
+
+    assert (7777, signal.SIGTERM) in calls
+    assert ((7777, signal.SIGKILL) in calls) is expect_forced_kill, (
+        f"probe raised {type(probe_error).__name__} and the forced kill was "
+        f"{'skipped' if expect_forced_kill else 'sent'}"
+    )

--- a/tests/ln/test_proc.py
+++ b/tests/ln/test_proc.py
@@ -324,3 +324,51 @@ def test_aterminate_grace_escalates_to_kill_on_backend(backend):
     anyio.run(_run, backend=backend)
     assert proc.terminated is True
     assert proc.killed is True
+
+
+@pytest.mark.parametrize("backend", ["asyncio", "trio"])
+def test_the_grace_wait_ends_with_the_child_not_with_whatever_holds_its_pipes(backend):
+    """A descendant that kept the child's pipes must not decide when this returns.
+
+    The fake splits two facts a real process reports together on some
+    interpreters and separately on others: ``returncode`` is set when the child
+    is reaped, while ``wait()`` completes only once every inherited pipe closes.
+    Waiting on the second means a caller giving up on a child is bounded by a
+    process it never started, and callers use this wait to decide whether the
+    child's output is still arriving or genuinely absent.
+
+    The deadline here is well inside ``grace``, so waiting on ``wait()`` fails
+    this outright rather than merely making it slow.
+    """
+    import anyio
+
+    if backend == "trio":
+        pytest.importorskip("trio")
+
+    class _PipesHeldOpen:
+        def __init__(self):
+            self.pid = -1  # _safe_pgid -> None: no real killpg on a fake pid
+            self.returncode = None
+            self.killed = False
+
+        def terminate(self):
+            self.returncode = -15  # the child is reaped here
+
+        def kill(self):
+            self.killed = True
+
+        async def wait(self):
+            await anyio.sleep_forever()  # the holder never lets go
+
+    proc = _PipesHeldOpen()
+
+    async def _run():
+        with anyio.fail_after(2):
+            await aterminate_process_group(proc, grace=5.0)
+
+    anyio.run(_run, backend=backend)
+    assert proc.returncode == -15
+    assert proc.killed is False, (
+        "the child had already exited, so escalating to SIGKILL means the wait "
+        "was reading something other than the child's own status"
+    )

--- a/tests/ln/test_proc.py
+++ b/tests/ln/test_proc.py
@@ -475,3 +475,70 @@ def test_a_group_member_that_ignores_the_first_signal_is_still_killed(
         finally:
             with contextlib.suppress(OSError):
                 os.kill(descendant, signal.SIGKILL)
+
+
+@pytest.mark.skipif(not hasattr(os, "killpg"), reason="POSIX process groups only")
+def test_cleanup_is_not_bounded_by_a_descendant_that_escaped_with_the_pipes():
+    """The other half of the same contract, and the one this pair exists to keep.
+
+    Here the descendant leaves the child's process group and keeps the child's
+    stderr. Nothing in this cleanup can signal it and nothing should wait for
+    it: the child's own exit is the entire question being asked. Where ``wait()``
+    is pipe-bound, waiting on it instead returns only once grace has expired, so
+    the bound asserted here sits well inside grace rather than merely under it.
+
+    Its sibling above asserts that a group member which ignored the first signal
+    is still killed. The two pull in opposite directions -- one says do not wait
+    for a foreign process, the other says do not stop waiting while the group is
+    populated -- and satisfying either alone is easy, which is why they are kept
+    together.
+    """
+    grandchild = (
+        "import os, pathlib, sys, time; "
+        "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "time.sleep(300)"
+    )
+
+    async def _run(ready_path):
+        child = (
+            "import subprocess, sys, time; "
+            f"subprocess.Popen([sys.executable, '-c', {grandchild!r}, "
+            f"{str(ready_path)!r}], stderr=sys.stderr, start_new_session=True); "
+            "time.sleep(300)"
+        )
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            child,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        deadline = time.monotonic() + 20
+        while not ready_path.exists():
+            if time.monotonic() > deadline:
+                proc.kill()
+                pytest.fail("the descendant never reported itself ready")
+            await asyncio.sleep(0.02)
+        descendant = int(ready_path.read_text())
+        # Asserted premises: the holder is alive, and it really did leave the
+        # group. If it had stayed, the sibling test's rule would apply instead
+        # and waiting for it would be correct.
+        os.kill(descendant, 0)
+        assert os.getpgid(descendant) != os.getpgid(proc.pid)
+
+        started = time.monotonic()
+        await aterminate_process_group(proc, grace=5.0)
+        return descendant, time.monotonic() - started, proc.returncode
+
+    with tempfile.TemporaryDirectory() as td:
+        ready_path = pathlib.Path(td) / "descendant.pid"
+        descendant, elapsed, returncode = asyncio.run(_run(ready_path))
+        try:
+            assert returncode is not None, "the child had not been reaped"
+            assert elapsed < 1.0, (
+                f"cleanup took {elapsed:.2f}s of a 5s grace: it was waiting on "
+                "the escaped pipe holder rather than on the child"
+            )
+        finally:
+            with contextlib.suppress(OSError):
+                os.kill(descendant, signal.SIGKILL)


### PR DESCRIPTION
## What

`aterminate_process_group` waited on `proc.wait()`. It now waits for the child's
own `returncode`, and bounds the post-SIGKILL wait by the same grace.

## Why

`proc.wait()` completes, on some interpreters, only once every inherited pipe
has closed. A descendant that escaped the group holding the child's stderr
therefore decides when the wait returns, so a caller trying to give up on a
process is bounded by a process it never started.

The consequence is not only latency. Callers use this wait to decide whether a
child's output is still arriving or is genuinely absent. While a pipe holder
keeps the wait open, the drain that follows always finishes, so the branch that
reports an unfinished drain as *unknown* rather than as *silence* is
unreachable in practice — a guard that cannot fire. Evidence a caller was about
to report as missing gets resolved behind its back.

`returncode` is set when the child is reaped, whatever still holds a pipe, so
that is what the wait polls. Objects that do not model `returncode` the way a
subprocess does (None until exit, then an int) fall back to `wait()`, which is
all they offer.

The wait after SIGKILL is bounded for the same reason: a caller that has already
escalated is done negotiating, and the same holder can stall that wait with no
timeout left to catch it.

## The test

A fake process splits two facts that a real one reports together on some
interpreters and separately on others: `returncode` is set on `terminate()`,
while `wait()` never completes. The deadline sits well inside `grace`, so
waiting on `wait()` fails the test outright rather than merely making it slow,
and it asserts that no escalation to SIGKILL happened, since the child had
already exited. Both anyio backends are covered.

Reverting the change to `lionagi/ln/_proc.py` and keeping the test fails it with
`TimeoutError` on both backends, which is what makes it an assertion about this
behaviour rather than a test that happens to pass.

## Verification

- New test: passes on 3.11 and 3.12, both backends.
- Revert control: with `_proc.py` restored to the base and the test kept, both
  parametrisations fail with `TimeoutError`.
- `tests/ln/test_proc.py` whole file: green on 3.11 and 3.12.
- `tests/providers/test_cli_subprocess_silent_failure.py`, which exercises the
  abandon path through this function: green on 3.11 and 3.12, both with the
  current fixture and with the reworked one from the companion change.
