### PR TITLE
fix(studio): let the resolved zone name win in the link-structure fallback too

### DIFF
--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -138,13 +138,25 @@ def _zone_name_from_link_structure(link: Path, resolved: Path | None) -> str | N
     zone sources — and it is accepted only if the stdlib can load it, so
     this never invents a zone.
     """
+    # Resolved first, link text second. The primary path already derives the
+    # name from where the link resolves rather than from what it says, and this
+    # fallback answers the same question, so the two must not disagree about
+    # which spelling wins. They differ whenever the link names an alias -- a
+    # localtime pointing at ``zoneinfo/US/Eastern`` that resolves to
+    # ``zoneinfo/America/New_York`` -- where both spellings load but only one is
+    # the zone the host actually uses. Link text stays as the second candidate
+    # for the case this fallback exists for, where the resolved path lands
+    # outside any component named ``zoneinfo`` and yields no name at all.
     candidates: list[Path] = []
+    if resolved is not None:
+        candidates.append(resolved)
     try:
-        candidates.append(link.readlink())
+        from_link_text = link.readlink()
     except OSError:
         pass
-    if resolved is not None and resolved not in candidates:
-        candidates.append(resolved)
+    else:
+        if from_link_text not in candidates:
+            candidates.append(from_link_text)
     for target in candidates:
         parts = target.parts
         for index in range(len(parts) - 1, -1, -1):

--- a/tests/studio/test_config_timezone.py
+++ b/tests/studio/test_config_timezone.py
@@ -132,6 +132,70 @@ def test_zone_follows_the_resolved_path_not_the_link_text(tz_host, tmp_path):
     assert config._system_local_tz_name() == "Asia/Tokyo"
 
 
+def test_link_structure_fallback_also_prefers_the_resolved_spelling(tz_host, tmp_path):
+    """The fallback answers the same question as the primary path, so it has to
+    answer it the same way.
+
+    Reached only when no search root contains the target, this derives a name
+    from the shape of the path instead. An alias link is where the two spellings
+    diverge: ``US/Eastern`` and ``America/New_York`` both load, but the second is
+    the zone the host is actually using, and the primary path already reports it
+    that way. Two code paths disagreeing about which spelling wins is worse than
+    either answer, because which one you get depends on whether the search root
+    happened to contain the file.
+    """
+    link, set_roots, zone_file = tz_host
+    # The search root carries both spellings as real files, so the loadability
+    # check inside the fallback accepts either and cannot be what decides this.
+    zone_file("roots", "America/New_York")
+    zone_file("roots", "US/Eastern", data_from="America/New_York")
+    # The host's actual chain lives in a tree that is NOT a search root, which
+    # is what makes the primary path come up empty and hands the question to the
+    # link-structure fallback. This is the macOS shape: /etc/localtime resolving
+    # into a versioned tree beside the one TZPATH points at.
+    outside = tmp_path / "outside" / "zoneinfo"
+    (outside / "America").mkdir(parents=True, exist_ok=True)
+    (outside / "America" / "New_York").write_bytes(_host_zone_bytes("America/New_York"))
+    (outside / "US").mkdir(parents=True, exist_ok=True)
+    (outside / "US" / "Eastern").symlink_to(outside / "America" / "New_York")
+    link.symlink_to(outside / "US" / "Eastern")
+    set_roots("roots")
+
+    # Precondition: the primary path really does fail here, or this test would
+    # pass while measuring the wrong code.
+    assert config._zone_name_from_path(link.resolve(), config._tz_search_roots()) is None
+
+    assert config._system_local_tz_name() == "America/New_York"
+
+
+def test_link_structure_fallback_still_uses_link_text_when_resolving_yields_no_name(
+    tz_host, tmp_path
+):
+    """The arm that keeps link text as a candidate rather than dropping it.
+
+    When the resolved path lands outside any component named ``zoneinfo`` it
+    yields no name, and the link's own text is the only thing left that does.
+    Without this the reordering above would turn a host that resolves fine today
+    into a refusal.
+    """
+    link, set_roots, zone_file = tz_host
+    zone_file("roots", "America/New_York")
+    # Resolves to a file under no component named zoneinfo, so the resolved
+    # candidate yields nothing and only the link's own text names a zone.
+    (tmp_path / "opaque").mkdir(parents=True, exist_ok=True)
+    real = tmp_path / "opaque" / "tzfile"
+    real.write_bytes(_host_zone_bytes("America/New_York"))
+    outside = tmp_path / "outside" / "zoneinfo"
+    (outside / "America").mkdir(parents=True, exist_ok=True)
+    (outside / "America" / "New_York").symlink_to(real)
+    link.symlink_to(outside / "America" / "New_York")
+    set_roots("roots")
+
+    assert config._zone_name_from_path(link.resolve(), config._tz_search_roots()) is None
+
+    assert config._system_local_tz_name() == "America/New_York"
+
+
 def test_shadowed_key_is_refused_rather_than_loading_another_zone(tz_host):
     """Two roots can hold the same key with different rules. The name derived
     from the root that contains localtime would be reopened from the earlier


### PR DESCRIPTION
## What

Two code paths derive the host's zone name from `/etc/localtime`, and they
disagreed about which spelling wins.

The **primary path** reads the name from where the link resolves rather than
from what it says. That is the right answer: an alias like `US/Eastern` and the
canonical `America/New_York` both load, but only the second is the zone the host
actually uses.

The **link-structure fallback**, reached when no search root contains the
target, tried the link text first and so reported the alias.

Which of the two answers a host got therefore depended on whether its search
root happened to contain the file — which is not something the answer should
depend on.

## The change

Resolved path first, link text second.

Link text stays as a candidate rather than being dropped. The case this fallback
exists for includes a `/etc/localtime` resolving to a file under no component
named `zoneinfo`, where the resolved path yields no name at all and the link's
own text is the only thing that does. Reordering without keeping it would turn
a host that resolves fine today into a refusal.

## Verification

Two arms, one per direction, both with a precondition assert that the primary
path really does come up empty — otherwise they would pass while measuring the
wrong code, which the first draft of them did.

Mutation-tested with the blast radius declared first: restoring the old ordering
was predicted to redden the resolved-spelling arm alone, and it did, failing
with `assert 'US/Eastern' == 'America/New_York'` — the defect stated verbatim.
The link-text arm stayed green, confirming that path is still covered. Source
restored and verified byte-identical.

All four timezone suites pass (67 tests). Note these need the studio extra
installed; without it three of the four skip silently.