### PR TITLE
fix(studio): serve a poller's own health gauges instead of projecting them away

### DIFF
--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -639,6 +639,11 @@ def _run_record(row: dict[str, Any]) -> dict[str, Any]:
 # reader in the app, and the API answers without a token when LIONAGI_STUDIO_AUTH_TOKEN
 # is unset, so records are projected onto this list rather than passed through -- which
 # also means a column added to the table later stays private until someone names it here.
+# That default is why the two github_poll self-health gauges are named below: they are
+# the poller's own liveness evidence, not its bookkeeping, and a caller that cannot read
+# them has no way to tell a poller still reading a quiet repo from one that stopped.
+# github_cursor stays unserved -- it is where the poll got to, which answers a different
+# question and is the bookkeeping this projection deliberately withholds.
 _SCHEDULE_SUMMARY_FIELDS = (
     "id",
     "name",
@@ -650,6 +655,8 @@ _SCHEDULE_SUMMARY_FIELDS = (
     "github_repo",
     "github_filter",
     "poll_interval_sec",
+    "last_healthy_poll_at",
+    "poller_consecutive_401",
     "action_kind",
     "action_model",
     "action_agent",

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -699,6 +699,10 @@ _SCHEDULE_DETAIL_KEYS = sorted(
         "interval_sec",
         "last_evaluated_at",
         "last_fired_at",
+        # The poller's own liveness gauges: stamped on every healthy poll
+        # including an empty one, so they are what separates a github_poll
+        # schedule still reading a quiet repo from one that stopped.
+        "last_healthy_poll_at",
         "last_status",
         "max_runs",
         "missed_fire_policy",
@@ -708,6 +712,7 @@ _SCHEDULE_DETAIL_KEYS = sorted(
         "on_success",
         "overlap_policy",
         "poll_interval_sec",
+        "poller_consecutive_401",
         "project",
         "recent_runs",
         "trigger_type",

--- a/tests/apps_studio_server/test_schedule_poller_fields.py
+++ b/tests/apps_studio_server/test_schedule_poller_fields.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The schedule routes serve a github_poll schedule's own health gauges.
+
+``last_healthy_poll_at`` is stamped on every healthy poll including an empty
+one, and ``poller_consecutive_401`` counts the authentication-failure streak.
+On a quiet repo no event arrives and no run row is written, so these two are
+the only fields that separate a poller still reading the repo from one that
+stopped -- a caller projected away from them cannot tell those apart, and the
+absence reads as health.
+
+The projection is a privacy boundary in both directions, so each test pairs
+the fields it requires with a field that must stay unserved: the authored
+prompt, which the record view widens to and the list view does not, and
+``github_cursor``, which is poll bookkeeping and is served on neither.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+import lionagi.state.db as state_db_mod  # noqa: E402
+from lionagi.state.db import StateDB  # noqa: E402
+from lionagi.studio.services.schedules import create_schedule  # noqa: E402
+
+HEALTHY_AT = 1_700_000_000.0
+
+
+def _patch_db(monkeypatch, db_path: Path) -> None:
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+
+def _make_client() -> TestClient:
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765")
+
+
+async def _seed_poller(*, polled: bool) -> str:
+    created = await create_schedule(
+        {
+            "name": f"poller-fields-{uuid.uuid4().hex[:8]}",
+            "trigger_type": "github_poll",
+            "github_repo": "acme/widgets",
+            "poll_interval_sec": 300,
+            "action_kind": "agent",
+            "action_prompt": "review the new commits",
+        }
+    )
+    if polled:
+        async with StateDB() as db:
+            await db.update_schedule(
+                created["id"],
+                last_healthy_poll_at=HEALTHY_AT,
+                poller_consecutive_401=3,
+                github_cursor="sha-deadbeef",
+            )
+    return created["id"]
+
+
+def test_list_serves_poller_health_gauges(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    sid = asyncio.run(_seed_poller(polled=True))
+
+    resp = _make_client().get("/api/schedules/")
+
+    assert resp.status_code == 200
+    row = next(item for item in resp.json()["schedules"] if item["id"] == sid)
+    assert row["last_healthy_poll_at"] == HEALTHY_AT
+    assert row["poller_consecutive_401"] == 3
+    assert "action_prompt" not in row
+    assert "github_cursor" not in row
+
+
+def test_record_serves_poller_health_gauges(tmp_path, monkeypatch):
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    sid = asyncio.run(_seed_poller(polled=True))
+
+    resp = _make_client().get(f"/api/schedules/{sid}")
+
+    assert resp.status_code == 200
+    row = resp.json()
+    assert row["last_healthy_poll_at"] == HEALTHY_AT
+    assert row["poller_consecutive_401"] == 3
+    assert "action_prompt" in row
+    assert "github_cursor" not in row
+
+
+def test_never_polled_serves_null_rather_than_omitting_the_field(tmp_path, monkeypatch):
+    """A poller that has never had a healthy read must be distinguishable from
+    a route that does not serve the gauge at all: the caller has to be able to
+    fail closed on "never", and an omitted key reads the same as an omitted
+    feature."""
+    _patch_db(monkeypatch, tmp_path / "state.db")
+    sid = asyncio.run(_seed_poller(polled=False))
+
+    resp = _make_client().get("/api/schedules/")
+
+    row = next(item for item in resp.json()["schedules"] if item["id"] == sid)
+    assert "last_healthy_poll_at" in row
+    assert row["last_healthy_poll_at"] is None
+    assert row["poller_consecutive_401"] == 0


### PR DESCRIPTION
Defect fix under maintenance exception.

## What was wrong

The schedule routes project each row onto an allow-list, so a column that is not named there stays private. `last_healthy_poll_at` and `poller_consecutive_401` were never named, which left every caller of `GET /schedules/` and `GET /schedules/{id}` unable to read them.

Those two are the only fields that answer whether a `github_poll` schedule is still reading its repo. The scheduler stamps `last_healthy_poll_at` on every healthy poll including an empty one, precisely so a quiet repo can still prove the poller is alive.

## Why it matters

On a quiet repo, no event arrives and no run row is written. Run history stays empty and `next_fire_at` is stale by design for this trigger type, since the cadence rides `last_fired_at + poll_interval_sec`. So every other signal a caller can reach looks identical whether the poller is healthy or dead, and the absence of alarming data reads as health. That is the wrong direction for a watchdog: a monitor built on these routes goes quiet exactly when the thing it watches stops.

## What changed

- `last_healthy_poll_at` and `poller_consecutive_401` are added to the schedule summary projection, so both routes serve them.
- `github_cursor` stays unserved. Where the poll got to is bookkeeping and answers a different question than whether the poller is alive.
- The never-polled case is pinned: a poller with no healthy read yet serves an explicit `null` rather than omitting the key, so a caller can fail closed on "never". An omitted key is indistinguishable from a route that does not serve the field at all.
- The API shape gate is widened to match, deliberately rather than incidentally.

## Tests

`tests/apps_studio_server/test_schedule_poller_fields.py` is new and covers the list route, the record route, and the never-polled case. Each test pairs the fields it requires with a field that must stay unserved (`action_prompt` on the list route, `github_cursor` on both), so it fails if the projection is widened into a pass-through rather than extended by name. All three fail on the parent commit with a `KeyError` on the gauge.

Run locally: the studio server, studio, contract, schedule MCP verb and schedule CLI suites, 3378 tests, no failures.
