### PR TITLE
fix(ci): give the registry alarm's issue commands a repository to act on

### DIFF
--- a/.github/workflows/image-matches-pypi.yml
+++ b/.github/workflows/image-matches-pypi.yml
@@ -158,6 +158,14 @@ jobs:
       - name: Record the readings, then open or close the issue
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job deliberately has no checkout: it reads PyPI and the
+          # registry over the network and needs none of the tree. That leaves
+          # the CLI with no git remote to infer a repository from, so every
+          # bare `gh issue` call below would exit with "failed to run git:
+          # fatal: not a git repository" before reaching the branch that
+          # decides whether to file, comment, or close. GH_REPO supplies what
+          # the checkout would otherwise have implied.
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ steps.pypi.outputs.version }}
           PRESENT: ${{ steps.registry.outputs.present }}
           COUNT: ${{ steps.registry.outputs.count }}

--- a/tests/scripts/test_workflow_gh_repo.py
+++ b/tests/scripts/test_workflow_gh_repo.py
@@ -1,0 +1,128 @@
+"""A checkout-free job that shells out to ``gh`` has to name its repository.
+
+``gh`` resolves the repository from the git remote of its working directory. A
+job with no ``actions/checkout`` step has no remote, so a repo-scoped
+subcommand exits with ``failed to run git: fatal: not a git repository``
+before doing any work.
+
+This is worth a static guard specifically because it survives the obvious
+verification. Running a step's script with a stubbed ``gh`` proves the script's
+own branching and proves nothing about the CLI, because the stub answers
+without ever performing the repository resolution the real CLI performs first.
+The precondition is invisible to every test that replaces the dependency.
+
+Lives in its own module rather than joining ``test_ci_hygiene.py``: that module
+skips entirely when ripgrep is absent, and a guard that quietly disappears on
+some runners is not a guard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+# Subcommands that resolve a repository from the working directory when no
+# --repo flag and no GH_REPO are supplied. `api` is left out on purpose: its
+# paths are usually written out in full, so including it would flag calls that
+# resolve nothing.
+REPO_SCOPED = ("issue", "pr", "release", "repo", "workflow", "run", "label")
+
+_GH_CALL = re.compile(r"\bgh\s+(" + "|".join(REPO_SCOPED) + r")\b")
+
+
+def _logical_lines(script: str) -> list[str]:
+    """Join backslash continuations so a flag on the next line still counts."""
+    return script.replace("\\\n", " ").splitlines()
+
+
+def _job_has_checkout(job: dict) -> bool:
+    for step in job.get("steps") or []:
+        if isinstance(step, dict) and str(step.get("uses", "")).startswith("actions/checkout"):
+            return True
+    return False
+
+
+def gh_repo_violations(text: str) -> list[str]:
+    """Return one description per checkout-free ``gh`` call with no repository."""
+    document = yaml.safe_load(text) or {}
+    workflow_env = document.get("env") or {}
+    violations: list[str] = []
+
+    for job_name, job in (document.get("jobs") or {}).items():
+        if not isinstance(job, dict) or _job_has_checkout(job):
+            continue
+        job_env = job.get("env") or {}
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict) or not step.get("run"):
+                continue
+            step_env = step.get("env") or {}
+            if any("GH_REPO" in env for env in (step_env, job_env, workflow_env)):
+                continue
+            for line in _logical_lines(str(step["run"])):
+                if _GH_CALL.search(line) and "--repo" not in line:
+                    name = step.get("name") or "<unnamed step>"
+                    violations.append(f"{job_name} / {name}: {line.strip()}")
+    return violations
+
+
+def test_no_checkout_free_gh_call_is_missing_a_repository() -> None:
+    found: list[str] = []
+    workflows = sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml"))
+
+    assert workflows, f"no workflow files under {WORKFLOW_DIR}; the check read nothing"
+
+    for path in workflows:
+        found.extend(f"{path.name}: {item}" for item in gh_repo_violations(path.read_text()))
+
+    assert not found, "gh calls that cannot resolve a repository:\n" + "\n".join(found)
+
+
+BROKEN = """
+jobs:
+  alarm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: File the issue
+        env:
+          GH_TOKEN: token
+        run: |
+          gh issue create --title "t" --body "b"
+"""
+
+
+def test_the_check_flags_a_checkout_free_call_with_no_repository() -> None:
+    """The broken control. Without this the check could pass by never matching."""
+    violations = gh_repo_violations(BROKEN)
+
+    assert len(violations) == 1
+    assert "gh issue create" in violations[0]
+
+
+@pytest.mark.parametrize(
+    "cure",
+    [
+        pytest.param("        env:\n          GH_REPO: owner/name\n", id="gh-repo-env"),
+        pytest.param("        env:\n          GH_TOKEN: t\n", id="explicit-repo-flag"),
+    ],
+)
+def test_the_check_accepts_a_call_that_names_its_repository(cure: str) -> None:
+    body = BROKEN.replace("        env:\n          GH_TOKEN: token\n", cure)
+    if "GH_REPO" not in cure:
+        body = body.replace("gh issue create --title", "gh issue create --repo o/n --title")
+
+    assert gh_repo_violations(body) == []
+
+
+def test_a_job_that_checks_out_is_not_flagged() -> None:
+    body = BROKEN.replace(
+        "    steps:\n",
+        "    steps:\n      - uses: actions/checkout@v5\n",
+    )
+
+    assert gh_repo_violations(body) == []


### PR DESCRIPTION
Closes #3415.

## The defect

The image-vs-PyPI job has no checkout, on purpose: it reads PyPI and the
registry over the network and needs nothing from the tree. That leaves `gh`
with no git remote to infer a repository from, so all four bare `gh issue`
calls exit with `failed to run git: fatal: not a git repository`.

The first of them is the `gh issue list` that looks for an already-open alarm,
and it runs *before* the branch that decides what to do. So the failure is
total: a scheduled run could not file a new alarm, could not comment on an open
one, and could not close a recovered one. The workflow's three intended
outcomes all reduced to the same red.

`GH_REPO` on the step supplies what a checkout would otherwise have implied.

## Why a guard, and why this kind

The step scripts were verified before merge by extracting them from the YAML
and running them against the live PyPI and registry APIs with `gh` stubbed.
That is why this got through, and the reason generalises: **a stub answers
without performing the repository resolution the real CLI performs first**, so
this precondition is invisible to any test that replaces the dependency. No
amount of re-running that verification would have found it.

So the guard reads the workflow files rather than executing them. It flags a
checkout-free job that invokes a repo-scoped `gh` subcommand with neither
`GH_REPO` in scope nor an explicit `--repo`, joining backslash continuations
first so a flag on the following line still counts.

## Verification

| arm | result |
|---|---|
| guard against the fixed tree | 5 passed |
| guard with the new `GH_REPO` line removed | **fails, naming all four call sites** |
| workflow file after the mutation was rolled back | byte-identical to before |

The mutation arm reproduces the reported defect independently: the four lines
it names are the four the report names. The module also carries a synthetic
broken control, because a checker whose only output is silence cannot otherwise
be distinguished from one that never matches, plus two accept-arms covering the
`--repo` flag and a job that does check out.

It sits in its own module rather than in the CI hygiene tests: that module
skips entirely when ripgrep is absent, and a guard that quietly disappears on
some runners is not a guard.