### PR TITLE
fix(studio): start from a pip install, resolve macOS timezones outside TZPATH roots, allow a loopback ?api= daemon override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- `li studio` and `li studio --no-frontend` start from a pip install. The
+  backend app lives inside the installed package; startup no longer requires
+  the repository's `apps/` tree, which the wheel never ships. `--dev` still
+  requires a repository checkout. (Released as 0.35.1.)
+- System timezone resolution no longer refuses to start when the
+  `/etc/localtime` target sits outside every `TZPATH` root — a Python whose
+  `TZPATH` points elsewhere (conda-style builds), or macOS mid tzdata-update
+  with the localtime chain and the `/usr/share/zoneinfo` chain in different
+  versioned trees. The zone name is read from the link path itself and
+  accepted only when the stdlib can load it; unloadable or lookalike
+  (`zoneinfo.backup`) targets still refuse, and `LIONAGI_SCHEDULER_TZ` still
+  wins. (Released as 0.35.1.)
+- The hosted Studio page accepts a `?api=` query parameter naming a loopback
+  daemon origin (for example `?api=http://127.0.0.1:8766`), so a daemon on a
+  non-default port is reachable without a rebuild. Non-loopback origins are
+  ignored; the override persists per tab. (Released as 0.35.1.)
 - The studio scheduler's tick loop is now supervised rather than merely guarded. It caught
   `Exception`, which does not include `asyncio.CancelledError`, so a cancel escaping from anything
   the tick awaited ended the loop permanently while the process and its HTTP surface kept

--- a/apps/studio/frontend/src/lib/api.test.ts
+++ b/apps/studio/frontend/src/lib/api.test.ts
@@ -925,21 +925,33 @@ describe("normalizeSignalEvent", () => {
 });
 
 describe("resolveApiBase ?api= override", () => {
+  // Suite-owned storage: the CI runner's test environment has no
+  // window.sessionStorage (locally jsdom provides one), and the impl reads
+  // window.sessionStorage under try/catch — so without this stub the four
+  // tests below throw in CI while passing locally.
+  const storage = new Map<string, string>();
+  const storageStub = {
+    getItem: (k: string) => storage.get(k) ?? null,
+    setItem: (k: string, v: string) => void storage.set(k, String(v)),
+    removeItem: (k: string) => void storage.delete(k),
+    clear: () => void storage.clear(),
+  } as unknown as Storage;
+
   beforeEach(() => {
-    delete (window as Window & { __STUDIO_API_BASE__?: string }).__STUDIO_API_BASE__;
-    window.sessionStorage.clear();
     vi.unstubAllGlobals();
+    delete (window as Window & { __STUDIO_API_BASE__?: string }).__STUDIO_API_BASE__;
+    storage.clear();
   });
 
   afterEach(() => {
-    window.sessionStorage.clear();
     vi.unstubAllGlobals();
+    storage.clear();
   });
 
   const stubLocation = (search: string) => {
     vi.stubGlobal("window", {
       ...window,
-      sessionStorage: window.sessionStorage,
+      sessionStorage: storageStub,
       location: {
         ...window.location,
         port: "",

--- a/apps/studio/frontend/src/lib/api.test.ts
+++ b/apps/studio/frontend/src/lib/api.test.ts
@@ -923,3 +923,56 @@ describe("normalizeSignalEvent", () => {
     expect(Math.abs(asBackendSends.ts - now)).toBeGreaterThan(1_000_000_000);
   });
 });
+
+describe("resolveApiBase ?api= override", () => {
+  beforeEach(() => {
+    delete (window as Window & { __STUDIO_API_BASE__?: string }).__STUDIO_API_BASE__;
+    window.sessionStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    window.sessionStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  const stubLocation = (search: string) => {
+    vi.stubGlobal("window", {
+      ...window,
+      sessionStorage: window.sessionStorage,
+      location: {
+        ...window.location,
+        port: "",
+        hostname: "studio.example",
+        protocol: "https:",
+        search,
+      },
+    });
+  };
+
+  it("a loopback ?api= wins over the baked base", () => {
+    stubLocation("?api=http://127.0.0.1:8766");
+    (window as Window & { __STUDIO_API_BASE__?: string }).__STUDIO_API_BASE__ =
+      "http://127.0.0.1:8765";
+    expect(resolveApiBase()).toBe("http://127.0.0.1:8766");
+  });
+
+  it("a non-loopback ?api= is ignored", () => {
+    stubLocation("?api=https://evil.example");
+    (window as Window & { __STUDIO_API_BASE__?: string }).__STUDIO_API_BASE__ =
+      "http://127.0.0.1:8765";
+    expect(resolveApiBase()).toBe("http://127.0.0.1:8765");
+  });
+
+  it("a malformed ?api= is ignored", () => {
+    stubLocation("?api=notaurl");
+    expect(resolveApiBase()).toBe("");
+  });
+
+  it("the override persists for the tab after the query param is gone", () => {
+    stubLocation("?api=http://localhost:8766");
+    expect(resolveApiBase()).toBe("http://localhost:8766");
+    stubLocation("");
+    expect(resolveApiBase()).toBe("http://localhost:8766");
+  });
+});

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -51,11 +51,70 @@ export function resolveAuthToken(): string | undefined {
   return undefined;
 }
 
+const API_OVERRIDE_STORAGE_KEY = "studio.apiBaseOverride";
+
+/**
+ * A viewer-supplied `?api=` override for the daemon address, restricted to
+ * loopback origins. The hosted page bakes its API base at build time, so
+ * without this a daemon on a non-default port (`li studio --port 8766`) is
+ * unreachable from the hosted page. Loopback-only keeps the override from
+ * turning a shared link into a way to point someone's session at a foreign
+ * API. Persisted per-tab so SPA navigation that rewrites the query string
+ * does not drop it.
+ */
+function resolveApiOverride(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  let fromQuery: string | null = null;
+  try {
+    fromQuery = new URLSearchParams(window.location.search).get("api");
+  } catch {
+    fromQuery = null;
+  }
+  const validated = (raw: string | null): string | undefined => {
+    if (!raw) return undefined;
+    let parsed: URL;
+    try {
+      parsed = new URL(raw);
+    } catch {
+      return undefined;
+    }
+    const loopback =
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "localhost" ||
+      parsed.hostname === "[::1]" ||
+      parsed.hostname === "::1";
+    if (!loopback || (parsed.protocol !== "http:" && parsed.protocol !== "https:")) {
+      return undefined;
+    }
+    return parsed.origin;
+  };
+  const fresh = validated(fromQuery);
+  if (fresh) {
+    try {
+      window.sessionStorage.setItem(API_OVERRIDE_STORAGE_KEY, fresh);
+    } catch {
+      // Storage unavailable (private mode etc.) — the query param still wins
+      // for this load.
+    }
+    return fresh;
+  }
+  try {
+    return validated(window.sessionStorage.getItem(API_OVERRIDE_STORAGE_KEY));
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveApiBase(): string {
-  // Priority: window.__STUDIO_API_BASE__ (runtime injection) >
+  // Priority: ?api= loopback override (per-tab) >
+  // window.__STUDIO_API_BASE__ (runtime injection) >
   // VITE_STUDIO_API_BASE (build-time env) > origin logic.
   // Treat empty string as "not configured" — defense against baking an empty
   // env var that silently produced same-origin /api/* requests.
+  const override = resolveApiOverride();
+  if (override) {
+    return override;
+  }
   if (typeof window !== "undefined" && window.__STUDIO_API_BASE__) {
     return window.__STUDIO_API_BASE__;
   }

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -260,13 +260,12 @@ def _start_hosted(host: str, port: int, no_open: bool) -> int:
 def _start_backend_only(host: str, port: int) -> int:
     import uvicorn
 
-    if not _ensure_apps_importable():
-        print(
-            "Error: studio backend not found. Run from the lionagi repo root or install "
-            "the full studio package.",
-            file=sys.stderr,
-        )
-        return 1
+    # The backend app lives inside the installed package
+    # (lionagi.studio.app); it does not import anything from the repo's
+    # apps/ tree, so a pip install must not be gated on finding one. The
+    # repo root is still added to sys.path when present, purely as a
+    # convenience for repo checkouts.
+    _ensure_apps_importable()
 
     print(f"Lion Studio API: http://{host}:{port}")
     # Set before uvicorn.run: the app is loaded via import string and reads this from env.

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -125,6 +125,42 @@ def _zone_name_from_path(path: Path, roots: list[Path]) -> str | None:
     return None
 
 
+def _zone_name_from_link_structure(link: Path, resolved: Path | None) -> str | None:
+    """Zone name read from the shape of the localtime link itself.
+
+    Reached only after no search root contains the target: a Python whose
+    ``TZPATH`` points elsewhere (conda and similar builds), or macOS mid
+    tzdata-update, where the ``/etc/localtime`` chain and the
+    ``/usr/share/zoneinfo`` chain resolve into different versioned trees.
+    The name is whatever follows a component spelled exactly ``zoneinfo`` —
+    a suffixed directory like ``zoneinfo.backup`` stays a refusal, keeping
+    the containment rule's judgment that unrelated lookalike trees are not
+    zone sources — and it is accepted only if the stdlib can load it, so
+    this never invents a zone.
+    """
+    candidates: list[Path] = []
+    try:
+        candidates.append(link.readlink())
+    except OSError:
+        pass
+    if resolved is not None and resolved not in candidates:
+        candidates.append(resolved)
+    for target in candidates:
+        parts = target.parts
+        for index in range(len(parts) - 1, -1, -1):
+            if parts[index] != "zoneinfo":
+                continue
+            name = "/".join(parts[index + 1 :])
+            if not name:
+                break
+            try:
+                zoneinfo.ZoneInfo(name)
+            except Exception:  # noqa: BLE001
+                break
+            return name
+    return None
+
+
 def _localtime_is_readable() -> bool:
     """Whether the host's localtime file exists and can actually be read.
 
@@ -172,6 +208,14 @@ def _resolve_system_local_tz() -> TimezoneResolution:
                 return TimezoneResolution(
                     name, TZ_SOURCE_SYSTEM_LOCALTIME, str(SYSTEM_LOCALTIME_LINK)
                 )
+
+    name = _zone_name_from_link_structure(SYSTEM_LOCALTIME_LINK, localtime)
+    if name is not None:
+        return TimezoneResolution(
+            name,
+            TZ_SOURCE_SYSTEM_LOCALTIME,
+            f"{SYSTEM_LOCALTIME_LINK} (zone name from link path)",
+        )
 
     if _localtime_is_readable():
         raise SystemTimezoneUnreadableError(

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -1097,3 +1097,19 @@ def test_launch_vite_dev_selects_the_local_url_for_a_non_default_loopback_host(
     assert result is not None
     proc, url = result
     assert url == "http://127.0.0.2:4001"
+
+
+def test_backend_starts_from_a_pip_install_without_apps_tree(monkeypatch, capsys):
+    """A wheel install has no apps/ tree next to the package. The backend app
+    lives inside the package itself, so backend-only startup (the default
+    hosted mode and --no-frontend) must not be gated on finding the repo."""
+    import lionagi.studio.cli as studio_mod
+
+    monkeypatch.setattr(studio_mod, "_find_repo_root", lambda: None)
+    with _stubbed_serve() as mock_run:
+        result = studio_mod._start_backend_only("127.0.0.1", 8765)
+
+    assert result == 0
+    mock_run.assert_called_once()
+    captured = capsys.readouterr()
+    assert "studio backend not found" not in captured.err

--- a/tests/studio/test_config_timezone.py
+++ b/tests/studio/test_config_timezone.py
@@ -263,3 +263,58 @@ def test_missing_localtime_falls_back_to_utc_with_a_warning(tz_host, caplog):
         assert config._system_local_tz_name() == "UTC"
 
     assert "LIONAGI_SCHEDULER_TZ" in caplog.text
+
+
+def test_target_outside_every_root_still_names_the_zone(tz_host):
+    """The localtime target can live in a tree no search root contains — a
+    Python whose TZPATH points elsewhere (conda-style builds), or macOS mid
+    tzdata-update with the two chains in different versioned trees. The link
+    path itself still names the zone, and the name is accepted because the
+    configured roots can load it."""
+    link, set_roots, zone_file = tz_host
+    link.symlink_to(zone_file("zoneinfo"))
+    zone_file("other-tree")
+    set_roots("other-tree")
+
+    resolution = config._resolve_system_local_tz()
+    assert resolution.name == "America/New_York"
+    assert resolution.source == config.TZ_SOURCE_SYSTEM_LOCALTIME
+    assert "link path" in resolution.detail
+
+
+def test_macos_version_skew_between_chains_resolves(tz_host, tmp_path):
+    """macOS layout: /etc/localtime resolves through a middle symlink into one
+    versioned tree while the search root points at another. Containment fails
+    on the version mismatch; the link's own path still says which zone."""
+    link, set_roots, zone_file = tz_host
+    zone_file("tz/2025a/zoneinfo")
+    middle = tmp_path / "var-zoneinfo"
+    middle.symlink_to(tmp_path / "tz" / "2025a" / "zoneinfo")
+    link.symlink_to(middle / "America" / "New_York")
+    zone_file("tz/2025b/zoneinfo")
+    set_roots("tz/2025b/zoneinfo")
+
+    assert config._system_local_tz_name() == "America/New_York"
+
+
+def test_link_named_zone_that_no_root_can_load_still_raises(tz_host):
+    """The link-path fallback never invents a zone: a name the configured
+    roots cannot load keeps the refusal, exactly as before."""
+    link, set_roots, zone_file = tz_host
+    link.symlink_to(zone_file("zoneinfo", "Nowhere/Fake", data_from="America/New_York"))
+    set_roots("empty-tree")
+
+    with pytest.raises(config.SystemTimezoneUnreadableError):
+        config._system_local_tz_name()
+
+
+def test_suffixed_lookalike_tree_still_refuses_after_fallback(tz_host):
+    """The fallback keys on a component spelled exactly ``zoneinfo``; a
+    lookalike such as ``zoneinfo.backup`` stays a refusal (the containment
+    rule's judgment, unchanged)."""
+    link, set_roots, zone_file = tz_host
+    link.symlink_to(zone_file("zoneinfo.backup"))
+    set_roots("zoneinfo")
+
+    with pytest.raises(config.SystemTimezoneUnreadableError):
+        config._system_local_tz_name()


### PR DESCRIPTION
Three defects reported against the 0.35.0 PyPI install, shipped as [v0.35.1](https://github.com/ohdearquant/lionagi/releases/tag/v0.35.1) from `release/0.35.1`; this lands the same fixes on `main` so the next release keeps them.

**1. `li studio` could not start from a pip install.** Backend-only startup (the default hosted mode and `--no-frontend`) was gated on finding the repository's `apps/` tree, which the wheel never ships — every pip user got "studio backend not found". The backend app lives inside the installed package and imports nothing from `apps/`, so the gate is removed. `--dev` still requires a checkout. Reproduced against the actual PyPI wheel on Python 3.12.6; the fixed wheel boots the daemon (HTTP 200 on /health).

**2. Timezone resolution refused to start when the `/etc/localtime` target sits outside every `TZPATH` root** — a Python whose `TZPATH` points elsewhere (conda-style builds), or macOS mid tzdata-update with the localtime chain and the `/usr/share/zoneinfo` chain in different versioned trees. The zone name is now read from the link path itself (a component spelled exactly `zoneinfo`), accepted only when the stdlib can load it. Lookalike trees (`zoneinfo.backup`), unloadable names, shadowed keys, and malformed tzfiles all still refuse, and `LIONAGI_SCHEDULER_TZ` still wins. New tests cover both new arms and pin the preserved refusals.

**3. The hosted Studio page pinned its API base at build time**, so a daemon on a non-default port (`li studio --port 8766`) was unreachable from the hosted page. A `?api=` query parameter naming a loopback origin now overrides it, persisted per tab; non-loopback and malformed values are ignored so a shared link cannot point a session at a foreign API.

Tests: `tests/studio/test_config_timezone.py` 18/18, `tests/cli/test_studio_cli.py` 58 passed / 4 skipped (node_modules), frontend vitest 1885/1885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)