### PR TITLE
fix(studio): send the shell token only to the daemon it was issued for

### DIFF
--- a/apps/studio/frontend/src/lib/api.test.ts
+++ b/apps/studio/frontend/src/lib/api.test.ts
@@ -988,3 +988,111 @@ describe("resolveApiBase ?api= override", () => {
     expect(resolveApiBase()).toBe("http://localhost:8766");
   });
 });
+
+describe("the shell token does not follow a ?api= override to another daemon", () => {
+  // The override is loopback-only, which bounds who can receive a redirected
+  // request but says nothing about whether they should be trusted with the
+  // shell's credential: anything able to bind a local port qualifies.
+  const storage = new Map<string, string>();
+  const storageStub = {
+    getItem: (k: string) => storage.get(k) ?? null,
+    setItem: (k: string, v: string) => void storage.set(k, String(v)),
+    removeItem: (k: string) => void storage.delete(k),
+    clear: () => void storage.clear(),
+  } as unknown as Storage;
+
+  const stubLocation = (search: string) => {
+    vi.stubGlobal("window", {
+      ...window,
+      sessionStorage: storageStub,
+      location: {
+        ...window.location,
+        port: "",
+        hostname: "studio.example",
+        protocol: "https:",
+        search,
+      },
+    });
+  };
+
+  const setInjected = (base?: string, token?: string) => {
+    const w = window as Window & {
+      __STUDIO_API_BASE__?: string;
+      __STUDIO_AUTH_TOKEN__?: string;
+    };
+    if (base === undefined) delete w.__STUDIO_API_BASE__;
+    else w.__STUDIO_API_BASE__ = base;
+    if (token === undefined) delete w.__STUDIO_AUTH_TOKEN__;
+    else w.__STUDIO_AUTH_TOKEN__ = token;
+  };
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    setInjected(undefined, undefined);
+    storage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setInjected(undefined, undefined);
+    storage.clear();
+  });
+
+  it("withholds the token when the override names a different daemon", () => {
+    stubLocation("?api=http://127.0.0.1:8766");
+    setInjected("http://127.0.0.1:8765", "shell-token");
+    // Precondition, so this is not asserting against a base that never moved.
+    expect(resolveApiBase()).toBe("http://127.0.0.1:8766");
+    expect(resolveAuthToken()).toBeUndefined();
+  });
+
+  it("still sends the token when the override names the issuing origin", () => {
+    // The documented workaround: a viewer pasting the address of the very
+    // daemon the shell started must not be punished for it.
+    stubLocation("?api=http://127.0.0.1:8765");
+    setInjected("http://127.0.0.1:8765", "shell-token");
+    expect(resolveApiBase()).toBe("http://127.0.0.1:8765");
+    expect(resolveAuthToken()).toBe("shell-token");
+  });
+
+  it("withholds the token when no issuing origin was injected", () => {
+    // Fail closed: with nothing declaring which daemon the token belongs to,
+    // an override cannot be shown to be that daemon.
+    stubLocation("?api=http://127.0.0.1:8766");
+    setInjected(undefined, "shell-token");
+    expect(resolveAuthToken()).toBeUndefined();
+  });
+
+  it("withholds the token when the injected base is unparseable", () => {
+    stubLocation("?api=http://127.0.0.1:8766");
+    setInjected("not a url", "shell-token");
+    expect(resolveAuthToken()).toBeUndefined();
+  });
+
+  it("is unchanged when no override is active", () => {
+    // The arm that would catch this fix over-reaching into the ordinary path.
+    stubLocation("");
+    setInjected("http://127.0.0.1:8765", "shell-token");
+    expect(resolveAuthToken()).toBe("shell-token");
+  });
+
+  it("is unchanged when a rejected override leaves the baked base in place", () => {
+    // A non-loopback ?api= never becomes the base, so nothing was redirected
+    // and there is no reason to withhold.
+    stubLocation("?api=https://evil.example");
+    setInjected("http://127.0.0.1:8765", "shell-token");
+    expect(resolveApiBase()).toBe("http://127.0.0.1:8765");
+    expect(resolveAuthToken()).toBe("shell-token");
+  });
+
+  it("keeps withholding after the query param is gone", () => {
+    // The override persists per-tab, so the suppression has to persist with it
+    // rather than lapsing on the next SPA navigation.
+    stubLocation("?api=http://127.0.0.1:8766");
+    setInjected("http://127.0.0.1:8765", "shell-token");
+    expect(resolveAuthToken()).toBeUndefined();
+    stubLocation("");
+    expect(resolveApiBase()).toBe("http://127.0.0.1:8766");
+    expect(resolveAuthToken()).toBeUndefined();
+  });
+});

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -43,12 +43,42 @@ declare global {
   }
 }
 
-/** Return the per-launch bearer token injected by the desktop shell, if any. */
+/**
+ * Return the per-launch bearer token injected by the desktop shell, if any.
+ *
+ * The token authenticates against the daemon the shell started, and the shell
+ * names that daemon in `__STUDIO_API_BASE__` when it injects the token. A
+ * `?api=` override takes priority over that base, so without a check here the
+ * page would keep sending the token after being pointed at a *different*
+ * daemon. Restricting the override to loopback bounds who that can be; it does
+ * not make them trusted, since any process able to listen on a local port would
+ * then be handed the credential by the next request.
+ *
+ * So the token travels only to the origin it was issued for. If an override is
+ * active and that origin cannot be established, the token is withheld:
+ * withholding costs an unauthenticated request against a daemon the viewer
+ * redirected the page to deliberately, and sending costs the credential itself.
+ *
+ * Decided here rather than at the call sites because there are several of them,
+ * and a rule about where a credential may travel should not be re-implemented
+ * once per request builder.
+ */
 export function resolveAuthToken(): string | undefined {
-  if (typeof window !== "undefined" && window.__STUDIO_AUTH_TOKEN__) {
-    return window.__STUDIO_AUTH_TOKEN__;
+  if (typeof window === "undefined") return undefined;
+  const token = window.__STUDIO_AUTH_TOKEN__;
+  if (!token) return undefined;
+
+  const override = resolveApiOverride();
+  if (!override) return token;
+
+  const issuedFor = window.__STUDIO_API_BASE__;
+  if (!issuedFor) return undefined;
+  try {
+    // resolveApiOverride already returns a bare origin, so both sides normalize.
+    return new URL(issuedFor).origin === override ? token : undefined;
+  } catch {
+    return undefined;
   }
-  return undefined;
 }
 
 const API_OVERRIDE_STORAGE_KEY = "studio.apiBaseOverride";


### PR DESCRIPTION
## The problem

The desktop shell injects a per-launch bearer token (`__STUDIO_AUTH_TOKEN__`)
together with the address of the daemon it started (`__STUDIO_API_BASE__`).

The `?api=` override takes priority over that address. So the page can be
pointed at a *different* daemon and, before this change, would keep attaching
the token to every request it made there.

The override is restricted to loopback, and that bounds who can receive the
redirected request. It does not make them trusted: anything able to bind a local
port qualifies, and would be handed the shell's credential by the next request.

## The fix

`resolveAuthToken()` now returns the token only when the resolved API base is
the origin the shell named. When an override is active and that origin cannot be
established — not injected, or unparseable — the token is withheld.

Withholding costs an unauthenticated request against a daemon the viewer
redirected the page to on purpose. Sending costs the credential. That trade
decides it.

**Placed at token resolution, not at the call sites.** Four request builders
attach this header. A rule about where a credential may travel should hold for
all of them rather than being restated four times, where the fifth one added
later would not have it.

## What still works

An override naming the very daemon the shell started compares equal and keeps
its token, so the documented `li studio --port 8766` workaround is unaffected. A
non-loopback `?api=` never becomes the base, so nothing is redirected and
nothing is withheld.

## Verification

7 new arms, covering both directions: the four withholding cases and three
cases that must be left alone (no override, rejected override, override naming
the issuing origin).

Mutation-tested with the blast radius declared first — reverting the check was
predicted to redden exactly the four withholding arms and leave the three
unchanged-behaviour arms green, which is what happened. The source was then
restored and verified byte-identical.

Full frontend suite green: 1892 tests across 88 files. `tsc --noEmit`, eslint
and prettier clean.