### PR TITLE
fix(studio): build the frontend once, on the build platform

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -7,11 +7,18 @@
 #   docker run -p 8765:8765 -v ~/.lionagi:/root/.lionagi -v "$PWD:/workspace" lion-studio
 
 # ── Stage 1: Build frontend ──────────────────────────────────────────────────
-FROM node:22-alpine AS frontend-build
+# Pinned to BUILDPLATFORM on purpose. This stage emits /build/dist, a static
+# SPA bundle that is identical whatever the target architecture, so under a
+# multi-arch build an unpinned stage gets built a second time under QEMU for
+# no benefit. npm under emulation is slow enough to exceed the job timeout,
+# which is how a release lost its image.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS frontend-build
 
 WORKDIR /build
 COPY apps/studio/frontend/package.json apps/studio/frontend/package-lock.json* ./
-RUN npm ci --legacy-peer-deps 2>/dev/null || npm install --legacy-peer-deps
+# stderr is npm's progress channel; discarding it makes a stalled install
+# indistinguishable from a slow one for as long as the build is allowed to run.
+RUN npm ci --legacy-peer-deps || npm install --legacy-peer-deps
 COPY apps/studio/frontend/ ./
 RUN npm run build
 


### PR DESCRIPTION
## What

`apps/studio/Dockerfile`'s `frontend-build` stage was unpinned. Under the
multi-arch release build (`linux/amd64,linux/arm64`) that means the stage runs
twice, the second time under QEMU emulation.

That stage emits `/build/dist`, a static SPA bundle. It is identical whatever
the target architecture, and stage 2 consumes it with a plain `COPY --from`.
The emulated pass produced nothing the native pass had not already produced.

It also did not finish. The most recent release's `arm64` pass reached
`npm ci` and then emitted **nothing for six hours**, until the job hit its
timeout. The image was never pushed, so the registry has no tag for that
version and `latest` still resolves to the previous one.

## The fix

- `FROM --platform=$BUILDPLATFORM node:22-alpine AS frontend-build` — builds
  the bundle once, natively; both target architectures copy the same output.
- Drop `2>/dev/null` from the `npm ci` line. stderr is npm's progress channel,
  so discarding it is why a wedged install and a slow one were
  indistinguishable for the entire six hours. The `||` fallback still covers a
  missing or unusable lockfile, and now reports why it fired.

## Verification

Not built locally — no Docker daemon available on this machine. The change is
verified by the release workflow's own `docker` and `verify-image` jobs, the
second of which reads the pushed tag back from the registry rather than
trusting the push step's exit code.

Worth noting `verify-image` did its job on the failed release: it failed with
an error naming the exact missing tag. The image being missing was detected and
reported correctly; nothing downstream acted on it.